### PR TITLE
Make Credential getters thread safe

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -702,13 +702,33 @@ func (a *Agent) GetLocalCandidates() ([]Candidate, error) {
 }
 
 // GetLocalUserCredentials returns the local user credentials
-func (a *Agent) GetLocalUserCredentials() (frag string, pwd string) {
-	return a.localUfrag, a.localPwd
+func (a *Agent) GetLocalUserCredentials() (frag string, pwd string, err error) {
+	valSet := make(chan struct{})
+	err = a.run(func(agent *Agent) {
+		frag = agent.localUfrag
+		pwd = agent.localPwd
+		close(valSet)
+	}, nil)
+
+	if err == nil {
+		<-valSet
+	}
+	return
 }
 
 // GetRemoteUserCredentials returns the remote user credentials
-func (a *Agent) GetRemoteUserCredentials() (frag string, pwd string) {
-	return a.remoteUfrag, a.remotePwd
+func (a *Agent) GetRemoteUserCredentials() (frag string, pwd string, err error) {
+	valSet := make(chan struct{})
+	err = a.run(func(agent *Agent) {
+		frag = agent.remoteUfrag
+		pwd = agent.remotePwd
+		close(valSet)
+	}, nil)
+
+	if err == nil {
+		<-valSet
+	}
+	return
 }
 
 // Close cleans up the Agent

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -163,8 +163,11 @@ func buildVNet(natType0, natType1 *vnet.NATType) (*virtualNet, error) {
 
 func connectWithVNet(aAgent, bAgent *Agent) (*Conn, *Conn) {
 	// Manual signaling
-	aUfrag, aPwd := aAgent.GetLocalUserCredentials()
-	bUfrag, bPwd := bAgent.GetLocalUserCredentials()
+	aUfrag, aPwd, err := aAgent.GetLocalUserCredentials()
+	check(err)
+
+	bUfrag, bPwd, err := bAgent.GetLocalUserCredentials()
+	check(err)
 
 	gatherAndExchangeCandidates(aAgent, bAgent)
 
@@ -585,8 +588,11 @@ func TestWriteUseValidPair(t *testing.T) {
 
 	gatherAndExchangeCandidates(controllingAgent, controlledAgent)
 
-	controllingUfrag, controllingPwd := controllingAgent.GetLocalUserCredentials()
-	controlledUfrag, controlledPwd := controlledAgent.GetLocalUserCredentials()
+	controllingUfrag, controllingPwd, err := controllingAgent.GetLocalUserCredentials()
+	assert.NoError(t, err)
+
+	controlledUfrag, controlledPwd, err := controlledAgent.GetLocalUserCredentials()
+	assert.NoError(t, err)
 
 	assert.NoError(t, controllingAgent.startConnectivityChecks(true, controlledUfrag, controlledPwd))
 	assert.NoError(t, controlledAgent.startConnectivityChecks(false, controllingUfrag, controllingPwd))

--- a/transport_test.go
+++ b/transport_test.go
@@ -226,13 +226,15 @@ func connect(aAgent, bAgent *Agent) (*Conn, *Conn) {
 
 	go func() {
 		var acceptErr error
-		bUfrag, bPwd := bAgent.GetLocalUserCredentials()
+		bUfrag, bPwd, acceptErr := bAgent.GetLocalUserCredentials()
+		check(acceptErr)
 		aConn, acceptErr = aAgent.Accept(context.TODO(), bUfrag, bPwd)
 		check(acceptErr)
 		close(accepted)
 	}()
 
-	aUfrag, aPwd := aAgent.GetLocalUserCredentials()
+	aUfrag, aPwd, err := aAgent.GetLocalUserCredentials()
+	check(err)
 	bConn, err := bAgent.Dial(context.TODO(), aUfrag, aPwd)
 	check(err)
 


### PR DESCRIPTION
GetRemoteUserCredentials and GetLocalUserCredentials were
not thread safe. This puts them both behind a .run
