### PR TITLE
Make Transport return addresses of the current pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ori Bernstein](https://eigenstate.org)
 * [Sam Lancia](https://github.com/nerd2)
 * [Lander Noterman](https://github.com/LanderN)
+* [Henry](https://github.com/cryptix)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/transport.go
+++ b/transport.go
@@ -115,14 +115,24 @@ func (c *Conn) Close() error {
 
 // TODO: Maybe just switch to using io.ReadWriteCloser?
 
-// LocalAddr is a stub
+// LocalAddr returns the local address of the current selected pair or nil if there is none.
 func (c *Conn) LocalAddr() net.Addr {
-	return nil
+	pair := c.agent.getSelectedPair()
+	if pair == nil {
+		return nil
+	}
+
+	return pair.local.addr()
 }
 
-// RemoteAddr is a stub
+// RemoteAddr returns the remote address of the current selected pair or nil if there is none.
 func (c *Conn) RemoteAddr() net.Addr {
-	return nil
+	pair := c.agent.getSelectedPair()
+	if pair == nil {
+		return nil
+	}
+
+	return pair.remote.addr()
 }
 
 // SetDeadline is a stub

--- a/transport_test.go
+++ b/transport_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pion/transport/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStressDuplex(t *testing.T) {
@@ -424,4 +425,41 @@ func TestConnStats(t *testing.T) {
 		// we should never get here.
 		panic(err)
 	}
+}
+
+func TestRemoteLocalAddr(t *testing.T) {
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	t.Run("Disconnected Returns nil", func(t *testing.T) {
+		disconnectedAgent, err := NewAgent(&AgentConfig{})
+		assert.NoError(t, err)
+
+		disconnectedConn := Conn{agent: disconnectedAgent}
+		assert.Nil(t, disconnectedConn.RemoteAddr())
+		assert.Nil(t, disconnectedConn.LocalAddr())
+
+		assert.NoError(t, disconnectedConn.Close())
+	})
+
+	t.Run("Remote/Local Pair Match between Agents", func(t *testing.T) {
+		ca, cb := pipe(nil)
+
+		// Assert that nothing is nil
+		assert.NotNil(t, ca.RemoteAddr())
+		assert.NotNil(t, ca.LocalAddr())
+
+		// Assert that they are equal
+		assert.Equal(t, ca.LocalAddr(), cb.RemoteAddr())
+		assert.Equal(t, cb.LocalAddr(), ca.RemoteAddr())
+
+		// Close
+		assert.NoError(t, ca.Close())
+		assert.NoError(t, cb.Close())
+	})
 }


### PR DESCRIPTION
Instead of always returning `nil` from `Conn.LocalAddr()` and `Conn.RemoteAddr()` pick the address the selected pair or nil if there is none.

I assume there is a reason for this but I couldn't find it anywhere. Primarily motivation for doing this was having correct addresses when passing them to the quic transport in pion/webrtc.

TODO:
* [x] remove `func getNetAddrFromCandidate`
I ran a few circles around this because I didn't see the unexported `addr() *net.UDPAddr`.

I feel like it should be easier to get this, maybe change `CandidateRelatedAddress` slightly? But since I'm fairly new to this code I wanted to check in first and not mangle it further.

updates pion/quic#31