### PR TITLE
Fixed closing transport during connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Konstantin Itskov](https://github.com/trivigy) - *Original Author*
 * [Luke Curley](https://github.com/kixelated)
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Adam Kiss](https://github.com/masterada)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/transport.go
+++ b/transport.go
@@ -42,6 +42,8 @@ func (a *Agent) connect(ctx context.Context, isControlling bool, remoteUfrag, re
 
 	// block until pair selected
 	select {
+	case <-a.done:
+		return nil, a.getErr()
 	case <-ctx.Done():
 		// TODO: Stop connectivity checks?
 		return nil, ErrCanceledByCaller


### PR DESCRIPTION
Avoid waiting for agent.onConnected in agent.connect if the agent
is closed.

#### Description

Related to https://github.com/pion/webrtc/issues/642. Fixes TestPeerConnection_Close_PreICE sometimes failing in the webrtc repo.
