### PR TITLE
Expose CheckInterval on AgentConfig

### DIFF
--- a/agent_config.go
+++ b/agent_config.go
@@ -83,6 +83,10 @@ type AgentConfig struct {
 	// A keepalive interval of 0 means we never send keepalive packets
 	KeepaliveInterval *time.Duration
 
+	// CheckInterval controls how often our task loop runs when in the
+	// connecting state.
+	CheckInterval *time.Duration
+
 	// NetworkTypes is an optional configuration for disabling or enabling
 	// support for specific network types.
 	NetworkTypes []NetworkType
@@ -92,10 +96,6 @@ type AgentConfig struct {
 	CandidateTypes []CandidateType
 
 	LoggerFactory logging.LoggerFactory
-
-	// checkInterval controls how often our internal task loop runs when
-	// in the connecting state. Only useful for testing.
-	checkInterval time.Duration
 
 	// MaxBindingRequests is the max amount of binding requests the agent will send
 	// over a candidate pair for validation or nomination, if after MaxBindingRequests
@@ -205,10 +205,10 @@ func (config *AgentConfig) initWithDefaults(a *Agent) {
 		a.keepaliveInterval = *config.KeepaliveInterval
 	}
 
-	if config.checkInterval == 0 {
+	if config.CheckInterval == nil {
 		a.checkInterval = defaultCheckInterval
 	} else {
-		a.checkInterval = config.checkInterval
+		a.checkInterval = *config.CheckInterval
 	}
 
 	if config.CandidateTypes == nil || len(config.CandidateTypes) == 0 {

--- a/agent_test.go
+++ b/agent_test.go
@@ -397,7 +397,7 @@ func TestConnectivityOnStartup(t *testing.T) {
 		Net:              net0,
 
 		KeepaliveInterval: &KeepaliveInterval,
-		checkInterval:     time.Hour,
+		CheckInterval:     &KeepaliveInterval,
 	}
 
 	aAgent, err := NewAgent(cfg0)
@@ -409,7 +409,7 @@ func TestConnectivityOnStartup(t *testing.T) {
 		MulticastDNSMode:  MulticastDNSModeDisabled,
 		Net:               net1,
 		KeepaliveInterval: &KeepaliveInterval,
-		checkInterval:     time.Hour,
+		CheckInterval:     &KeepaliveInterval,
 	}
 
 	bAgent, err := NewAgent(cfg1)
@@ -1493,6 +1493,7 @@ func TestCloseInConnectionStateCallback(t *testing.T) {
 	disconnectedDuration := time.Second
 	failedDuration := time.Second
 	KeepaliveInterval := time.Duration(0)
+	CheckInterval := 500 * time.Millisecond
 
 	cfg := &AgentConfig{
 		Urls:                []*URL{},
@@ -1500,7 +1501,7 @@ func TestCloseInConnectionStateCallback(t *testing.T) {
 		DisconnectedTimeout: &disconnectedDuration,
 		FailedTimeout:       &failedDuration,
 		KeepaliveInterval:   &KeepaliveInterval,
-		checkInterval:       500 * time.Millisecond,
+		CheckInterval:       &CheckInterval,
 	}
 
 	aAgent, err := NewAgent(cfg)
@@ -1544,6 +1545,7 @@ func TestRunTaskInConnectionStateCallback(t *testing.T) {
 
 	oneSecond := time.Second
 	KeepaliveInterval := time.Duration(0)
+	CheckInterval := 50 * time.Millisecond
 
 	cfg := &AgentConfig{
 		Urls:                []*URL{},
@@ -1551,7 +1553,7 @@ func TestRunTaskInConnectionStateCallback(t *testing.T) {
 		DisconnectedTimeout: &oneSecond,
 		FailedTimeout:       &oneSecond,
 		KeepaliveInterval:   &KeepaliveInterval,
-		checkInterval:       50 * time.Millisecond,
+		CheckInterval:       &CheckInterval,
 	}
 
 	aAgent, err := NewAgent(cfg)
@@ -1588,6 +1590,7 @@ func TestRunTaskInSelectedCandidatePairChangeCallback(t *testing.T) {
 
 	oneSecond := time.Second
 	KeepaliveInterval := time.Duration(0)
+	CheckInterval := 50 * time.Millisecond
 
 	cfg := &AgentConfig{
 		Urls:                []*URL{},
@@ -1595,7 +1598,7 @@ func TestRunTaskInSelectedCandidatePairChangeCallback(t *testing.T) {
 		DisconnectedTimeout: &oneSecond,
 		FailedTimeout:       &oneSecond,
 		KeepaliveInterval:   &KeepaliveInterval,
-		checkInterval:       50 * time.Millisecond,
+		CheckInterval:       &CheckInterval,
 	}
 
 	aAgent, err := NewAgent(cfg)
@@ -1648,6 +1651,7 @@ func TestLiteLifecycle(t *testing.T) {
 	disconnectedDuration := time.Second
 	failedDuration := time.Second
 	KeepaliveInterval := time.Duration(0)
+	CheckInterval := 500 * time.Millisecond
 	bAgent, err := NewAgent(&AgentConfig{
 		Lite:                true,
 		CandidateTypes:      []CandidateType{CandidateTypeHost},
@@ -1656,7 +1660,7 @@ func TestLiteLifecycle(t *testing.T) {
 		DisconnectedTimeout: &disconnectedDuration,
 		FailedTimeout:       &failedDuration,
 		KeepaliveInterval:   &KeepaliveInterval,
-		checkInterval:       500 * time.Millisecond,
+		CheckInterval:       &CheckInterval,
 	})
 	require.NoError(t, err)
 

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -496,7 +496,7 @@ func TestDisconnectedToConnected(t *testing.T) {
 		Net:                 net0,
 		DisconnectedTimeout: &disconnectTimeout,
 		KeepaliveInterval:   &keepaliveInterval,
-		checkInterval:       keepaliveInterval,
+		CheckInterval:       &keepaliveInterval,
 	})
 	assert.NoError(t, err)
 
@@ -506,7 +506,7 @@ func TestDisconnectedToConnected(t *testing.T) {
 		Net:                 net1,
 		DisconnectedTimeout: &disconnectTimeout,
 		KeepaliveInterval:   &keepaliveInterval,
-		checkInterval:       keepaliveInterval,
+		CheckInterval:       &keepaliveInterval,
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Exposes the `CheckInterval` property on `AgentConfig`. Seems like [this was commented to be done](https://github.com/pion/ice/pull/201#discussion_r449843334), but just never happened.

Useful for reducing connection times.