### PR TITLE
Use os.IsTimeout instead of os.ErrDeadlineExceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Antoine Baché](https://github.com/Antonito)
 * [Will Forcey](https://github.com/wawesomeNOGUI)
 * [David Zhao](https://github.com/davidzhao)
+* [Juliusz Chroboczek](https://github.com/jech)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -1,7 +1,6 @@
 package ice
 
 import (
-	"errors"
 	"io"
 	"net"
 	"os"
@@ -213,7 +212,7 @@ func (m *UDPMuxDefault) connWorker() {
 		if m.IsClosed() {
 			return
 		} else if err != nil {
-			if errors.Is(err, os.ErrDeadlineExceeded) {
+			if os.IsTimeout(err) {
 				continue
 			} else if err != io.EOF {
 				logger.Errorf("could not read udp packet: %v", err)


### PR DESCRIPTION
This fixes compilation with Go 1.13 and 1.14.

Fixes #360.
