### PR TITLE
Discard non-STUN if no associated candidate

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -654,12 +654,16 @@ func (a *Agent) handleInbound(m *stun.Message, local *Candidate, remote net.Addr
 	}
 }
 
-// noSTUNSeen processes non STUN traffic from a remote candidate
-func (a *Agent) noSTUNSeen(local *Candidate, remote net.Addr) {
+// noSTUNSeen processes non STUN traffic from a remote candidate,
+// and returns true if it is an actual remote candidate
+func (a *Agent) noSTUNSeen(local *Candidate, remote net.Addr) bool {
 	remoteCandidate := a.findRemoteCandidate(local.NetworkType, remote)
-	if remoteCandidate != nil {
-		remoteCandidate.seen(false)
+	if remoteCandidate == nil {
+		return false
 	}
+
+	remoteCandidate.seen(false)
+	return true
 }
 
 func (a *Agent) getBestPair() (*candidatePair, error) {


### PR DESCRIPTION
If a inbound message is not associated with a valid remote STUN
candidate discard it

Resolves #20

-----

@kixelated I believe all the issues you cited are resolved when this lands.


* Remote STUN messages are checked via MessageIntegrity (so no MITM)
* Remotes can't create prflx candidates (no DoS possible)
* We discard non-STUN messages if we don't have an associated candidate
   - Since we are dealing with lossy messages I think success just matters for outbound. I would prefer not to lose inbound messages from a candidate if it is valid.