### PR TITLE
Fix closeable panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jason Maldonis](https://github.com/jjmaldonis)
 * [Nevio Vesic](https://github.com/0x19)
 * [David Hamilton](https://github.com/dihamilton)
+* [adwpc](https://github.com/adwpc)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/gather.go
+++ b/gather.go
@@ -22,6 +22,11 @@ type closeable interface {
 
 // Close a net.Conn and log if we have a failure
 func closeConnAndLog(c closeable, log logging.LeveledLogger, msg string) {
+	if c == nil {
+		log.Warnf("Conn is not allocated")
+		return
+	}
+
 	log.Warnf(msg)
 	if err := c.Close(); err != nil {
 		log.Warnf("Failed to close conn: %v", err)


### PR DESCRIPTION
Fix closeable panic when conn == nil

#### Description

ice WARNING: 2020/04/09 23:38:28 conn= &{{0xc0003f6d00}} , err=<nil>, a.portmax=43063 a.portmin=43061
ice WARNING: 2020/04/09 23:38:28 could not get server reflexive address udp6 stun:stun.stunprotocol.org:3478: write udp6 [::]:43062->[2600:1f16:8c5:101::108]:3478: sendto: no route to host
ice WARNING: 2020/04/09 23:38:28 conn= &{{0xc000122380}} , err=<nil>, a.portmax=43063 a.portmin=43061
ice WARNING: 2020/04/09 23:38:33 could not get server reflexive address udp4 stun:stun.stunprotocol.org:3478: read udp4 0.0.0.0:43063: i/o timeout

#### Reference issue
Fixes https://github.com/pion/ion/issues/114
