### PR TITLE
Cancel Previous Gathering Routine On Restart

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1196,8 +1196,10 @@ func (a *Agent) SetRemoteCredentials(remoteUfrag, remotePwd string) error {
 // Restart restarts the ICE Agent with the provided ufrag/pwd
 // If no ufrag/pwd is provided the Agent will generate one itself
 //
-// Restart must only be called when GatheringState is GatheringStateComplete
-// a user must then call GatherCandidates explicitly to start generating new ones
+// If there is a gatherer routine currently running, Restart will
+// cancel it.
+// After a Restart, the user must then call GatherCandidates explicitly
+// to start generating new ones.
 func (a *Agent) Restart(ufrag, pwd string) error {
 	if ufrag == "" {
 		var err error
@@ -1224,8 +1226,7 @@ func (a *Agent) Restart(ufrag, pwd string) error {
 	var err error
 	if runErr := a.run(a.context(), func(ctx context.Context, agent *Agent) {
 		if agent.gatheringState == GatheringStateGathering {
-			err = ErrRestartWhenGathering
-			return
+			agent.gatherCandidateCancel()
 		}
 
 		// Clear all agent needed to take back to fresh state

--- a/errors.go
+++ b/errors.go
@@ -97,9 +97,6 @@ var (
 	// ErrInvalidMulticastDNSHostName indicates an invalid MulticastDNSHostName
 	ErrInvalidMulticastDNSHostName = errors.New("invalid mDNS HostName, must end with .local and can only contain a single '.'")
 
-	// ErrRestartWhenGathering indicates Restart was called when Agent is in GatheringStateGathering
-	ErrRestartWhenGathering = errors.New("ICE Agent can not be restarted when gathering")
-
 	// ErrRunCanceled indicates a run operation was canceled by its individual done
 	ErrRunCanceled = errors.New("run was canceled by done")
 


### PR DESCRIPTION
#### Description

Updated ICE agent restart method to cancel the current gathering and then restart the candidate gathering process.

#### Reference issue

Fixes #280 
