### PR TITLE
fix: Controlled selectors now timeout with CandidateSelectionTimeout

### DIFF
--- a/selection.go
+++ b/selection.go
@@ -206,7 +206,7 @@ func (s *controlledSelector) ContactCandidates() {
 			s.agent.checkKeepalive()
 		}
 	} else {
-		if time.Since(s.startTime) > s.agent.connectionTimeout {
+		if time.Since(s.startTime) > s.agent.candidateSelectionTimeout {
 			s.log.Trace("check timeout reached and no valid candidate pair found, marking connection as failed")
 			s.agent.updateConnectionState(ConnectionStateFailed)
 		} else {

--- a/selection.go
+++ b/selection.go
@@ -207,6 +207,7 @@ func (s *controlledSelector) ContactCandidates() {
 		}
 	} else {
 		if time.Since(s.startTime) > s.agent.connectionTimeout {
+			s.log.Trace("check timeout reached and no valid candidate pair found, marking connection as failed")
 			s.agent.updateConnectionState(ConnectionStateFailed)
 		} else {
 			s.log.Trace("pinging all candidates")


### PR DESCRIPTION
I noticed some peer connections weren't closing when the peer was a controlled selector and its state was in the `checking` state (i.e. waiting to determine good candidate pairs). With this PR a controlled selector will timeout its connectivity checks after `CandidateSelectionTimeout` has passed.