### PR TITLE
Populate RelayProtocol for relay candidates

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -28,6 +28,7 @@ korymiller1489 <kmiller@unwiredrevolution.com>
 Kyle Carberry <kyle@carberry.com>
 Lander Noterman <lander.noterman@basalte.be>
 Luke Curley <kixelated@gmail.com>
+Meelap Shah <meelapshah@gmail.com>
 Michael MacDonald <github@macdonald.cx>
 Michael MacDonald <mike.macdonald@savantsystems.com>
 Nevio Vesic <nevio@subspace.com>

--- a/agent_stats.go
+++ b/agent_stats.go
@@ -58,6 +58,10 @@ func (a *Agent) GetLocalCandidatesStats() []CandidateStats {
 		result := make([]CandidateStats, 0, len(agent.localCandidates))
 		for networkType, localCandidates := range agent.localCandidates {
 			for _, c := range localCandidates {
+				relayProtocol := ""
+				if c.Type() == CandidateTypeRelay {
+					relayProtocol = c.(*CandidateRelay).RelayProtocol()
+				}
 				stat := CandidateStats{
 					Timestamp:     time.Now(),
 					ID:            c.ID(),
@@ -67,7 +71,7 @@ func (a *Agent) GetLocalCandidatesStats() []CandidateStats {
 					CandidateType: c.Type(),
 					Priority:      c.Priority(),
 					// URL string
-					RelayProtocol: "udp",
+					RelayProtocol: relayProtocol,
 					// Deleted bool
 				}
 				result = append(result, stat)
@@ -98,7 +102,7 @@ func (a *Agent) GetRemoteCandidatesStats() []CandidateStats {
 					CandidateType: c.Type(),
 					Priority:      c.Priority(),
 					// URL string
-					RelayProtocol: "udp",
+					RelayProtocol: "",
 				}
 				result = append(result, stat)
 			}

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -492,7 +492,7 @@ func UnmarshalCandidate(raw string) (Candidate, error) {
 	case "prflx":
 		return NewCandidatePeerReflexive(&CandidatePeerReflexiveConfig{"", protocol, address, port, component, priority, foundation, relatedAddress, relatedPort})
 	case "relay":
-		return NewCandidateRelay(&CandidateRelayConfig{"", protocol, address, port, component, priority, foundation, relatedAddress, relatedPort, nil})
+		return NewCandidateRelay(&CandidateRelayConfig{"", protocol, address, port, component, priority, foundation, relatedAddress, relatedPort, "", nil})
 	default:
 	}
 

--- a/candidate_relay.go
+++ b/candidate_relay.go
@@ -8,21 +8,23 @@ import (
 type CandidateRelay struct {
 	candidateBase
 
-	onClose func() error
+	relayProtocol string
+	onClose       func() error
 }
 
 // CandidateRelayConfig is the config required to create a new CandidateRelay
 type CandidateRelayConfig struct {
-	CandidateID string
-	Network     string
-	Address     string
-	Port        int
-	Component   uint16
-	Priority    uint32
-	Foundation  string
-	RelAddr     string
-	RelPort     int
-	OnClose     func() error
+	CandidateID   string
+	Network       string
+	Address       string
+	Port          int
+	Component     uint16
+	Priority      uint32
+	Foundation    string
+	RelAddr       string
+	RelPort       int
+	RelayProtocol string
+	OnClose       func() error
 }
 
 // NewCandidateRelay creates a new relay candidate
@@ -59,8 +61,14 @@ func NewCandidateRelay(config *CandidateRelayConfig) (*CandidateRelay, error) {
 				Port:    config.RelPort,
 			},
 		},
-		onClose: config.OnClose,
+		relayProtocol: config.RelayProtocol,
+		onClose:       config.OnClose,
 	}, nil
+}
+
+// RelayProtocol returns the protocol used between the endpoint and the relay server.
+func (c *CandidateRelay) RelayProtocol() string {
+	return c.relayProtocol
 }
 
 func (c *CandidateRelay) close() error {

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -262,6 +262,7 @@ func TestCandidateMarshal(t *testing.T) {
 					port:           5000,
 					relatedAddress: &CandidateRelatedAddress{"192.168.0.1", 5001},
 				},
+				"",
 				nil,
 			},
 			"848194626 1 udp 16777215 50.0.0.1 5000 typ relay raddr 192.168.0.1 rport 5001",


### PR DESCRIPTION
#### Description

Candidates have a field `RelayProtocol` on their stat as defined [here](https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatestats-relayprotocol):
> It is the protocol used by the endpoint to communicate with the TURN
> server. This is only present for local candidates. Valid values are
> "udp", "tcp", or "tls".

Currently, the field is populated with "udp" for all local and remote candidates of all types. Instead, we should leave it blank for all but local relay candidates in which case we should populate it with the protocol used to talk to the TURN server.
