### PR TITLE
Allow gathering srflx candidates from turn: urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [adwpc](https://github.com/adwpc)
 * [Ori Bernstein](https://eigenstate.org)
 * [Sam Lancia](https://github.com/nerd2)
+* [Lander Noterman](https://github.com/LanderN)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/gather.go
+++ b/gather.go
@@ -252,10 +252,6 @@ func (a *Agent) gatherCandidatesSrflxMapped(networkTypes []NetworkType, wg *sync
 func (a *Agent) gatherCandidatesSrflx(urls []*URL, networkTypes []NetworkType, wg *sync.WaitGroup) {
 	for _, networkType := range networkTypes {
 		for i := range urls {
-			if urls[i].Scheme != SchemeTypeSTUN {
-				continue
-			}
-
 			wg.Add(1)
 			go func(url URL, network string) {
 				defer wg.Done()


### PR DESCRIPTION
#### Description
This PR enables gathering srflx candidates from `turn:` urls.