### PR TITLE
Fix duplicate TCP candidates

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -808,17 +808,18 @@ func (a *Agent) addRemoteCandidate(c Candidate) {
 
 func (a *Agent) addCandidate(ctx context.Context, c Candidate, candidateConn net.PacketConn) error {
 	return a.run(ctx, func(ctx context.Context, agent *Agent) {
-		c.start(a, candidateConn, a.startedCh)
-
 		set := a.localCandidates[c.NetworkType()]
 		for _, candidate := range set {
 			if candidate.Equal(c) {
+				a.log.Debugf("Ignore duplicate candidate: %s", c.String())
 				if err := c.close(); err != nil {
 					a.log.Warnf("Failed to close duplicate candidate: %v", err)
 				}
 				return
 			}
 		}
+
+		c.start(a, candidateConn, a.startedCh)
 
 		set = append(set, c)
 		a.localCandidates[c.NetworkType()] = set

--- a/tcp_mux.go
+++ b/tcp_mux.go
@@ -159,7 +159,7 @@ func (m *TCPMuxDefault) handleConn(conn net.Conn) {
 
 	n, err := readStreamingPacket(conn, buf)
 	if err != nil {
-		m.params.Logger.Warnf("Error reading first packet: %s", err)
+		m.params.Logger.Warnf("Error reading first packet from %s: %s", conn.RemoteAddr().String(), err)
 		return
 	}
 


### PR DESCRIPTION
#### Description
Duplicate TCP candidates share the same candidateConn by tcpMux.GetConnByUfrag, which would be closed if started before checking