### PR TITLE
Do not prematurely unlock mutex in handleRecv

### DIFF
--- a/tcp_packet_conn.go
+++ b/tcp_packet_conn.go
@@ -194,9 +194,10 @@ func (t *tcpPacketConn) removeConn(conn net.Conn) {
 func (t *tcpPacketConn) Close() error {
 	t.mu.Lock()
 
+	var shouldCloseRecvChan bool
 	t.closeOnce.Do(func() {
 		close(t.closedChan)
-		close(t.recvChan)
+		shouldCloseRecvChan = true
 	})
 
 	for _, conn := range t.conns {
@@ -207,6 +208,10 @@ func (t *tcpPacketConn) Close() error {
 	t.mu.Unlock()
 
 	t.wg.Wait()
+
+	if shouldCloseRecvChan {
+		close(t.recvChan)
+	}
 
 	return nil
 }


### PR DESCRIPTION


#### Description
Mutex being unlocked too soon caused a panic. See the issue for more details and a link to `pion/webrtc` issue.

Is there a better way of preventing a write to closed channel than this?

#### Reference issue
Fixes #260
