### PR TITLE
Avoid gathering duplicate candidates

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -109,9 +109,6 @@ var (
 	// ErrTCPRemoteAddrAlreadyExists indicates we already have the connection with same remote addr.
 	ErrTCPRemoteAddrAlreadyExists = errors.New("conn with same remote addr already exists")
 
-	// ErrMuxNotStarted indicates the Mux has not been started prior to use
-	ErrMuxNotStarted = errors.New("mux must be started first")
-
 	errSendPacket                    = errors.New("failed to send packet")
 	errAttributeTooShortICECandidate = errors.New("attribute not long enough to be ICE candidate")
 	errParseComponent                = errors.New("could not parse component")
@@ -132,4 +129,6 @@ var (
 	errUnknownRole                   = errors.New("unknown role")
 	errMismatchUsername              = errors.New("username mismatch")
 	errICEWriteSTUNMessage           = errors.New("the ICE conn can't write STUN messages")
+	errUDPMuxDisabled                = errors.New("UDPMux is not enabled")
+	errCandidateIPNotFound           = errors.New("could not determine local IP for Mux candidate")
 )

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -184,8 +184,9 @@ func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr string) 
 	if ok {
 		existing.removeAddress(addr)
 	}
-
 	m.addressMap[addr] = conn
+
+	m.params.Logger.Debugf("Registered %s for %s", addr, conn.params.Key)
 }
 
 func (m *UDPMuxDefault) createMuxedConn(key string) *udpMuxedConn {
@@ -257,11 +258,12 @@ func (m *UDPMuxDefault) connWorker() {
 		}
 
 		if destinationConn == nil {
+			m.params.Logger.Tracef("dropping packet from %s, addr: %s", udpAddr.String(), addr.String())
 			continue
 		}
 
 		if err = destinationConn.writePacket(buf[:n], udpAddr); err != nil {
-			logger.Errorf("could not write packet: %v", err)
+			m.params.Logger.Errorf("could not write packet: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Duplicate candidates are useless, but also detrimental to how UDPMux
functions. Closing one connection for a Ufrag would end up terminating
other identital candidates for the same Ufrag.

This happens when both of the public and private IPs on a system are 
mapped to one of the same (i.e. via `Nat1To1IPs`). Adding this check 
improves the ease of deployment for pion.
