### PR TITLE
Add InterfaceFilter to AgentConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Robert Eperjesi](https://github.com/epes)
 * [Sebastian Waisbrot](https://github.com/seppo0010)
 * [Zizheng Tai](https://github.com/ZizhengTai)
+* [Aaron France](https://github.com/AeroNotix)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/agent.go
+++ b/agent.go
@@ -154,6 +154,8 @@ type Agent struct {
 	log           logging.LeveledLogger
 
 	net *vnet.Net
+
+	interfaceFilter func(string) bool
 }
 
 func (a *Agent) ok() error {
@@ -252,6 +254,10 @@ type AgentConfig struct {
 	// Net is the our abstracted network interface for internal development purpose only
 	// (see github.com/pion/transport/vnet)
 	Net *vnet.Net
+
+	// InterfaceFilter is a function that you can use in order to  whitelist or blacklist
+	// the interfaces which are used to gather ICE candidates.
+	InterfaceFilter func(string) bool
 }
 
 func containsCandidateType(candidateType CandidateType, candidateTypeList []CandidateType) bool {
@@ -355,6 +361,8 @@ func NewAgent(config *AgentConfig) (*Agent, error) {
 		mDNSConn: mDNSConn,
 
 		forceCandidateContact: make(chan bool, 1),
+
+		interfaceFilter: config.InterfaceFilter,
 	}
 	a.haveStarted.Store(false)
 

--- a/gather.go
+++ b/gather.go
@@ -41,6 +41,10 @@ func (a *Agent) localInterfaces(networkTypes []NetworkType) ([]net.IP, error) {
 			continue // loopback interface
 		}
 
+		if a.interfaceFilter != nil && !a.interfaceFilter(iface.Name) {
+			continue
+		}
+
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue


### PR DESCRIPTION
This callback can be used to exclude interfaces from gathering.

Relates to pion/webrtc#843