### PR TITLE
Respect port range for srv reflexive candidates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - lll
     - maligned
     - gochecknoglobals
+    - interfacer
 
 issues:
   exclude-use-default: false

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/pion/logging v0.2.1
-	github.com/pion/stun v0.2.1
-	github.com/pion/transport v0.6.0
+	github.com/pion/stun v0.2.2
+	github.com/pion/transport v0.7.0
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
-github.com/pion/stun v0.2.1 h1:rSKJ0ynYkRalRD8BifmkaGLeepCFuGTwG6FxPsrPK8o=
-github.com/pion/stun v0.2.1/go.mod h1:TChCNKgwnFiFG/c9K+zqEdd6pO6tlODb9yN1W/zVfsE=
-github.com/pion/transport v0.6.0 h1:WAoyJg/6OI8dhCVFl/0JHTMd1iu2iHgGUXevptMtJ3U=
-github.com/pion/transport v0.6.0/go.mod h1:iWZ07doqOosSLMhZ+FXUTq+TamDoXSllxpbGcfkCmbE=
+github.com/pion/stun v0.2.2 h1:0IJCwJFOdEmHzz4oxl9SBGLlJbnNbF+0h6XSOmuE034=
+github.com/pion/stun v0.2.2/go.mod h1:TChCNKgwnFiFG/c9K+zqEdd6pO6tlODb9yN1W/zVfsE=
+github.com/pion/transport v0.7.0 h1:EsXN8TglHMlKZMo4ZGqwK6QgXBu0WYg7wfGMWIXsS+w=
+github.com/pion/transport v0.7.0/go.mod h1:iWZ07doqOosSLMhZ+FXUTq+TamDoXSllxpbGcfkCmbE=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/util.go
+++ b/util.go
@@ -1,10 +1,8 @@
 package ice
 
 import (
-	"fmt"
 	"math/rand"
 	"net"
-	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -50,23 +48,6 @@ func randSeq(n int) string {
 		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
-}
-
-// flattenErrs flattens multiple errors into one
-func flattenErrs(errs []error) error {
-	var errstrings []string
-
-	for _, err := range errs {
-		if err != nil {
-			errstrings = append(errstrings, err.Error())
-		}
-	}
-
-	if len(errstrings) == 0 {
-		return nil
-	}
-
-	return fmt.Errorf(strings.Join(errstrings, "\n"))
 }
 
 func parseAddr(in net.Addr) (net.IP, int, NetworkType, bool) {


### PR DESCRIPTION
Modified gatherCandidatesReflective to respect port min and max
constraints when allocating connections for server reflexive
candidates.

#### Reference issue
Related to https://github.com/pion/webrtc/issues/668

#### Depends on
https://github.com/pion/stun/pull/9