### PR TITLE
Don't unset the selected pair on timeout

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -753,11 +753,10 @@ func (a *Agent) validateSelectedPair() bool {
 		return false
 	}
 
-	if (a.connectionTimeout != 0) &&
-		(time.Since(selectedPair.remote.LastReceived()) > a.connectionTimeout) {
-		a.setSelectedPair(nil)
+	if (a.connectionTimeout != 0) && (time.Since(selectedPair.remote.LastReceived()) > a.connectionTimeout) {
 		a.updateConnectionState(ConnectionStateDisconnected)
-		return false
+	} else {
+		a.updateConnectionState(ConnectionStateConnected)
 	}
 
 	return true

--- a/transport.go
+++ b/transport.go
@@ -93,7 +93,17 @@ func (c *Conn) Write(p []byte) (int, error) {
 
 	pair := c.agent.getSelectedPair()
 	if pair == nil {
-		return 0, err
+		bestValidPair := make(chan *candidatePair, 1)
+		if err = c.agent.run(func(a *Agent) {
+			bestValidPair <- a.getBestValidCandidatePair()
+		}); err != nil {
+			return 0, err
+		}
+
+		pair = <-bestValidPair
+		if pair == nil {
+			return 0, err
+		}
 	}
 
 	atomic.AddUint64(&c.bytesSent, uint64(len(p)))


### PR DESCRIPTION
The selected pair must NEVER be cleared. Instead we
should keep sending connectivity checks on it. If we go to failed the
user will then create a new PeerConnection or do an iceRestart.
In the future we may support nominations, but not standardized yet.

This test asserts that we can move from
Connected -> Disconnected -> Connected

Resolves #186