### PR TITLE
Add error message when no pairs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -654,6 +654,12 @@ func (a *Agent) setSelectedPair(p *candidatePair) {
 }
 
 func (a *Agent) pingAllCandidates() {
+	a.log.Trace("pinging all candidates")
+
+	if len(a.checklist) == 0 {
+		a.log.Warn("pingAllCandidates called with no candidate pairs. Connection is not possible yet.")
+	}
+
 	for _, p := range a.checklist {
 		if p.state == CandidatePairStateWaiting {
 			p.state = CandidatePairStateInProgress

--- a/selection.go
+++ b/selection.go
@@ -92,8 +92,6 @@ func (s *controllingSelector) ContactCandidates() {
 			s.nominatePair(p)
 			return
 		}
-
-		s.log.Trace("pinging all candidates")
 		s.agent.pingAllCandidates()
 	}
 }
@@ -215,7 +213,6 @@ func (s *controlledSelector) ContactCandidates() {
 			s.log.Trace("check timeout reached and no valid candidate pair found, marking connection as failed")
 			s.agent.updateConnectionState(ConnectionStateFailed)
 		} else {
-			s.log.Trace("pinging all candidates")
 			s.agent.pingAllCandidates()
 		}
 	}


### PR DESCRIPTION
Add error message if pingAllCandidates is called and we
have no candidate pairs. This may help users when debugging.