### PR TITLE
Leave it to the caller to reject invalid stun URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Adam Kiss](https://github.com/masterada)
 * [Aleksandr Razumov](https://github.com/ernado)
 * [Yutaka Takeda](https://github.com/enobufs)
+* [mchlrhw](https://github.com/mchlrhw)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/url.go
+++ b/url.go
@@ -154,19 +154,21 @@ func ParseURL(raw string) (*URL, error) {
 		return nil, ErrPort
 	}
 
+	var retErr error
+
 	switch {
 	case u.Scheme == SchemeTypeSTUN:
 		qArgs, err := url.ParseQuery(rawParts.RawQuery)
-		if err != nil || len(qArgs) > 0 {
-			return nil, ErrSTUNQuery
-		}
 		u.Proto = ProtoTypeUDP
+		if err != nil || len(qArgs) > 0 {
+			retErr = ErrSTUNQuery
+		}
 	case u.Scheme == SchemeTypeSTUNS:
 		qArgs, err := url.ParseQuery(rawParts.RawQuery)
-		if err != nil || len(qArgs) > 0 {
-			return nil, ErrSTUNQuery
-		}
 		u.Proto = ProtoTypeTCP
+		if err != nil || len(qArgs) > 0 {
+			retErr = ErrSTUNQuery
+		}
 	case u.Scheme == SchemeTypeTURN:
 		proto, err := parseProto(rawParts.RawQuery)
 		if err != nil {
@@ -189,7 +191,7 @@ func ParseURL(raw string) (*URL, error) {
 		}
 	}
 
-	return &u, nil
+	return &u, retErr
 }
 
 func parseProto(raw string) (ProtoType, error) {


### PR DESCRIPTION
#### Description
URLs in the stun and stuns schemes should not have a query, but it is useful to leave it up to the caller to decide how to handle invalid URLs, so now we return both the error and the parsed URL.

#### Reference issue
Related to https://github.com/pion/webrtc/issues/735
