### PR TITLE
Reduce iteration in TestRandomGeneratorCollision

### DIFF
--- a/rand_test.go
+++ b/rand_test.go
@@ -69,7 +69,7 @@ func TestRandomGeneratorCollision(t *testing.T) {
 		},
 	}
 
-	const N = 1000
+	const N = 100
 	const iteration = 100
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
It took too long when -race is specified.
