### PR TITLE
Add ability to filter interfaces

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -150,6 +150,8 @@ type Agent struct {
 	log           logging.LeveledLogger
 
 	net *vnet.Net
+
+	interfaceFilter func(string) bool
 }
 
 func (a *Agent) ok() error {
@@ -234,6 +236,10 @@ type AgentConfig struct {
 	// Net is the our abstracted network interface for internal development purpose only
 	// (see github.com/pion/transport/vnet)
 	Net *vnet.Net
+
+	// InterfaceFilter is a function that you can use in order to  whitelist or blacklist
+	// the interfaces which are used to gather ICE candidates.
+	InterfaceFilter func(string) bool
 }
 
 func containsCandidateType(candidateType CandidateType, candidateTypeList []CandidateType) bool {
@@ -337,6 +343,8 @@ func NewAgent(config *AgentConfig) (*Agent, error) {
 		mDNSConn: mDNSConn,
 
 		forceCandidateContact: make(chan bool, 1),
+
+		interfaceFilter: config.InterfaceFilter,
 	}
 	a.haveStarted.Store(false)
 

--- a/gather.go
+++ b/gather.go
@@ -41,6 +41,10 @@ func (a *Agent) localInterfaces(networkTypes []NetworkType) ([]net.IP, error) {
 			continue // loopback interface
 		}
 
+		if a.interfaceFilter != nil && !a.interfaceFilter(iface.Name) {
+			continue
+		}
+
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue


### PR DESCRIPTION
#### Description

Adds ability to filter specific interfaces via the use of a call back which is passed the name of the interface.

* An accompanying PR will be sent to pion/webrtc in order to expose
this through the SettingsEngine

