### PR TITLE
Assert that a bindingSuccessResponse is symmetric

### DIFF
--- a/candidate.go
+++ b/candidate.go
@@ -117,39 +117,6 @@ func NewCandidateRelay(network string, ip net.IP, port int, component uint16, re
 	}, nil
 }
 
-// handleNewPeerReflexiveCandidate creates a ReflexiveCandidate from a remote transport address
-func handleNewPeerReflexiveCandidate(local *Candidate, remote net.Addr) (*Candidate, error) {
-	var ip net.IP
-	var port int
-
-	switch addr := remote.(type) {
-	case *net.UDPAddr:
-		ip = addr.IP
-		port = addr.Port
-	case *net.TCPAddr:
-		ip = addr.IP
-		port = addr.Port
-	default:
-		return nil, fmt.Errorf("unsupported address type %T", addr)
-	}
-
-	pflxCandidate, err := NewCandidatePeerReflexive(
-		local.NetworkType.String(), // assume, same as that of local
-		ip,
-		port,
-		local.Component,
-		"", // unknown at this moment. TODO: need a review
-		0,  // unknown at this moment. TODO: need a review
-	)
-
-	if err != nil {
-		return nil, flattenErrs([]error{fmt.Errorf("failed to create peer-reflexive candidate: %v", remote), err})
-	}
-
-	// Add pflxCandidate to the remote candidate list
-	return pflxCandidate, nil
-}
-
 // start runs the candidate using the provided connection
 func (c *Candidate) start(a *Agent, conn net.PacketConn) {
 	c.agent = a

--- a/util.go
+++ b/util.go
@@ -68,3 +68,27 @@ func flattenErrs(errs []error) error {
 
 	return fmt.Errorf(strings.Join(errstrings, "\n"))
 }
+
+func parseAddr(in net.Addr) (net.IP, int, NetworkType, bool) {
+	switch addr := in.(type) {
+	case *net.UDPAddr:
+		return addr.IP, addr.Port, NetworkTypeUDP4, true
+	case *net.TCPAddr:
+		return addr.IP, addr.Port, NetworkTypeTCP4, true
+	}
+	return nil, 0, 0, false
+}
+
+func addrEqual(a, b net.Addr) bool {
+	aIP, aPort, aType, aOk := parseAddr(a)
+	if !aOk {
+		return false
+	}
+
+	bIP, bPort, bType, bOk := parseAddr(b)
+	if !bOk {
+		return false
+	}
+
+	return aType == bType && aIP.Equal(bIP) && aPort == bPort
+}


### PR DESCRIPTION
We previously didn't correctly follow [0] This updates
the agent to assert that a bindingSuccessResponse is
for the address it was sent too.

https://tools.ietf.org/html/rfc8445#section-7.2.5.2.1