### PR TITLE
Update UDPMux to dispatch inbound packets on ufrag

### DIFF
--- a/agent_udpmux_test.go
+++ b/agent_udpmux_test.go
@@ -41,7 +41,9 @@ func TestMuxAgent(t *testing.T) {
 	muxedA, err := NewAgent(&AgentConfig{
 		UDPMux:         udpMux,
 		CandidateTypes: []CandidateType{CandidateTypeHost},
-		NetworkTypes:   supportedNetworkTypes(),
+		NetworkTypes: []NetworkType{
+			NetworkTypeUDP4,
+		},
 	})
 	require.NoError(t, err)
 

--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -147,6 +147,7 @@ func (c *udpMuxedConn) addAddress(addr string) {
 func (c *udpMuxedConn) removeAddress(addr string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	newAddresses := make([]string, 0, len(c.addresses))
 	for _, a := range c.addresses {
 		if a != addr {


### PR DESCRIPTION
If we get a packet for an address we don't know dispatch it
by ufrag still.

Resolves #357
