### PR TITLE
Generalize UDP and TCP Mux

### DIFF
--- a/agent_udpmux_test.go
+++ b/agent_udpmux_test.go
@@ -20,18 +20,22 @@ func TestMuxAgent(t *testing.T) {
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
 
-	loggerFactory := logging.NewDefaultLoggerFactory()
-	udpMux := NewUDPMuxDefault(UDPMuxParams{
-		Logger: loggerFactory.NewLogger("ice"),
-	})
-	muxPort := 7686
+	const muxPort = 7686
+
 	c, err := net.ListenUDP(udp, &net.UDPAddr{
 		Port: muxPort,
 	})
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	udpMux := NewUDPMuxDefault(UDPMuxParams{
+		Logger:  loggerFactory.NewLogger("ice"),
+		UDPConn: c,
+	})
+
 	require.NoError(t, err)
-	require.NoError(t, udpMux.Start(c))
 	defer func() {
 		_ = udpMux.Close()
+		_ = c.Close()
 	}()
 
 	muxedA, err := NewAgent(&AgentConfig{

--- a/gather.go
+++ b/gather.go
@@ -178,7 +178,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 				// accessible from the current interface.
 			case udp:
 				if a.udpMux != nil {
-					conn, err = a.udpMux.GetConn(a.localUfrag, network)
+					conn, err = a.udpMux.GetConn(a.localUfrag)
 					if err != nil {
 						a.log.Warnf("could not get udp muxed connection: %v\n", err)
 						continue


### PR DESCRIPTION
Refactor UDPMux to match TCPMux patterns. The goal is to have a
collection of mux instances and no specific UDP/TCP code

Resolves #350
