### PR TITLE
Make mDNS opportunistic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Nevio Vesic](https://github.com/0x19)
 * [David Hamilton](https://github.com/dihamilton)
 * [adwpc](https://github.com/adwpc)
+* [Ori Bernstein](https://eigenstate.org)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
It seems like mDNS was intended to be opportunistic, but right now,
if creating an mDNS client fails, the whole ICE connection fails.
This allows pion to work in more restricted network namespaces,
or on less supported environments like 9front.

This allows webwormhole work on Plan 9.