### PR TITLE
Fix IPv6 addresses gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Nevio Vesic](https://github.com/0x19)
 * [David Hamilton](https://github.com/dihamilton)
 * [adwpc](https://github.com/adwpc)
+* [BUPTCZQ](https://github.com/buptczq)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/util.go
+++ b/util.go
@@ -26,7 +26,7 @@ func (a *atomicError) Load() error {
 // https://tools.ietf.org/html/rfc8445#section-5.1.1.1
 func isSupportedIPv6(ip net.IP) bool {
 	if len(ip) != net.IPv6len ||
-		!isZeros(ip[0:12]) || // !(IPv4-compatible IPv6)
+		isZeros(ip[0:12]) || // !(IPv4-compatible IPv6)
 		ip[0] == 0xfe && ip[1]&0xc0 == 0xc0 || // !(IPv6 site-local unicast)
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() {

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package ice
 
 import (
+	"net"
 	"regexp"
 	"testing"
 )
@@ -13,5 +14,27 @@ func TestRandSeq(t *testing.T) {
 	var isLetter = regexp.MustCompile(`^[a-zA-Z]+$`).MatchString
 	if !isLetter(randSeq(10)) {
 		t.Errorf("randSeq should be AlphaNumeric only")
+	}
+}
+
+func TestIsSupportedIPv6(t *testing.T) {
+	if isSupportedIPv6(net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}) {
+		t.Errorf("isSupportedIPv6 return true with IPv4-compatible IPv6 address")
+	}
+
+	if isSupportedIPv6(net.ParseIP("fec0::2333")) {
+		t.Errorf("isSupportedIPv6 return true with IPv6 site-local unicast address")
+	}
+
+	if isSupportedIPv6(net.ParseIP("fe80::2333")) {
+		t.Errorf("isSupportedIPv6 return true with IPv6 link-local address")
+	}
+
+	if isSupportedIPv6(net.ParseIP("ff02::2333")) {
+		t.Errorf("isSupportedIPv6 return true with IPv6 link-local multicast address")
+	}
+
+	if !isSupportedIPv6(net.ParseIP("2001::1")) {
+		t.Errorf("isSupportedIPv6 return false with IPv6 global unicast address")
 	}
 }


### PR DESCRIPTION
Fix IPv6 addresses gathering

#### Description
Fix isSupportedIPv6 function, when a global unicast address passed to, the function returns false.

