### PR TITLE
Gather: fix closable crash again

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 	"time"
 
@@ -22,8 +23,8 @@ type closeable interface {
 
 // Close a net.Conn and log if we have a failure
 func closeConnAndLog(c closeable, log logging.LeveledLogger, msg string) {
-	if c == nil {
-		log.Warnf("Conn is not allocated")
+	if c == nil || (reflect.ValueOf(c).Kind() == reflect.Ptr && reflect.ValueOf(c).IsNil()) {
+		log.Warnf("Conn is not allocated (%s)", msg)
 		return
 	}
 

--- a/gather_test.go
+++ b/gather_test.go
@@ -256,3 +256,13 @@ func TestTURNConcurrency(t *testing.T) {
 		runTest(ProtoTypeUDP, SchemeTypeTURNS, nil, serverListener, serverPort)
 	})
 }
+
+func TestCloseConnLog(t *testing.T) {
+	a, err := NewAgent(&AgentConfig{})
+	assert.NoError(t, err)
+	defer a.Close()
+
+	closeConnAndLog(nil, a.log, "normal nil")
+	var nc *net.UDPConn
+	closeConnAndLog(nc, a.log, "nil ptr")
+}


### PR DESCRIPTION
#### Description

Unfortunately Go has a bit of a gotcha with nil interface checking, so despite #170, we can still get

```

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x55755b6ae4]

goroutine 425 [running]:
net.(*UDPConn).Close(0x0, 0x4000e28f80, 0x76)
	<autogenerated>:1 +0x4
repo.jazznetworks.com/vaion/vaion/vendor/github.com/pion/ice.closeConnAndLog(0x7f65f5e090, 0x0, 0x5576f7e2a0, 0x4000ed2080, 0x4000e28f80, 0x76)
	vendor/github.com/pion/ice/gather.go:32 +0xdc
repo.jazznetworks.com/vaion/vaion/vendor/github.com/pion/ice.(*Agent).gatherCandidatesSrflx.func1(0x40001be920, 0x40000fdb80, 0x1, 0x5576cbc7e6, 0x11, 0x4b66, 0x0, 0x0, 0x0, 0x0, ...)
	vendor/github.com/pion/ice/gather.go:266 +0x388
created by repo.jazznetworks.com/vaion/vaion/vendor/github.com/pion/ice.(*Agent).gatherCandidatesSrflx
	vendor/github.com/pion/ice/gather.go:255 +0x114
```

#### Reference issue
Fixes pion/ion#114
