### PR TITLE
Fix UDPMux logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Will Forcey](https://github.com/wawesomeNOGUI)
 * [David Zhao](https://github.com/davidzhao)
 * [Juliusz Chroboczek](https://github.com/jech)
+* [Jin Gong](https://github.com/cgojin)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -47,6 +47,10 @@ type UDPMuxParams struct {
 
 // NewUDPMuxDefault creates an implementation of UDPMux
 func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
+	if params.Logger == nil {
+		params.Logger = logging.NewDefaultLoggerFactory().NewLogger("ice")
+	}
+
 	m := &UDPMuxDefault{
 		addressMap: map[string]*udpMuxedConn{},
 		params:     params,

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun"
 	"github.com/pion/transport/test"
 	"github.com/stretchr/testify/require"
@@ -28,9 +27,8 @@ func TestUDPMux(t *testing.T) {
 	conn, err := net.ListenUDP(udp, &net.UDPAddr{})
 	require.NoError(t, err)
 
-	loggerFactory := logging.NewDefaultLoggerFactory()
 	udpMux := NewUDPMuxDefault(UDPMuxParams{
-		Logger:  loggerFactory.NewLogger("ice"),
+		Logger:  nil,
 		UDPConn: conn,
 	})
 


### PR DESCRIPTION
If no logger is passed in, it will be created.

Error running [ice-single-port](https://github.com/pion/webrtc/tree/master/examples/ice-single-port) :
invalid memory address or nil pointer dereference

