### PR TITLE
Add MulticastHostName to AgentConfig

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -199,6 +199,9 @@ type AgentConfig struct {
 	// MulticastDNSMode controls mDNS behavior for the ICE agent
 	MulticastDNSMode MulticastDNSMode
 
+	// MulticastHostName controls the hostname for this agent. If none is specified a random one will be generated
+	MulticastHostName string
+
 	// ConnectionTimeout defaults to 30 seconds when this property is nil.
 	// If the duration is 0, we will never timeout this connection.
 	ConnectionTimeout *time.Duration
@@ -313,6 +316,7 @@ func createMulticastDNS(mDNSMode MulticastDNSMode, mDNSName string, log logging.
 
 // NewAgent creates a new Agent
 func NewAgent(config *AgentConfig) (*Agent, error) {
+	var err error
 	if config.PortMax < config.PortMin {
 		return nil, ErrPort
 	}
@@ -337,9 +341,15 @@ func NewAgent(config *AgentConfig) (*Agent, error) {
 		localPwd = config.LocalPwd
 	}
 
-	mDNSName, err := generateMulticastDNSName()
-	if err != nil {
-		return nil, err
+	mDNSName := config.MulticastHostName
+	if mDNSName == "" {
+		if mDNSName, err = generateMulticastDNSName(); err != nil {
+			return nil, err
+		}
+	}
+
+	if !strings.HasSuffix(mDNSName, ".local") || len(strings.Split(mDNSName, ".")) != 2 {
+		return nil, ErrInvalidMulticastHostName
 	}
 
 	mDNSMode := config.MulticastDNSMode

--- a/errors.go
+++ b/errors.go
@@ -94,4 +94,7 @@ var (
 	// ErrIneffectiveNAT1To1IPMappingSrflx indicates that 1:1 NAT IP mapping for srflx candidate is
 	// requested, but the srflx candidate type is disabled.
 	ErrIneffectiveNAT1To1IPMappingSrflx = errors.New("1:1 NAT IP mapping for srflx candidate ineffective")
+
+	// ErrInvalidMulticastHostName indicates an invalid MulticastHostName
+	ErrInvalidMulticastHostName = errors.New("invalid mDNS HostName, must end with .local and can only contain a single '.'")
 )


### PR DESCRIPTION
Allow users to pass in a static MulticastHostName, this can be used to
connect peers in a LAN without signaling. If you set a static uFrag/uPwd
on either side and have a static hostname you can gather without knowing
an IP Address on either side.
