### PR TITLE
Send connectivity checks right on agent start

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -26,7 +26,7 @@ func testTimeout(t *testing.T, c *Conn, timeout time.Duration) {
 	statechan := make(chan ConnectionState)
 	ticker := time.NewTicker(pollrate)
 
-	for cnt := time.Duration(0); cnt <= timeout+taskLoopInterval; cnt += pollrate {
+	for cnt := time.Duration(0); cnt <= timeout+defaultTaskLoopInterval; cnt += pollrate {
 		<-ticker.C
 		err := c.agent.run(func(agent *Agent) {
 			statechan <- agent.connectionState


### PR DESCRIPTION
Connectivity checks are done via a Ticker, the inital tick does not
happen immediately (by design) causing the startup time to be the Duration the
Ticker is created with.

This change adds another chan forceCandidateContact that can be used to
force contact at anytime. Currently it is only called on startup, but
could be useful in the future for reuse.

Resolve #15
