### PR TITLE
Check for nil when loading atomic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Chao Yuan](https://github.com/yuanchao0310)
 * [Jason Maldonis](https://github.com/jjmaldonis)
 * [Nevio Vesic](https://github.com/0x19)
+* [David Hamilton](https://github.com/dihamilton)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -194,7 +194,11 @@ func (c *candidateBase) String() string {
 // LastReceived returns a time.Time indicating the last time
 // this candidate was received
 func (c *candidateBase) LastReceived() time.Time {
-	return c.lastReceived.Load().(time.Time)
+	lastReceived := c.lastReceived.Load()
+	if lastReceived == nil {
+		return time.Time{}
+	}
+	return lastReceived.(time.Time)
 }
 
 func (c *candidateBase) setLastReceived(t time.Time) {
@@ -204,7 +208,11 @@ func (c *candidateBase) setLastReceived(t time.Time) {
 // LastSent returns a time.Time indicating the last time
 // this candidate was sent
 func (c *candidateBase) LastSent() time.Time {
-	return c.lastSent.Load().(time.Time)
+	lastSent := c.lastSent.Load()
+	if lastSent == nil {
+		return time.Time{}
+	}
+	return lastSent.(time.Time)
 }
 
 func (c *candidateBase) setLastSent(t time.Time) {

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -1,6 +1,11 @@
 package ice
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestCandidatePriority(t *testing.T) {
 	for _, test := range []struct {
@@ -48,4 +53,22 @@ func TestCandidatePriority(t *testing.T) {
 			t.Fatalf("Candidate(%v).Priority() = %d, want %d", test.Candidate, got, want)
 		}
 	}
+}
+
+
+func TestCandidateLastSent(t *testing.T) {
+	candidate := candidateBase{}
+	assert.Equal(t, candidate.LastSent(), time.Time{})
+	now := time.Now()
+	candidate.setLastSent(now)
+	assert.Equal(t, candidate.LastSent(), now)
+}
+
+
+func TestCandidateLastReceived(t *testing.T) {
+	candidate := candidateBase{}
+	assert.Equal(t, candidate.LastReceived(), time.Time{})
+	now := time.Now()
+	candidate.setLastReceived(now)
+	assert.Equal(t, candidate.LastReceived(), now)
 }


### PR DESCRIPTION
#### Description

This is required to prevent an error when values are loaded without first being set.

I'm not sure about follow on effects so it would be worth someone with more experience taking a look.

The affected areas are: https://github.com/pion/ice/blob/57e7b93a4bac70ee2fd3b38cc2fdf3c6d586ed27/agent.go#L777
and
https://github.com/pion/ice/blob/57e7b93a4bac70ee2fd3b38cc2fdf3c6d586ed27/agent.go#L798
where I think calling PingCandidate if lastSent has not been set is probably fine.


#### Reference issue
