### PR TITLE
Fix ComponentRTCP value

### DIFF
--- a/candidate.go
+++ b/candidate.go
@@ -7,13 +7,12 @@ import (
 )
 
 const (
-	receiveMTU             = 8192
-	defaultLocalPreference = 65535
-
 	// ComponentRTP indicates that the candidate is used for RTP
-	ComponentRTP uint16 = 1
+	ComponentRTP uint16 = 1 + iota
 	// ComponentRTCP indicates that the candidate is used for RTCP
 	ComponentRTCP
+	receiveMTU             = 8192
+	defaultLocalPreference = 65535
 )
 
 // Candidate represents an ICE candidate


### PR DESCRIPTION
#### Description

The value of `ComponentRTCP` was set to 1 which has possibly resulted in the same priority for RTP and RTCP candidates and potentially more problems.

```
a=candidate:3031764619 1 udp 2130706431 192.168.24.132 60513 typ host
a=candidate:3031764619 2 udp 2130706431 192.168.24.132 60513 typ host
a=candidate:233762139 1 udp 2130706431 172.17.0.1 33110 typ host
a=candidate:233762139 2 udp 2130706431 172.17.0.1 33110 typ host
a=candidate:940760967 1 udp 1694498815 MY.PUBLIC.IP.ADDR 63447 typ srflx raddr 0.0.0.0 rport 49823
a=candidate:940760967 2 udp 1694498815 MY.PUBLIC.IP.ADDR 63447 typ srflx raddr 0.0.0.0 rport 49823
```

#### Note
I'm not sure if it is left intentionally or if I am having any misconceptions.