### PR TITLE
Seed everytime when calling generateRandString

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -1,9 +1,5 @@
 package ice
 
-import (
-	"crypto/rand"
-)
-
 // MulticastDNSMode represents the different Multicast modes ICE can run in
 type MulticastDNSMode byte
 
@@ -20,12 +16,5 @@ const (
 )
 
 func generateMulticastDNSName() (string, error) {
-	b := make([]byte, 16)
-	_, err := rand.Read(b) //nolint
-
-	if err != nil {
-		return "", err
-	}
-
 	return generateRandString("", ".local")
 }

--- a/util.go
+++ b/util.go
@@ -81,9 +81,7 @@ func generateCandidateID() (string, error) {
 
 func generateRandString(prefix, sufix string) (string, error) {
 	b := make([]byte, 16)
-	_, err := rand.Read(b) //nolint
-
-	if err != nil {
+	if _, err := rand.New(rand.NewSource(time.Now().UnixNano())).Read(b); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
This isn't in a hot path, so no performance hit. Also want to avoid side
effects from doing in an init