### PR TITLE
Use binding request for keepalive

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -549,7 +549,9 @@ func (a *Agent) checkKeepalive() {
 
 	if (a.keepaliveInterval != 0) &&
 		(time.Since(a.selectedPair.local.LastSent()) > a.keepaliveInterval) {
-		a.keepaliveCandidate(a.selectedPair.local, a.selectedPair.remote)
+		// we use binding request instead of indication to support refresh consent schemas
+		// see https://tools.ietf.org/html/rfc7675
+		a.selector.PingCandidate(a.selectedPair.local, a.selectedPair.remote)
 	}
 }
 

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -105,22 +105,6 @@ func (p *candidatePair) Write(b []byte) (int, error) {
 	return p.local.writeTo(b, p.remote)
 }
 
-// keepaliveCandidate sends a STUN Binding Indication to the remote candidate
-func (a *Agent) keepaliveCandidate(local, remote Candidate) {
-	msg, err := stun.Build(stun.NewType(stun.MethodBinding, stun.ClassIndication), stun.TransactionID,
-		stun.NewUsername(a.remoteUfrag+":"+a.localUfrag),
-		stun.NewShortTermIntegrity(a.remotePwd),
-		stun.Fingerprint,
-	)
-
-	if err != nil {
-		a.log.Error(err.Error())
-		return
-	}
-
-	a.sendSTUN(msg, local, remote)
-}
-
 func (a *Agent) sendSTUN(msg *stun.Message, local, remote Candidate) {
 	_, err := local.writeTo(msg.Raw, remote)
 	if err != nil {


### PR DESCRIPTION
instead of indication (to support consent refreshness)