### PR TITLE
 Select candidate pair when network updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sam Lancia](https://github.com/nerd2)
 * [BUPTCZQ](https://github.com/buptczq)
 * [Henry](https://github.com/cryptix)
+* [cnderrauber](https://github.com/cnderrauber)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/selection.go
+++ b/selection.go
@@ -288,7 +288,7 @@ func (s *controlledSelector) HandleBindingRequest(m *stun.Message, local, remote
 			// previously sent by this pair produced a successful response and
 			// generated a valid pair (Section 7.2.5.3.2).  The agent sets the
 			// nominated flag value of the valid pair to true.
-			if selectedPair := s.agent.getSelectedPair(); selectedPair == nil {
+			if selectedPair := s.agent.getSelectedPair(); selectedPair != p {
 				s.agent.setSelectedPair(p)
 			}
 			s.agent.sendBindingSuccess(m, local, remote)


### PR DESCRIPTION
#### Description
When webrtc's network changed(eg. from wifi to 4g)，it will gather ice candidate and send stun bind....., after process, webrtc will send a stun bind with use candidate, but the pion' ice will not set selected candidate pair because it's selectedPair is not nil. So it will not send data to the new pair, the media transport is interrupted.
#### Reference issue
Fixes #...
