### PR TITLE
Support WASM build/test

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/candidate_relay_test.go
+++ b/candidate_relay_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/gather_test.go
+++ b/gather_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/gather_vnet_test.go
+++ b/gather_vnet_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ice
 
 import (


### PR DESCRIPTION
Some tests using net.Conn connection are disabled for now
as it is not fully supported by WASM MVP stage.

preparation for https://github.com/pion/.goassets/pull/4