### PR TITLE
Make TCP ICE candidates have lower preference

### DIFF
--- a/candidate_test.go
+++ b/candidate_test.go
@@ -22,6 +22,39 @@ func TestCandidatePriority(t *testing.T) {
 			WantPriority: 2130706431,
 		},
 		{
+			Candidate: &CandidateHost{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypeHost,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP4,
+					tcpType:       TCPTypeActive,
+				},
+			},
+			WantPriority: 2128609279,
+		},
+		{
+			Candidate: &CandidateHost{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypeHost,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP4,
+					tcpType:       TCPTypePassive,
+				},
+			},
+			WantPriority: 2124414975,
+		},
+		{
+			Candidate: &CandidateHost{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypeHost,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP4,
+					tcpType:       TCPTypeSimultaneousOpen,
+				},
+			},
+			WantPriority: 2120220671,
+		},
+		{
 			Candidate: &CandidatePeerReflexive{
 				candidateBase: candidateBase{
 					candidateType: CandidateTypePeerReflexive,
@@ -29,6 +62,39 @@ func TestCandidatePriority(t *testing.T) {
 				},
 			},
 			WantPriority: 1862270975,
+		},
+		{
+			Candidate: &CandidatePeerReflexive{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypePeerReflexive,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP6,
+					tcpType:       TCPTypeSimultaneousOpen,
+				},
+			},
+			WantPriority: 1860173823,
+		},
+		{
+			Candidate: &CandidatePeerReflexive{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypePeerReflexive,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP6,
+					tcpType:       TCPTypeActive,
+				},
+			},
+			WantPriority: 1855979519,
+		},
+		{
+			Candidate: &CandidatePeerReflexive{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypePeerReflexive,
+					component:     ComponentRTP,
+					networkType:   NetworkTypeTCP6,
+					tcpType:       TCPTypePassive,
+				},
+			},
+			WantPriority: 1851785215,
 		},
 		{
 			Candidate: &CandidateServerReflexive{


### PR DESCRIPTION
Closes #262.

Adds the changes in determining local preference for ICE TCP candidates according to RFC 6544, section 4.2.

https://tools.ietf.org/html/rfc6544#section-4.2

The only thing I'm not sure about is the value of `otherPref`, which is currently always set to `8191`, but the RFC says the following:

> If any two candidates have the same type-preference and direction-pref, they MUST have a unique other-pref.  With this specification, this usually only happens with multi-homed hosts, in which case other-pref is the preference for the particular IP address from which the candidate was obtained.  When there is only a single IP address, this value SHOULD be set to the maximum allowed value (8191).