### PR TITLE
Don't leak goroutines via mDNS queries

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -741,7 +741,7 @@ func (a *Agent) resolveAndAddMulticastCandidate(c *CandidateHost) {
 	if a.mDNSConn == nil {
 		return
 	}
-	_, src, err := a.mDNSConn.Query(context.TODO(), c.Address())
+	_, src, err := a.mDNSConn.Query(c.context(), c.Address())
 	if err != nil {
 		a.log.Warnf("Failed to discover mDNS candidate %s: %v", c.Address(), err)
 		return


### PR DESCRIPTION
mDNSConn.Query() will block indefinitely until something replies. Much
of the time, nothing will, and the goroutines making these queries will
block forever. By passing the CandidateHost's context, the queries will
at least be cancelled when the host disconnects.

#### Description
While I was SIGQUIT-debugging (ctrl+\) a project, I noticed many hundreds of coroutines hanging out looking like this:

```
goroutine 12420 [select]:
github.com/pion/mdns.(*Conn).Query(0xc0117fe480, 0xab26c0, 0xc000096008, 0xc0139a4145, 0x2a, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/sidney/.go/pkg/mod/github.com/pion/mdns@v0.0.4/conn.go:137 +0x2ee
github.com/pion/ice/v2.(*Agent).resolveAndAddMulticastCandidate(0xc002320dc0, 0xc01871a370)
	/Users/sidney/.go/pkg/mod/github.com/pion/ice/v2@v2.0.0-rc.9/agent.go:744 +0x85
created by github.com/pion/ice/v2.(*Agent).AddRemoteCandidate
	/Users/sidney/.go/pkg/mod/github.com/pion/ice/v2@v2.0.0-rc.9/agent.go:725 +0x165
```

As far as I can tell, these tasks are spawned to do mDNS queries on ICE candidates, but they usually don't return and live forever. This change makes sure they get cleaned up… but I wonder if they should go away even sooner, e.g. after a timeout.

#### Reference issue
Fixes (n/a — should I file a separate issue?)
