### PR TITLE
Fix TestRelayOnlyConnection on debian

### DIFF
--- a/candidate_relay_test.go
+++ b/candidate_relay_test.go
@@ -46,7 +46,7 @@ func TestRelayOnlyConnection(t *testing.T) {
 		Urls: []*URL{
 			{
 				Scheme:   SchemeTypeTURN,
-				Host:     "localhost",
+				Host:     "127.0.0.1",
 				Username: "username",
 				Password: "password",
 				Port:     serverPort,

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -42,7 +42,7 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 		Urls: []*URL{
 			{
 				Scheme: SchemeTypeSTUN,
-				Host:   "localhost",
+				Host:   "127.0.0.1",
 				Port:   serverPort,
 			},
 		},


### PR DESCRIPTION
Debian based linux uses 127.0.1.1 as a local loopback address
in some condition of the install.

ref: https://github.com/pion/ice/pull/142