### PR TITLE
Emit Closed via ConnectionStateCallback

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -522,6 +522,7 @@ func (a *Agent) Close() error {
 	}
 
 	<-done
+	a.updateConnectionState(ConnectionStateClosed)
 
 	return nil
 }


### PR DESCRIPTION
When Close is called on an agent emit 'Closed'
to the connection state callback

Resolves #39
