### PR TITLE
Agent: More frequent candidate check in connecting state

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -38,8 +38,7 @@ type Agent struct {
 	onConnected     chan struct{}
 	onConnectedOnce sync.Once
 
-	connectivityTicker *time.Ticker
-	// force candidate to be contacted immediately (instead of waiting for connectivityTicker)
+	// force candidate to be contacted immediately (instead of waiting for task ticker)
 	forceCandidateContact chan bool
 
 	tieBreaker uint64
@@ -82,8 +81,8 @@ type Agent struct {
 	// 0 means never
 	keepaliveInterval time.Duration
 
-	// How after should we run our internal taskLoop
-	taskLoopInterval time.Duration
+	// How often should we run our internal taskLoop to check for state changes when connecting
+	checkInterval time.Duration
 
 	localUfrag      string
 	localPwd        string
@@ -362,9 +361,7 @@ func (a *Agent) startConnectivityChecks(isControlling bool, remoteUfrag, remoteP
 
 		agent.updateConnectionState(ConnectionStateChecking)
 
-		// TODO this should be dynamic, and grow when the connection is stable
 		a.requestConnectivityCheck()
-		agent.connectivityTicker = time.NewTicker(a.taskLoopInterval)
 		go a.connectivityChecks()
 	}, nil)
 }
@@ -404,12 +401,34 @@ func (a *Agent) connectivityChecks() {
 	}
 
 	for {
+		interval := defaultKeepaliveInterval
+
+		updateInterval := func(x time.Duration) {
+			if x != 0 && (interval == 0 || interval > x) {
+				interval = x
+			}
+		}
+
+		switch lastConnectionState {
+		case ConnectionStateNew, ConnectionStateChecking: // While connecting, check candidates more frequently
+			updateInterval(a.checkInterval)
+		case ConnectionStateConnected, ConnectionStateDisconnected:
+			updateInterval(a.keepaliveInterval)
+		default:
+		}
+		// Ensure we run our task loop as quickly as the minimum of our various configured timeouts
+		updateInterval(a.disconnectedTimeout)
+		updateInterval(a.failedTimeout)
+
+		t := time.NewTimer(interval)
 		select {
 		case <-a.forceCandidateContact:
+			t.Stop()
 			contact()
-		case <-a.connectivityTicker.C:
+		case <-t.C:
 			contact()
 		case <-a.done:
+			t.Stop()
 			return
 		}
 	}
@@ -747,10 +766,6 @@ func (a *Agent) Close() error {
 
 		if err := a.buffer.Close(); err != nil {
 			a.log.Warnf("failed to close buffer: %v", err)
-		}
-
-		if a.connectivityTicker != nil {
-			a.connectivityTicker.Stop()
 		}
 
 		a.closeMulticastConn()

--- a/agent_config.go
+++ b/agent_config.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	// taskLoopInterval is the interval at which the agent performs checks
-	defaultTaskLoopInterval = 2 * time.Second
+	// defaultCheckInterval is the interval at which the agent performs candidate checks in the connecting phase
+	defaultCheckInterval = 200 * time.Millisecond
 
 	// keepaliveInterval used to keep candidates alive
 	defaultKeepaliveInterval = 2 * time.Second
@@ -95,10 +95,9 @@ type AgentConfig struct {
 
 	LoggerFactory logging.LoggerFactory
 
-	// taskLoopInterval controls how often our internal task loop runs, this
-	// task loop handles things like sending keepAlives. This is only value for testing
-	// keepAlive behavior should be modified with KeepaliveInterval and ConnectionTimeout
-	taskLoopInterval time.Duration
+	// checkInterval controls how often our internal task loop runs when
+	// in the connecting state. Only useful for testing.
+	checkInterval time.Duration
 
 	// MaxBindingRequests is the max amount of binding requests the agent will send
 	// over a candidate pair for validation or nomination, if after MaxBindingRequests
@@ -205,10 +204,10 @@ func (config *AgentConfig) initWithDefaults(a *Agent) {
 		a.keepaliveInterval = *config.KeepaliveInterval
 	}
 
-	if config.taskLoopInterval == 0 {
-		a.taskLoopInterval = defaultTaskLoopInterval
+	if config.checkInterval == 0 {
+		a.checkInterval = defaultCheckInterval
 	} else {
-		a.taskLoopInterval = config.taskLoopInterval
+		a.checkInterval = config.checkInterval
 	}
 
 	if config.CandidateTypes == nil || len(config.CandidateTypes) == 0 {

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -475,7 +475,7 @@ func TestDisconnectedToConnected(t *testing.T) {
 		Net:                 net0,
 		DisconnectedTimeout: &disconnectTimeout,
 		KeepaliveInterval:   &keepaliveInterval,
-		taskLoopInterval:    keepaliveInterval,
+		checkInterval:       keepaliveInterval,
 	})
 	assert.NoError(t, err)
 
@@ -485,7 +485,7 @@ func TestDisconnectedToConnected(t *testing.T) {
 		Net:                 net1,
 		DisconnectedTimeout: &disconnectTimeout,
 		KeepaliveInterval:   &keepaliveInterval,
-		taskLoopInterval:    keepaliveInterval,
+		checkInterval:       keepaliveInterval,
 	})
 	assert.NoError(t, err)
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -41,7 +41,7 @@ func testTimeout(t *testing.T, c *Conn, timeout time.Duration) {
 
 	startedAt := time.Now()
 
-	for cnt := time.Duration(0); cnt <= timeout+defaultTaskLoopInterval; cnt += pollrate {
+	for cnt := time.Duration(0); cnt <= timeout+defaultCheckInterval; cnt += pollrate {
 		<-ticker.C
 
 		err := c.agent.run(func(agent *Agent) {


### PR DESCRIPTION
#### Description

In the ICE connecting state, candidates may not be nominated until 500mS or 1S after ICE start time. But currently the task ticker only runs every 2 seconds by default, leading to slower than necessary ICE completion.

Run the task check ticker more frequently when we don't have chosen pairs.
