### PR TITLE
Remove candidateSelectionTimeout

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -58,11 +58,10 @@ type Agent struct {
 
 	maxBindingRequests uint16
 
-	candidateSelectionTimeout time.Duration
-	hostAcceptanceMinWait     time.Duration
-	srflxAcceptanceMinWait    time.Duration
-	prflxAcceptanceMinWait    time.Duration
-	relayAcceptanceMinWait    time.Duration
+	hostAcceptanceMinWait  time.Duration
+	srflxAcceptanceMinWait time.Duration
+	prflxAcceptanceMinWait time.Duration
+	relayAcceptanceMinWait time.Duration
 
 	portmin uint16
 	portmax uint16

--- a/agent_config.go
+++ b/agent_config.go
@@ -20,9 +20,6 @@ const (
 	// defaultFailedTimeout is the default time till an Agent transitions to failed after disconnected
 	defaultFailedTimeout = 25 * time.Second
 
-	// timeout for candidate selection, after this time, the best candidate is used
-	defaultCandidateSelectionTimeout = 10 * time.Second
-
 	// wait time before nominating a host candidate
 	defaultHostAcceptanceMinWait = 0
 
@@ -104,11 +101,6 @@ type AgentConfig struct {
 	// the candidate is yet to answer a binding request or a nomination we set the pair as failed
 	MaxBindingRequests *uint16
 
-	// CandidatesSelectionTimeout specify a timeout for selecting candidates, if no nomination has happen
-	// before this timeout, once hit we will nominate the best valid candidate available,
-	// or mark the connection as failed if no valid candidate is available
-	CandidateSelectionTimeout *time.Duration
-
 	// Lite agents do not perform connectivity check and only provide host candidates.
 	Lite bool
 
@@ -154,12 +146,6 @@ func (config *AgentConfig) initWithDefaults(a *Agent) {
 		a.maxBindingRequests = defaultMaxBindingRequests
 	} else {
 		a.maxBindingRequests = *config.MaxBindingRequests
-	}
-
-	if config.CandidateSelectionTimeout == nil {
-		a.candidateSelectionTimeout = defaultCandidateSelectionTimeout
-	} else {
-		a.candidateSelectionTimeout = *config.CandidateSelectionTimeout
 	}
 
 	if config.HostAcceptanceMinWait == nil {


### PR DESCRIPTION
    Remove candidateSelectionTimeout
    
    The code that uses this field was removed in
    e264665676a68107c582a480318880c08f2e19a5 but the field
    wasn't properly removed from the public API.

