### PR TITLE
Gather STUN/TURN URLs concurrently

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -891,6 +891,9 @@ func (a *Agent) addCandidate(c Candidate, candidateConn net.PacketConn) error {
 		set := a.localCandidates[c.NetworkType()]
 		for _, candidate := range set {
 			if candidate.Equal(c) {
+				if err := c.close(); err != nil {
+					a.log.Warnf("Failed to close duplicate candidate: %v", err)
+				}
 				return
 			}
 		}

--- a/agent.go
+++ b/agent.go
@@ -4,7 +4,6 @@ package ice
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"net"
 	"strings"
@@ -1303,41 +1302,3 @@ func (a *Agent) GetRemoteCandidatesStats() []CandidateStats {
 	}
 	return <-resultChan
 }
-
-// Role represents ICE agent role, which can be controlling or controlled.
-type Role byte
-
-// UnmarshalText implements TextUnmarshaler.
-func (r *Role) UnmarshalText(text []byte) error {
-	switch string(text) {
-	case "controlling":
-		*r = Controlling
-	case "controlled":
-		*r = Controlled
-	default:
-		return fmt.Errorf("unknown role %q", text)
-	}
-	return nil
-}
-
-// MarshalText implements TextMarshaler.
-func (r Role) MarshalText() (text []byte, err error) {
-	return []byte(r.String()), nil
-}
-
-func (r Role) String() string {
-	switch r {
-	case Controlling:
-		return "controlling"
-	case Controlled:
-		return "controlled"
-	default:
-		return "unknown"
-	}
-}
-
-// Possible ICE agent roles.
-const (
-	Controlling Role = iota
-	Controlled
-)

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -73,13 +73,7 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 	<-aConnected
 	<-bConnected
 
-	if err = aAgent.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err = bAgent.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err = server.Close(); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, aAgent.Close())
+	assert.NoError(t, bAgent.Close())
+	assert.NoError(t, server.Close())
 }

--- a/gather.go
+++ b/gather.go
@@ -134,14 +134,7 @@ func (a *Agent) gatherCandidatesLocal(networkTypes []NetworkType) {
 					}
 				}
 
-				if err := a.run(func(agent *Agent) {
-					c.start(a, conn)
-					a.addCandidate(c)
-
-					if a.onCandidateHdlr != nil {
-						go a.onCandidateHdlr(c)
-					}
-				}); err != nil {
+				if err := a.addCandidate(c, conn); err != nil {
 					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
 				}
 			}(network, ip, mappedIP)
@@ -204,14 +197,7 @@ func (a *Agent) gatherCandidatesSrflx(urls []*URL, networkTypes []NetworkType) {
 					continue
 				}
 
-				if err := a.run(func(agent *Agent) {
-					c.start(a, conn)
-					a.addCandidate(c)
-
-					if a.onCandidateHdlr != nil {
-						go a.onCandidateHdlr(c)
-					}
-				}); err != nil {
+				if err := a.addCandidate(c, conn); err != nil {
 					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
 				}
 			}
@@ -247,14 +233,7 @@ func (a *Agent) gatherCandidatesSrflx(urls []*URL, networkTypes []NetworkType) {
 				continue
 			}
 
-			if err := a.run(func(agent *Agent) {
-				c.start(a, conn)
-				a.addCandidate(c)
-
-				if a.onCandidateHdlr != nil {
-					go a.onCandidateHdlr(c)
-				}
-			}); err != nil {
+			if err := a.addCandidate(c, conn); err != nil {
 				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
 			}
 		}
@@ -353,14 +332,7 @@ func (a *Agent) gatherCandidatesRelay(urls []*URL) error {
 			continue
 		}
 
-		if err := a.run(func(agent *Agent) {
-			candidate.start(a, relayConn)
-			a.addCandidate(candidate)
-
-			if a.onCandidateHdlr != nil {
-				go a.onCandidateHdlr(candidate)
-			}
-		}); err != nil {
+		if err := a.addCandidate(candidate, relayConn); err != nil {
 			a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
 		}
 	}

--- a/gather.go
+++ b/gather.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pion/stun"
 	"github.com/pion/transport/vnet"
 	"github.com/pion/turn/v2"
 )
@@ -469,59 +468,4 @@ func (a *Agent) gatherCandidatesRelay(urls []*URL) error {
 	}
 
 	return nil
