### PR TITLE
Support proxy dialer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [JooYoung Lim](https://github.com/DevRockstarZ)
 * [Kory Miller](https://github.com/korymiller1489)
 * [ZHENK](https://github.com/scorpionknifes)
-* [assadobaid] (https://github.com/assadobaid)
+* [Assad Obaid](https://github.com/assadobaid)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [JooYoung Lim](https://github.com/DevRockstarZ)
 * [Kory Miller](https://github.com/korymiller1489)
 * [ZHENK](https://github.com/scorpionknifes)
+* [assadobaid] (https://github.com/assadobaid)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/agent.go
+++ b/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pion/stun"
 	"github.com/pion/transport/packetio"
 	"github.com/pion/transport/vnet"
+	"golang.org/x/net/proxy"
 )
 
 type bindingRequest struct {
@@ -126,6 +127,8 @@ type Agent struct {
 	interfaceFilter func(string) bool
 
 	insecureSkipVerify bool
+
+	proxyDialer proxy.Dialer
 }
 
 type task struct {

--- a/agent_config.go
+++ b/agent_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/transport/vnet"
+	"golang.org/x/net/proxy"
 )
 
 const (
@@ -143,6 +144,10 @@ type AgentConfig struct {
 	// Currently only passive candidates are supported. This functionality is
 	// experimental and the API might change in the future.
 	TCPMux TCPMux
+
+	// Proxy Dialer is a dialer that should be implemented by the user based on golang.org/x/net/proxy
+	// dial interface in order to support corporate proxies
+	ProxyDialer proxy.Dialer
 }
 
 // initWithDefaults populates an agent and falls back to defaults if fields are unset
@@ -206,6 +211,11 @@ func (config *AgentConfig) initWithDefaults(a *Agent) {
 	} else {
 		a.candidateTypes = config.CandidateTypes
 	}
+
+	if config.ProxyDialer != nil {
+		a.proxyDialer = config.ProxyDialer
+	}
+
 }
 
 func (config *AgentConfig) initExtIPMapping(a *Agent) error {

--- a/agent_config.go
+++ b/agent_config.go
@@ -215,7 +215,6 @@ func (config *AgentConfig) initWithDefaults(a *Agent) {
 	if config.ProxyDialer != nil {
 		a.proxyDialer = config.ProxyDialer
 	}
-
 }
 
 func (config *AgentConfig) initExtIPMapping(a *Agent) error {

--- a/gather.go
+++ b/gather.go
@@ -369,73 +369,59 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 
 				RelAddr = locConn.LocalAddr().(*net.UDPAddr).IP.String()
 				RelPort = locConn.LocalAddr().(*net.UDPAddr).Port
-			case url.Proto == ProtoTypeTCP && url.Scheme == SchemeTypeTURN:
-				var connectErr error
-				var conn net.Conn
-				if a.proxyDialer != nil {
-					conn, connectErr = a.proxyDialer.Dial(NetworkTypeTCP4.String(), TURNServerAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to Dial TCP Addr %s via proxy dialer: %v\n", TURNServerAddr, connectErr)
-						return
-					}
-				} else {
-					tcpAddr, connectErr := net.ResolveTCPAddr(NetworkTypeTCP4.String(), TURNServerAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to resolve TCP Addr %s: %v\n", TURNServerAddr, connectErr)
-						return
-					}
-					conn, connectErr = net.DialTCP(NetworkTypeTCP4.String(), nil, tcpAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
-						return
-					}
+			case a.proxyDialer != nil && url.Proto == ProtoTypeTCP &&
+				(url.Scheme == SchemeTypeTURN || url.Scheme == SchemeTypeTURNS):
+				conn, connectErr := a.proxyDialer.Dial(NetworkTypeTCP4.String(), TURNServerAddr)
+				if connectErr != nil {
+					a.log.Warnf("Failed to Dial TCP Addr %s via proxy dialer: %v\n", TURNServerAddr, connectErr)
+					return
 				}
+
+				RelAddr = conn.LocalAddr().(*net.TCPAddr).IP.String()
+				RelPort = conn.LocalAddr().(*net.TCPAddr).Port
+				locConn = turn.NewSTUNConn(conn)
+
+			case url.Proto == ProtoTypeTCP && url.Scheme == SchemeTypeTURN:
+				tcpAddr, connectErr := net.ResolveTCPAddr(NetworkTypeTCP4.String(), TURNServerAddr)
+				if connectErr != nil {
+					a.log.Warnf("Failed to resolve TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+					return
+				}
+
+				conn, connectErr := net.DialTCP(NetworkTypeTCP4.String(), nil, tcpAddr)
+				if connectErr != nil {
+					a.log.Warnf("Failed to Dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+					return
+				}
+
 				RelAddr = conn.LocalAddr().(*net.TCPAddr).IP.String()
 				RelPort = conn.LocalAddr().(*net.TCPAddr).Port
 				locConn = turn.NewSTUNConn(conn)
 			case url.Proto == ProtoTypeUDP && url.Scheme == SchemeTypeTURNS:
-				var connectErr error
-				var conn net.Conn
-				if a.proxyDialer != nil {
-					conn, connectErr = a.proxyDialer.Dial(network, TURNServerAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to Dial DTLS Addr %s, via proxy Dialer: %v\n", TURNServerAddr, connectErr)
-						return
-					}
-				} else {
-					udpAddr, connectErr := net.ResolveUDPAddr(network, TURNServerAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to resolve UDP Addr %s: %v\n", TURNServerAddr, connectErr)
-						return
-					}
-					conn, connectErr = dtls.Dial(network, udpAddr, &dtls.Config{
-						InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
-					})
-					if connectErr != nil {
-						a.log.Warnf("Failed to Dial DTLS Addr %s: %v\n", TURNServerAddr, connectErr)
-						return
-					}
+				udpAddr, connectErr := net.ResolveUDPAddr(network, TURNServerAddr)
+				if connectErr != nil {
+					a.log.Warnf("Failed to resolve UDP Addr %s: %v\n", TURNServerAddr, connectErr)
+					return
 				}
+
+				conn, connectErr := dtls.Dial(network, udpAddr, &dtls.Config{
+					InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
+				})
+				if connectErr != nil {
+					a.log.Warnf("Failed to Dial DTLS Addr %s: %v\n", TURNServerAddr, connectErr)
+					return
+				}
+
 				RelAddr = conn.LocalAddr().(*net.UDPAddr).IP.String()
 				RelPort = conn.LocalAddr().(*net.UDPAddr).Port
 				locConn = &fakePacketConn{conn}
 			case url.Proto == ProtoTypeTCP && url.Scheme == SchemeTypeTURNS:
-				var connectErr error
-				var conn net.Conn
-				if a.proxyDialer != nil {
-					conn, connectErr = a.proxyDialer.Dial(NetworkTypeTCP4.String(), TURNServerAddr)
-					if connectErr != nil {
-						a.log.Warnf("Failed to Dial TLS Addr %s via proxy dialer: %v\n", TURNServerAddr, connectErr)
-						return
-					}
-				} else {
-					conn, connectErr = tls.Dial(NetworkTypeTCP4.String(), TURNServerAddr, &tls.Config{
-						InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
-					})
-					if connectErr != nil {
-						a.log.Warnf("Failed to Dial TLS Addr %s: %v\n", TURNServerAddr, connectErr)
-						return
-					}
+				conn, connectErr := tls.Dial(NetworkTypeTCP4.String(), TURNServerAddr, &tls.Config{
+					InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
+				})
+				if connectErr != nil {
+					a.log.Warnf("Failed to Dial TLS Addr %s: %v\n", TURNServerAddr, connectErr)
+					return
 				}
 				RelAddr = conn.LocalAddr().(*net.TCPAddr).IP.String()
 				RelPort = conn.LocalAddr().(*net.TCPAddr).Port

--- a/gather.go
+++ b/gather.go
@@ -405,7 +405,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				} else {
 					udpAddr, connectErr := net.ResolveUDPAddr(network, TURNServerAddr)
 					if connectErr != nil {
-						a.log.Warnf("Failed to Dial DTLS Addr %s, via proxy dialer: %v\n", TURNServerAddr, connectErr)
+						a.log.Warnf("Failed to resolve UDP Addr %s: %v\n", TURNServerAddr, connectErr)
 						return
 					}
 					conn, connectErr = dtls.Dial(network, udpAddr, &dtls.Config{

--- a/gather.go
+++ b/gather.go
@@ -375,7 +375,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				if a.proxyDialer != nil {
 					conn, connectErr = a.proxyDialer.Dial(NetworkTypeTCP4.String(), TURNServerAddr)
 					if connectErr != nil {
-						a.log.Warnf("Failed to Dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+						a.log.Warnf("Failed to Dial TCP Addr %s via proxy dialer: %v\n", TURNServerAddr, connectErr)
 						return
 					}
 				} else {
@@ -386,7 +386,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 					}
 					conn, connectErr = net.DialTCP(NetworkTypeTCP4.String(), nil, tcpAddr)
 					if connectErr != nil {
-						a.log.Warnf("Failed to dial Addr %s: %v\n", TURNServerAddr, connectErr)
+						a.log.Warnf("Failed to dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
 						return
 					}
 				}
@@ -399,7 +399,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				if a.proxyDialer != nil {
 					conn, connectErr = a.proxyDialer.Dial(network, TURNServerAddr)
 					if connectErr != nil {
-						a.log.Warnf("Failed to Dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+						a.log.Warnf("Failed to Dial DTLS Addr %s, via proxy Dialer: %v\n", TURNServerAddr, connectErr)
 						return
 					}
 				} else {

--- a/gather_test.go
+++ b/gather_test.go
@@ -414,7 +414,7 @@ func TestCloseConnLog(t *testing.T) {
 	assert.NoError(t, a.Close())
 }
 
-func TestTURNTCPPROXY(t *testing.T) {
+func TestTURNTCPProxy(t *testing.T) {
 	report := test.CheckRoutines(t)
 	defer report()
 

--- a/gather_test.go
+++ b/gather_test.go
@@ -466,11 +466,10 @@ func TestTURNTCPProxy(t *testing.T) {
 		})
 
 		a, err := NewAgent(&AgentConfig{
-			CandidateTypes:     []CandidateType{CandidateTypeRelay},
-			InsecureSkipVerify: true,
-			NetworkTypes:       supportedNetworkTypes(),
-			Urls:               urls,
-			ProxyDialer:        proxy.FromEnvironment(),
+			CandidateTypes: []CandidateType{CandidateTypeRelay},
+			NetworkTypes:   supportedNetworkTypes(),
+			Urls:           urls,
+			ProxyDialer:    proxy.FromEnvironment(),
 		})
 		assert.NoError(t, err)
 
@@ -488,7 +487,7 @@ func TestTURNTCPProxy(t *testing.T) {
 		assert.NoError(t, server.Close())
 	}
 
-	t.Run("TCP Relay", func(t *testing.T) {
+	t.Run("TCP Relay via proxy", func(t *testing.T) {
 		serverPort := randomPort(t)
 		serverListener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(serverPort))
 		assert.NoError(t, err)


### PR DESCRIPTION
#### Description
When Running pion webRTC behind a http or https proxy e.g a corporate proxy Dialing to turn server fails. This fix enables user to implement golang.org/x/net/proxy Dial interface and provide it to the ICE package via settingEngine.

#### Reference issue
Fixes #284  
