### PR TITLE
Fix Ticker leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Adam Kiss](https://github.com/masterada)
 * [Aleksandr Razumov](https://github.com/ernado)
 * [Yutaka Takeda](https://github.com/enobufs)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/agent_test.go
+++ b/agent_test.go
@@ -222,6 +222,7 @@ func TestHandlePeerReflexive(t *testing.T) {
 		var config AgentConfig
 		runAgentTest(t, &config, func(a *Agent) {
 			a.selector = &controllingSelector{agent: a, log: a.log}
+			a.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 
 			hostConfig := CandidateHostConfig{
 				Network:   "udp",
@@ -287,6 +288,7 @@ func TestHandlePeerReflexive(t *testing.T) {
 		var config AgentConfig
 		runAgentTest(t, &config, func(a *Agent) {
 			a.selector = &controllingSelector{agent: a, log: a.log}
+			a.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 
 			hostConfig := CandidateHostConfig{
 				Network:   "tcp",
@@ -318,6 +320,7 @@ func TestHandlePeerReflexive(t *testing.T) {
 		var config AgentConfig
 		runAgentTest(t, &config, func(a *Agent) {
 			a.selector = &controllingSelector{agent: a, log: a.log}
+			a.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 			tID := [stun.TransactionIDSize]byte{}
 			copy(tID[:], []byte("ABC"))
 			a.pendingBindingRequests = []bindingRequest{
@@ -470,6 +473,7 @@ func TestInboundValidity(t *testing.T) {
 
 		err = a.run(func(a *Agent) {
 			a.selector = &controllingSelector{agent: a, log: a.log}
+			a.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 			a.handleInbound(buildMsg(stun.ClassRequest, a.localUfrag+":"+a.remoteUfrag, a.localPwd), local, remote)
 			if len(a.remoteCandidates) != 1 {
 				t.Fatal("Binding with valid values was unable to create prflx candidate")
@@ -485,6 +489,7 @@ func TestInboundValidity(t *testing.T) {
 		var config AgentConfig
 		runAgentTest(t, &config, func(a *Agent) {
 			a.selector = &controllingSelector{agent: a, log: a.log}
+			a.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(a.localUfrag+":"+a.remoteUfrag),
 				stun.NewShortTermIntegrity(a.localPwd),


### PR DESCRIPTION
####  Description

time.Ticker leaks if not Stop()-ed after use.
Close connectivity interval ticker on Agent.Close() to fix leak.

---

Calling `webrtc.NewPeerConnection` and `webrtc.Close` repeatedly causes continuous increase of memory usage.
As a result of heap memory analysis using pprof, I've found that Agent.Ticker is leaked as following:
![image](https://user-images.githubusercontent.com/8390204/62290616-b66ceb00-b49c-11e9-8181-e73e6fbed75e.png)