-}
-
-// getXORMappedAddr initiates a stun requests to serverAddr using conn, reads the response and returns
-// the XORMappedAddress returned by the stun server.
-//
-// Adapted from stun v0.2.
-func getXORMappedAddr(conn net.PacketConn, serverAddr net.Addr, deadline time.Duration) (*stun.XORMappedAddress, error) {
-	if deadline > 0 {
-		if err := conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
-			return nil, err
-		}
-	}
-	defer func() {
-		if deadline > 0 {
-			_ = conn.SetReadDeadline(time.Time{})
-		}
-	}()
-	resp, err := stunRequest(
-		func(p []byte) (int, error) {
-			n, _, errr := conn.ReadFrom(p)
-			return n, errr
-		},
-		func(b []byte) (int, error) {
-			return conn.WriteTo(b, serverAddr)
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	var addr stun.XORMappedAddress
-	if err = addr.GetFrom(resp); err != nil {
-		return nil, fmt.Errorf("failed to get XOR-MAPPED-ADDRESS response: %v", err)
-	}
-	return &addr, nil
-}
-
-func stunRequest(read func([]byte) (int, error), write func([]byte) (int, error)) (*stun.Message, error) {
-	req, err := stun.Build(stun.BindingRequest, stun.TransactionID)
-	if err != nil {
-		return nil, err
-	}
-	if _, err = write(req.Raw); err != nil {
-		return nil, err
-	}
-	const maxMessageSize = 1280
-	bs := make([]byte, maxMessageSize)
-	n, err := read(bs)
-	if err != nil {
-		return nil, err
-	}
-	res := &stun.Message{Raw: bs[:n]}
-	if err := res.Decode(); err != nil {
-		return nil, err
-	}
-	return res, nil
 }

--- a/gather_test.go
+++ b/gather_test.go
@@ -14,47 +14,28 @@ import (
 
 func TestListenUDP(t *testing.T) {
 	a, err := NewAgent(&AgentConfig{})
-	if err != nil {
-		t.Fatalf("Failed to create agent: %s", err)
-	}
+	assert.NoError(t, err)
 
 	localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
-	if len(localIPs) == 0 {
-		t.Fatal("localInterfaces found no interfaces, unable to test")
-	} else if err != nil {
-		t.Fatal(err)
-	}
+	assert.NotEqual(t, len(localIPs), 0, "localInterfaces found no interfaces, unable to test")
+	assert.NoError(t, err)
 
 	ip := localIPs[0]
 
 	conn, err := a.listenUDP(0, 0, udp, &net.UDPAddr{IP: ip, Port: 0})
-	if err != nil {
-		t.Fatalf("listenUDP error with no port restriction %v", err)
-	} else if conn == nil {
-		t.Fatalf("listenUDP error with no port restriction return a nil conn")
-	}
+	assert.NoError(t, err, "listenUDP error with no port restriction")
+	assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
 	_, err = a.listenUDP(4999, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
-	if err == nil {
-		t.Fatal("listenUDP with invalid port range did not fail")
-	}
-	if err != ErrPort {
-		t.Fatal("listenUDP with invalid port range did not return ErrPort")
-	}
+	assert.Equal(t, err, ErrPort, "listenUDP with invalid port range did not return ErrPort")
 
 	conn, err = a.listenUDP(5000, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
-	if err != nil {
-		t.Fatalf("listenUDP error with no port restriction %v", err)
-	} else if conn == nil {
-		t.Fatalf("listenUDP error with no port restriction return a nil conn")
-	}
+	assert.NoError(t, err, "listenUDP error with no port restriction")
+	assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
 	_, port, err := net.SplitHostPort(conn.LocalAddr().String())
-	if err != nil {
-		t.Fatal(err)
-	} else if port != "5000" {
-		t.Fatalf("listenUDP with port restriction of 5000 listened on incorrect port (%s)", port)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, port, "5000", "listenUDP with port restriction of 5000 listened on incorrect port")
 
 	portMin := 5100
 	portMax := 5109
@@ -63,11 +44,8 @@ func TestListenUDP(t *testing.T) {
 	portRange := make([]int, 0, total)
 	for i := 0; i < total; i++ {
 		conn, err = a.listenUDP(portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
-		if err != nil {
-			t.Fatalf("listenUDP error with no port restriction %v", err)
-		} else if conn == nil {
-			t.Fatalf("listenUDP error with no port restriction return a nil conn")
-		}
+		assert.NoError(t, err, "listenUDP error with no port restriction")
+		assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
 		_, port, err = net.SplitHostPort(conn.LocalAddr().String())
 		if err != nil {
@@ -88,12 +66,7 @@ func TestListenUDP(t *testing.T) {
 		t.Fatalf("listenUDP with port restriction [%d, %d], got:%v, want:%v", portMin, portMax, result, portRange)
 	}
 	_, err = a.listenUDP(portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
-	if err == nil {
-		t.Fatalf("listenUDP with port restriction [%d, %d], should return error", portMin, portMax)
-	}
-	if err != ErrPort {
-		t.Fatalf("listenUDP with port restriction [%d, %d], did not return ErrPort", portMin, portMax)
-	}
+	assert.Equal(t, err, ErrPort, "listenUDP with port restriction [%d, %d], did not return ErrPort", portMin, portMax)
 
 	assert.NoError(t, a.Close())
 }

--- a/gather_test.go
+++ b/gather_test.go
@@ -16,20 +16,20 @@ func TestListenUDP(t *testing.T) {
 	a, err := NewAgent(&AgentConfig{})
 	assert.NoError(t, err)
 
-	localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+	localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 	assert.NotEqual(t, len(localIPs), 0, "localInterfaces found no interfaces, unable to test")
 	assert.NoError(t, err)
 
 	ip := localIPs[0]
 
-	conn, err := a.listenUDP(0, 0, udp, &net.UDPAddr{IP: ip, Port: 0})
+	conn, err := listenUDPInPortRange(a.net, a.log, 0, 0, udp, &net.UDPAddr{IP: ip, Port: 0})
 	assert.NoError(t, err, "listenUDP error with no port restriction")
 	assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
-	_, err = a.listenUDP(4999, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
+	_, err = listenUDPInPortRange(a.net, a.log, 4999, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
 	assert.Equal(t, err, ErrPort, "listenUDP with invalid port range did not return ErrPort")
 
-	conn, err = a.listenUDP(5000, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
+	conn, err = listenUDPInPortRange(a.net, a.log, 5000, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
 	assert.NoError(t, err, "listenUDP error with no port restriction")
 	assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
@@ -43,7 +43,7 @@ func TestListenUDP(t *testing.T) {
 	result := make([]int, 0, total)
 	portRange := make([]int, 0, total)
 	for i := 0; i < total; i++ {
-		conn, err = a.listenUDP(portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
+		conn, err = listenUDPInPortRange(a.net, a.log, portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
 		assert.NoError(t, err, "listenUDP error with no port restriction")
 		assert.NotNil(t, conn, "listenUDP error with no port restriction return a nil conn")
 
@@ -65,7 +65,7 @@ func TestListenUDP(t *testing.T) {
 	if !reflect.DeepEqual(result, portRange) {
 		t.Fatalf("listenUDP with port restriction [%d, %d], got:%v, want:%v", portMin, portMax, result, portRange)
 	}
-	_, err = a.listenUDP(portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
+	_, err = listenUDPInPortRange(a.net, a.log, portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
 	assert.Equal(t, err, ErrPort, "listenUDP with port restriction [%d, %d], did not return ErrPort", portMin, portMax)
 
 	assert.NoError(t, a.Close())

--- a/gather_vnet_test.go
+++ b/gather_vnet_test.go
@@ -26,7 +26,7 @@ func TestVNetGather(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 		if len(localIPs) > 0 {
 			t.Fatal("should return no local IP")
 		} else if err != nil {
@@ -66,7 +66,7 @@ func TestVNetGather(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 		if len(localIPs) == 0 {
 			t.Fatal("should have one local IP")
 		} else if err != nil {
@@ -109,7 +109,7 @@ func TestVNetGather(t *testing.T) {
 			t.Fatalf("Failed to create agent: %s", err)
 		}
 
-		localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 		if len(localIPs) == 0 {
 			t.Fatal("localInterfaces found no interfaces, unable to test")
 		} else if err != nil {
@@ -118,7 +118,7 @@ func TestVNetGather(t *testing.T) {
 
 		ip := localIPs[0]
 
-		conn, err := a.listenUDP(0, 0, udp, &net.UDPAddr{IP: ip, Port: 0})
+		conn, err := listenUDPInPortRange(a.net, a.log, 0, 0, udp, &net.UDPAddr{IP: ip, Port: 0})
 		if err != nil {
 			t.Fatalf("listenUDP error with no port restriction %v", err)
 		} else if conn == nil {
@@ -129,12 +129,12 @@ func TestVNetGather(t *testing.T) {
 			t.Fatalf("failed to close conn")
 		}
 
-		_, err = a.listenUDP(4999, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
+		_, err = listenUDPInPortRange(a.net, a.log, 4999, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
 		if err != ErrPort {
 			t.Fatal("listenUDP with invalid port range did not return ErrPort")
 		}
 
-		conn, err = a.listenUDP(5000, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
+		conn, err = listenUDPInPortRange(a.net, a.log, 5000, 5000, udp, &net.UDPAddr{IP: ip, Port: 0})
 		if err != nil {
 			t.Fatalf("listenUDP error with no port restriction %v", err)
 		} else if conn == nil {
@@ -384,7 +384,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 		if err != nil {
 			t.Fatal(err)
 		} else if len(localIPs) != 0 {
@@ -404,7 +404,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := a.localInterfaces([]NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, []NetworkType{NetworkTypeUDP4})
 		if err != nil {
 			t.Fatal(err)
 		} else if len(localIPs) == 0 {

--- a/role.go
+++ b/role.go
@@ -1,0 +1,41 @@
+package ice
+
+import "fmt"
+
+// Role represents ICE agent role, which can be controlling or controlled.
+type Role byte
+
+// Possible ICE agent roles.
+const (
+	Controlling Role = iota
+	Controlled
+)
+
+// UnmarshalText implements TextUnmarshaler.
+func (r *Role) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "controlling":
+		*r = Controlling
+	case "controlled":
+		*r = Controlled
+	default:
+		return fmt.Errorf("unknown role %q", text)
+	}
+	return nil
+}
+
+// MarshalText implements TextMarshaler.
+func (r Role) MarshalText() (text []byte, err error) {
+	return []byte(r.String()), nil
+}
+
+func (r Role) String() string {
+	switch r {
+	case Controlling:
+		return "controlling"
+	case Controlled:
+		return "controlled"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
Gather candidates of each type concurrently, this way a single slow
TURN/STUN server doesn't block the others.

We should make the entire gather process more concurrent and spawn each
gather in a separate goroutine eventually

Resolves #118 