### PR TITLE
Improved performance of UDPMux

### DIFF
--- a/agent_udpmux_test.go
+++ b/agent_udpmux_test.go
@@ -21,8 +21,7 @@ func TestMuxAgent(t *testing.T) {
 
 	loggerFactory := logging.NewDefaultLoggerFactory()
 	udpMux := NewUDPMuxDefault(UDPMuxParams{
-		Logger:         loggerFactory.NewLogger("ice"),
-		ReadBufferSize: 20,
+		Logger: loggerFactory.NewLogger("ice"),
 	})
 	muxPort := 7686
 	require.NoError(t, udpMux.Start(muxPort))


### PR DESCRIPTION
The previous implementation of UDPMux was dropping
packets due to channel usage in the critical write path.