### PR TITLE
Increase binding req timeout value

### DIFF
--- a/agent_config.go
+++ b/agent_config.go
@@ -39,7 +39,7 @@ const (
 	maxBufferSize = 1000 * 1000 // 1MB
 
 	// wait time before binding requests can be deleted
-	maxBindingRequestTimeout = 500 * time.Millisecond
+	maxBindingRequestTimeout = 4000 * time.Millisecond
 )
 
 var (

--- a/agent_test.go
+++ b/agent_test.go
@@ -1208,20 +1208,20 @@ func TestBindingRequestTimeout(t *testing.T) {
 
 	now := time.Now()
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
-		timestamp: now,
+		timestamp: now, // valid
 	})
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
-		timestamp: now.Add(-25 * time.Millisecond),
+		timestamp: now.Add(-3900 * time.Millisecond), // valid
 	})
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
-		timestamp: now.Add(-750 * time.Millisecond),
+		timestamp: now.Add(-4100 * time.Millisecond), // invalid
 	})
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
-		timestamp: now.Add(-75 * time.Hour),
+		timestamp: now.Add(-75 * time.Hour), // invalid
 	})
 
 	a.invalidatePendingBindingRequests(now)
-	assert.Equal(t, len(a.pendingBindingRequests), expectedRemovalCount, "Binding invalidation due to timeout did not remove the correct number of binding requests")
+	assert.Equal(t, expectedRemovalCount, len(a.pendingBindingRequests), "Binding invalidation due to timeout did not remove the correct number of binding requests")
 	assert.NoError(t, a.Close())
 }
 


### PR DESCRIPTION
Resolves #255

#### Description
See #255 for details

Per discussion with @Sean-Der we decided to simply increase the maxBindingRequestTImeout from 500msec to 4000msec.