### PR TITLE
Improve Gathering error handling

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -97,7 +97,7 @@ func (a *Agent) GatherCandidates() error {
 	gatherErrChan := make(chan error, 1)
 
 	runErr := a.run(func(agent *Agent) {
-		if a.gatheringState == GatheringStateGathering {
+		if a.gatheringState != GatheringStateNew {
 			gatherErrChan <- ErrMultipleGatherAttempted
 			return
 		} else if a.onCandidateHdlr == nil {


### PR DESCRIPTION
Gather only asserted that it wasn't GatheringStateGathering. This
meant that if gathering was complete it would allow multiple runs.
