### PR TITLE
Configuration support for local agent username fragment and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Aaron France](https://github.com/AeroNotix)
 * [Chao Yuan](https://github.com/yuanchao0310)
 * [Jason Maldonis](https://github.com/jjmaldonis)
+* [Nevio Vesic](https://github.com/0x19)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,14 @@ var (
 	// ErrPort indicates malformed port is provided.
 	ErrPort = errors.New("invalid port")
 
+	// ErrLocalUfragInsufficientBits indicates local username fragment insufficient bits are provided.
+	// Have to be at least 24 bits long
+	ErrLocalUfragInsufficientBits = errors.New("local username fragment is less than 24 bits long")
+
+	// ErrLocalPwdInsufficientBits indicates local passoword insufficient bits are provided.
+	// Have to be at least 128 bits long
+	ErrLocalPwdInsufficientBits = errors.New("local password is less than 128 bits long")
+
 	// ErrProtoType indicates an unsupported transport type was provided.
 	ErrProtoType = errors.New("invalid transport protocol type")
 

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b h1:lkjdUzSyJ5P1+eal9fxXX9Xg2BTfswsonKUse48C0uE=
 golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 h1:DPz9iiH3YoKiKhX/ijjoZvT0VFwK2c6CWYWQ7Zyr8TU=
 golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
#### Description

Adding configuration support for local username fragment and password, making sure we are validating values based on the RFC standard. Wrote unit test case to cover backward compatibility and test RFC standard validation.

#### Unit Test Case Output

```
go test -run TestAgentCredentials
ice ERROR: 2019/11/07 03:50:38 failed to accept local username fragment as it is less than 24 bits long
ice ERROR: 2019/11/07 03:50:38 failed to accept local password as it is less than 128 bits long
PASS
ok  	github.com/pion/ice	0.032s
```
