### PR TITLE
Fix flaky tests

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -228,12 +228,12 @@ func runAgentTest(t *testing.T, config *AgentConfig, task func(a *Agent)) {
 }
 
 func TestHandlePeerReflexive(t *testing.T) {
-	// Limit runtime in case of deadlocks
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 2)
+	defer lim.Stop()
 
 	t.Run("UDP pflx candidate from handleInbound()", func(t *testing.T) {
 		var config AgentConfig
@@ -466,11 +466,11 @@ func TestConnectivityOnStartup(t *testing.T) {
 }
 
 func TestConnectivityLite(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
 
 	stunServerURL := &URL{
 		Scheme: SchemeTypeSTUN,
@@ -710,11 +710,11 @@ func TestInvalidAgentStarts(t *testing.T) {
 
 // Assert that Agent emits Connecting/Connected/Disconnected/Failed/Closed messages
 func TestConnectionStateCallback(t *testing.T) {
-	lim := test.TimeOut(time.Second * 5)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
 
 	disconnectedDuration := time.Second
 	failedDuration := time.Second
@@ -1253,11 +1253,11 @@ func TestAgentCredentials(t *testing.T) {
 // Assert that Agent on Failure deletes all existing candidates
 // User can then do an ICE Restart to bring agent back
 func TestConnectionStateFailedDeleteAllCandidates(t *testing.T) {
-	lim := test.TimeOut(time.Second * 5)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
 
 	oneSecond := time.Second
 	KeepaliveInterval := time.Duration(0)
@@ -1300,11 +1300,11 @@ func TestConnectionStateFailedDeleteAllCandidates(t *testing.T) {
 
 // Assert that the ICE Agent can go directly from Connecting -> Failed on both sides
 func TestConnectionStateConnectingToFailed(t *testing.T) {
-	lim := test.TimeOut(time.Second * 5)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 5)
+	defer lim.Stop()
 
 	oneSecond := time.Second
 	KeepaliveInterval := time.Duration(0)
@@ -1361,11 +1361,11 @@ func TestConnectionStateConnectingToFailed(t *testing.T) {
 }
 
 func TestAgentRestart(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
 
 	t.Run("Restart During Gather", func(t *testing.T) {
 		agent, err := NewAgent(&AgentConfig{})

--- a/agent_test.go
+++ b/agent_test.go
@@ -30,6 +30,9 @@ func (m *mockPacketConn) SetReadDeadline(t time.Time) error                   { 
 func (m *mockPacketConn) SetWriteDeadline(t time.Time) error                  { return nil }
 
 func TestPairSearch(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 10)
 	defer lim.Stop()
@@ -55,6 +58,9 @@ func TestPairSearch(t *testing.T) {
 }
 
 func TestPairPriority(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// avoid deadlocks?
 	defer test.TimeOut(1 * time.Second).Stop()
 
@@ -142,6 +148,9 @@ func TestPairPriority(t *testing.T) {
 }
 
 func TestOnSelectedCandidatePairChange(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// avoid deadlocks?
 	defer test.TimeOut(1 * time.Second).Stop()
 
@@ -220,7 +229,7 @@ func runAgentTest(t *testing.T, config *AgentConfig, task func(a *Agent)) {
 
 func TestHandlePeerReflexive(t *testing.T) {
 	// Limit runtime in case of deadlocks
-	lim := test.TimeOut(time.Second * 2)
+	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
 
 	report := test.CheckRoutines(t)

--- a/candidate.go
+++ b/candidate.go
@@ -37,6 +37,6 @@ type Candidate interface {
 
 	close() error
 	seen(outbound bool)
-	start(a *Agent, conn net.PacketConn)
+	start(a *Agent, conn net.PacketConn, initializedCh <-chan struct{})
 	writeTo(raw []byte, dst Candidate) (int, error)
 }

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func TestServerReflexiveOnlyConnection(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
-
-	report := test.CheckRoutines(t)
-	defer report()
 
 	serverPort := randomPort(t)
 	serverListener, err := net.ListenPacket("udp4", "127.0.0.1:"+strconv.Itoa(serverPort))

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -430,11 +430,11 @@ func TestConnectivityVNet(t *testing.T) {
 
 // TestDisconnectedToConnected asserts that an agent can go to disconnected, and then return to connected successfully
 func TestDisconnectedToConnected(t *testing.T) {
-	lim := test.TimeOut(time.Second * 10)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
 
 	loggerFactory := logging.NewDefaultLoggerFactory()
 
@@ -526,11 +526,11 @@ func TestDisconnectedToConnected(t *testing.T) {
 
 // Agent.Write should use the best valid pair if a selected pair is not yet available
 func TestWriteUseValidPair(t *testing.T) {
-	lim := test.TimeOut(time.Second * 10)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 10)
+	defer lim.Stop()
 
 	loggerFactory := logging.NewDefaultLoggerFactory()
 

--- a/gather_test.go
+++ b/gather_test.go
@@ -80,11 +80,11 @@ func TestListenUDP(t *testing.T) {
 
 // Assert that STUN gathering is done concurrently
 func TestSTUNConcurrency(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
 
 	serverPort := randomPort(t)
 	serverListener, err := net.ListenPacket("udp4", "127.0.0.1:"+strconv.Itoa(serverPort))
@@ -139,11 +139,11 @@ func TestSTUNConcurrency(t *testing.T) {
 
 // Assert that TURN gathering is done concurrently
 func TestTURNConcurrency(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
 
 	runTest := func(protocol ProtoType, scheme SchemeType, packetConn net.PacketConn, listener net.Listener, serverPort int) {
 		packetConnConfigs := []turn.PacketConnConfig{}

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestMulticastDNSOnlyConnection(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
-
-	report := test.CheckRoutines(t)
-	defer report()
 
 	cfg := &AgentConfig{
 		NetworkTypes:     []NetworkType{NetworkTypeUDP4},
@@ -54,12 +54,12 @@ func TestMulticastDNSOnlyConnection(t *testing.T) {
 }
 
 func TestMulticastDNSMixedConnection(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
-
-	report := test.CheckRoutines(t)
-	defer report()
 
 	aAgent, err := NewAgent(&AgentConfig{
 		NetworkTypes:     []NetworkType{NetworkTypeUDP4},
@@ -98,11 +98,11 @@ func TestMulticastDNSMixedConnection(t *testing.T) {
 }
 
 func TestMulticastDNSStaticHostName(t *testing.T) {
-	lim := test.TimeOut(time.Second * 30)
-	defer lim.Stop()
-
 	report := test.CheckRoutines(t)
 	defer report()
+
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
 
 	_, err := NewAgent(&AgentConfig{
 		NetworkTypes:         []NetworkType{NetworkTypeUDP4},

--- a/transport.go
+++ b/transport.go
@@ -45,9 +45,6 @@ func (a *Agent) connect(ctx context.Context, isControlling bool, remoteUfrag, re
 	if err != nil {
 		return nil, err
 	}
-	if a.opened {
-		return nil, errors.New("a connection is already opened")
-	}
 	err = a.startConnectivityChecks(isControlling, remoteUfrag, remotePwd)
 	if err != nil {
 		return nil, err

--- a/transport_test.go
+++ b/transport_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestStressDuplex(t *testing.T) {
-	// Limit runtime in case of deadlocks
-	lim := test.TimeOut(time.Second * 20)
-	defer lim.Stop()
-
 	// Check for leaking routines
 	report := test.CheckRoutines(t)
 	defer report()
+
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
 
 	// Run the test
 	stressDuplex(t)

--- a/transport_test.go
+++ b/transport_test.go
@@ -31,6 +31,13 @@ func testTimeout(t *testing.T, c *Conn, timeout time.Duration) {
 	const margin = 20 * time.Millisecond // allow 20msec error in time
 	statechan := make(chan ConnectionState, 1)
 	ticker := time.NewTicker(pollrate)
+	defer func() {
+		ticker.Stop()
+		err := c.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
 
 	startedAt := time.Now()
 
@@ -64,25 +71,37 @@ func TestTimeout(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	ca, cb := pipe(nil)
-	err := cb.Close()
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
 
-	if err != nil {
-		// we should never get here.
-		panic(err)
-	}
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
 
-	testTimeout(t, ca, defaultDisconnectedTimeout)
+	t.Run("WithoutDisconnectTimeout", func(t *testing.T) {
+		ca, cb := pipe(nil)
+		err := cb.Close()
 
-	ca, cb = pipeWithTimeout(5*time.Second, 3*time.Second)
-	err = cb.Close()
+		if err != nil {
+			// we should never get here.
+			panic(err)
+		}
 
-	if err != nil {
-		// we should never get here.
-		panic(err)
-	}
+		testTimeout(t, ca, defaultDisconnectedTimeout)
+	})
 
-	testTimeout(t, ca, 5*time.Second)
+	t.Run("WithDisconnectTimeout", func(t *testing.T) {
+		ca, cb := pipeWithTimeout(5*time.Second, 3*time.Second)
+		err := cb.Close()
+
+		if err != nil {
+			// we should never get here.
+			panic(err)
+		}
+
+		testTimeout(t, ca, 5*time.Second)
+	})
 }
 
 func TestReadClosed(t *testing.T) {

--- a/transport_test.go
+++ b/transport_test.go
@@ -86,6 +86,14 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestReadClosed(t *testing.T) {
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
 	ca, cb := pipe(nil)
 
 	err := ca.Close()
@@ -351,6 +359,14 @@ func randomPort(t testing.TB) int {
 }
 
 func TestConnStats(t *testing.T) {
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
 	ca, cb := pipe(nil)
 	if _, err := ca.Write(make([]byte, 10)); err != nil {
 		t.Fatal("unexpected error trying to write")


### PR DESCRIPTION
Avoid using uninitialized object on receiving packet.

Fix routine leak in TestTimeout.
Which seems caused timeout during routine leak test which requires max 10s.

### Reference issue
Fixes #202
Related #204 