### PR TITLE
Start Agent performance refactor

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -119,15 +119,9 @@ func handleInboundCandidateMsg(c Candidate, buffer []byte, srcAddr net.Addr, log
 		return
 	}
 
-	isValidRemoteCandidate := make(chan bool, 1)
-	err := c.agent().run(func(agent *Agent) {
-		isValidRemoteCandidate <- agent.noSTUNSeen(c, srcAddr)
-	})
-
-	if err != nil {
-		log.Warnf("Failed to handle message: %v", err)
-	} else if !<-isValidRemoteCandidate {
+	if !c.agent().validateNonSTUNTraffic(c, srcAddr) {
 		log.Warnf("Discarded message from %s, not a valid remote candidate", c.addr())
+		return
 	}
 
 	// NOTE This will return packetio.ErrFull if the buffer ever manages to fill up.

--- a/candidatetype.go
+++ b/candidatetype.go
@@ -44,3 +44,15 @@ func (c CandidateType) Preference() uint16 {
 	}
 	return 0
 }
+
+func containsCandidateType(candidateType CandidateType, candidateTypeList []CandidateType) bool {
+	if candidateTypeList == nil {
+		return false
+	}
+	for _, ct := range candidateTypeList {
+		if ct == candidateType {
+			return true
+		}
+	}
+	return false
+}

--- a/gather.go
+++ b/gather.go
@@ -95,7 +95,6 @@ func (a *Agent) gatherCandidates() {
 			}
 		}
 	}
-
 	if err := a.run(func(agent *Agent) {
 		if a.onCandidateHdlr != nil {
 			go a.onCandidateHdlr(nil)

--- a/mdns.go
+++ b/mdns.go
@@ -1,5 +1,13 @@
 package ice
 
+import (
+	"net"
+
+	"github.com/pion/logging"
+	"github.com/pion/mdns"
+	"golang.org/x/net/ipv4"
+)
+
 // MulticastDNSMode represents the different Multicast modes ICE can run in
 type MulticastDNSMode byte
 
@@ -17,4 +25,35 @@ const (
 
 func generateMulticastDNSName() (string, error) {
 	return generateRandString("", ".local")
+}
+
+func createMulticastDNS(mDNSMode MulticastDNSMode, mDNSName string, log logging.LeveledLogger) (*mdns.Conn, MulticastDNSMode, error) {
+	if mDNSMode == MulticastDNSModeDisabled {
+		return nil, mDNSMode, nil
+	}
+
+	addr, mdnsErr := net.ResolveUDPAddr("udp4", mdns.DefaultAddress)
+	if mdnsErr != nil {
+		return nil, mDNSMode, mdnsErr
+	}
+
+	l, mdnsErr := net.ListenUDP("udp4", addr)
+	if mdnsErr != nil {
+		// If ICE fails to start MulticastDNS server just warn the user and continue
+		log.Errorf("Failed to enable mDNS, continuing in mDNS disabled mode: (%s)", mdnsErr)
+		return nil, MulticastDNSModeDisabled, nil
+	}
+
+	switch mDNSMode {
+	case MulticastDNSModeQueryOnly:
+		conn, err := mdns.Server(ipv4.NewPacketConn(l), &mdns.Config{})
+		return conn, mDNSMode, err
+	case MulticastDNSModeQueryAndGather:
+		conn, err := mdns.Server(ipv4.NewPacketConn(l), &mdns.Config{
+			LocalNames: []string{mDNSName},
+		})
+		return conn, mDNSMode, err
+	default:
+		return nil, mDNSMode, nil
+	}
 }

--- a/selection.go
+++ b/selection.go
@@ -71,7 +71,7 @@ func (s *controllingSelector) isNominatable(c Candidate) bool {
 
 func (s *controllingSelector) ContactCandidates() {
 	switch {
-	case s.agent.selectedPair != nil:
+	case s.agent.getSelectedPair() != nil:
 		if s.agent.validateSelectedPair() {
 			s.log.Trace("checking keepalive")
 			s.agent.checkKeepalive()
@@ -130,7 +130,7 @@ func (s *controllingSelector) HandleBindingRequest(m *stun.Message, local, remot
 		return
 	}
 
-	if p.state == CandidatePairStateSucceeded && s.nominatedPair == nil && s.agent.selectedPair == nil {
+	if p.state == CandidatePairStateSucceeded && s.nominatedPair == nil && s.agent.getSelectedPair() == nil {
 		bestPair := s.agent.getBestAvailableCandidatePair()
 		if bestPair == nil {
 			s.log.Tracef("No best pair available\n")
@@ -170,7 +170,7 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)
-	if pendingRequest.isUseCandidate && s.agent.selectedPair == nil {
+	if pendingRequest.isUseCandidate && s.agent.getSelectedPair() == nil {
 		s.agent.setSelectedPair(p)
 	}
 }
@@ -203,7 +203,7 @@ func (s *controlledSelector) Start() {
 }
 
 func (s *controlledSelector) ContactCandidates() {
-	if s.agent.selectedPair != nil {
+	if s.agent.getSelectedPair() != nil {
 		if s.agent.validateSelectedPair() {
 			s.log.Trace("checking keepalive")
 			s.agent.checkKeepalive()
@@ -288,7 +288,7 @@ func (s *controlledSelector) HandleBindingRequest(m *stun.Message, local, remote
 			// previously sent by this pair produced a successful response and
 			// generated a valid pair (Section 7.2.5.3.2).  The agent sets the
 			// nominated flag value of the valid pair to true.
-			if s.agent.selectedPair == nil {
+			if selectedPair := s.agent.getSelectedPair(); selectedPair == nil {
 				s.agent.setSelectedPair(p)
 			}
 			s.agent.sendBindingSuccess(m, local, remote)

--- a/transport.go
+++ b/transport.go
@@ -91,8 +91,8 @@ func (c *Conn) Write(p []byte) (int, error) {
 		return 0, errors.New("the ICE conn can't write STUN messages")
 	}
 
-	pair, err := c.agent.getSelectedPair()
-	if err != nil {
+	pair := c.agent.getSelectedPair()
+	if pair == nil {
 		return 0, err
 	}
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -29,7 +29,7 @@ func TestStressDuplex(t *testing.T) {
 func testTimeout(t *testing.T, c *Conn, timeout time.Duration) {
 	const pollrate = 100 * time.Millisecond
 	const margin = 20 * time.Millisecond // allow 20msec error in time
-	statechan := make(chan ConnectionState)
+	statechan := make(chan ConnectionState, 1)
 	ticker := time.NewTicker(pollrate)
 
 	startedAt := time.Now()

--- a/util.go
+++ b/util.go
@@ -246,3 +246,14 @@ func listenUDPInPortRange(vnet *vnet.Net, log logging.LeveledLogger, portMax, po
 	}
 	return nil, ErrPort
 }
+
+func addrIPAndPort(addr net.Addr) (net.IP, int, error) {
+	switch casted := addr.(type) {
+	case *net.UDPAddr:
+		return casted.IP, casted.Port, nil
+	case *net.TCPAddr:
+		return casted.IP, casted.Port, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported address type %T", addr)
+	}
+}


### PR DESCRIPTION
Remove taskChan and make .run just take an Agent wide mutex and run the
function. These is now a blocking operation so all channels used to
communicate from it must be buffered.

After this we will slowly remove usage of .run and make things more
thread safe.

Relates to #80, #67, #2
