### PR TITLE
Don't leak goroutines via mDNS queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [BUPTCZQ](https://github.com/buptczq)
 * [Henry](https://github.com/cryptix)
 * [Jerko Steiner](https://github.com/jeremija)
+* [Sidney San Martin](https://github.com/s4y)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/agent.go
+++ b/agent.go
@@ -741,7 +741,7 @@ func (a *Agent) resolveAndAddMulticastCandidate(c *CandidateHost) {
 	if a.mDNSConn == nil {
 		return
 	}
-	_, src, err := a.mDNSConn.Query(context.TODO(), c.Address())
+	_, src, err := a.mDNSConn.Query(c.context(), c.Address())
 	if err != nil {
 		a.log.Warnf("Failed to discover mDNS candidate %s: %v", c.Address(), err)
 		return


### PR DESCRIPTION
mDNSConn.Query() will block indefinitely until something replies. Much
of the time, nothing will, and the goroutines making these queries will
block forever. By passing the CandidateHost's context, the queries will
at least be cancelled when the host disconnects.
