### PR TITLE
Optimize ice.Agent.getBestPair()

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -312,3 +312,22 @@ func TestHandlePeerReflexive(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkGetBestPair(b *testing.B) {
+	a, err := NewAgent(&AgentConfig{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// There are no pairs so this will error.
+		_, _ = a.getBestPair()
+	}
+
+	err = a.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
This function should be trivial but profiles show it taking 3-5% of my
application's CPU time. The problem is the constant creation of a
channel for message passing. This function is called by srtp.WriteRTP
for each packet, so it adds up.

My fix was to create a `runInner` function that utilizies a mutex. I
wanted to convert all `run` functions to `runInner` but the code
occasionally deadlocks in unit tests. The package is definitely a
candidate for a rewrite.

```
name           old time/op    new time/op    delta
GetBestPair-8     915ns ± 3%      80ns ± 4%  -91.23%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
GetBestPair-8      128B ± 0%       16B ± 0%  -87.50%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
GetBestPair-8      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
```