### PR TITLE
Remove unknown constant

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,6 +17,7 @@ Chao Yuan <yuanchao0310@163.com>
 David Hamilton <davidhamiltron@gmail.com>
 David Zhao <david@davidzhao.com>
 Henry <cryptix@riseup.net>
+hn8 <10730886+hn8@users.noreply.github.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Hugo Arregui <hugo@decentraland.org>
 Jason Maldonis <jason.maldonis@i3pd.com>
@@ -41,6 +42,7 @@ Sean DuBois <sean@siobud.com>
 Sebastian Waisbrot <seppo0010@gmail.com>
 Sidney San Martín <sidney@s4y.us>
 Will Forcey <wsforc3y@gmail.com>
+Woodrow Douglass <wdouglass@carnegierobotics.com>
 Yutaka Takeda <yt0916@gmail.com>
 ZHENK <chengzhenyang@gmail.com>
 Zizheng Tai <me@zizheng.me>

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -172,6 +172,8 @@ func (c *candidateBase) LocalPreference() uint16 {
 				}
 			case CandidateTypeUnspecified:
 				return 0
+			default:
+				return 0
 			}
 			return 0
 		}()

--- a/candidatepair_state.go
+++ b/candidatepair_state.go
@@ -20,6 +20,9 @@ const (
 	// CandidatePairStateSucceeded means a check for this pair was already
 	// done and produced a successful result.
 	CandidatePairStateSucceeded
+
+	// CandidatePairStateUnknown probably indicates an error
+	CandidatePairStateUnknown
 )
 
 func (c CandidatePairState) String() string {
@@ -32,6 +35,7 @@ func (c CandidatePairState) String() string {
 		return "failed"
 	case CandidatePairStateSucceeded:
 		return "succeeded"
+	default:
+		return "Unknown candidate pair state"
 	}
-	return "Unknown candidate pair state"
 }

--- a/candidatepair_test.go
+++ b/candidatepair_test.go
@@ -131,3 +131,11 @@ func TestNilCandidatePairString(t *testing.T) {
 	var nilCandidatePair *CandidatePair
 	assert.Equal(t, nilCandidatePair.String(), "")
 }
+
+func TestInvalidCandidatePairStateString(t *testing.T) {
+	state := CandidatePairState(0)
+	assert.NotEqual(t, "waiting", state.String())
+	assert.NotEqual(t, "in-progress", state.String())
+	assert.NotEqual(t, "failed", state.String())
+	assert.NotEqual(t, "succeeded", state.String())
+}

--- a/candidatetype.go
+++ b/candidatetype.go
@@ -10,6 +10,7 @@ const (
 	CandidateTypeServerReflexive
 	CandidateTypePeerReflexive
 	CandidateTypeRelay
+	CandidateTypeUnknown
 )
 
 // String makes CandidateType printable
@@ -25,8 +26,9 @@ func (c CandidateType) String() string {
 		return "relay"
 	case CandidateTypeUnspecified:
 		return "Unknown candidate type"
+	default:
+		return "Unknown candidate type"
 	}
-	return "Unknown candidate type"
 }
 
 // Preference returns the preference weight of a CandidateType
@@ -45,8 +47,9 @@ func (c CandidateType) Preference() uint16 {
 		return 100
 	case CandidateTypeRelay, CandidateTypeUnspecified:
 		return 0
+	default:
+		return 0
 	}
-	return 0
 }
 
 func containsCandidateType(candidateType CandidateType, candidateTypeList []CandidateType) bool {

--- a/gather.go
+++ b/gather.go
@@ -114,6 +114,7 @@ func (a *Agent) gatherCandidates(ctx context.Context) {
 				wg.Done()
 			}()
 		case CandidateTypePeerReflexive, CandidateTypeUnspecified:
+		default:
 		}
 	}
 	// Block until all STUN and TURN URLs have been gathered (or timed out)

--- a/ice.go
+++ b/ice.go
@@ -25,6 +25,9 @@ const (
 
 	// ConnectionStateClosed ICE agent has finished and is no longer handling requests
 	ConnectionStateClosed
+
+	// Unknown State
+	ConnectionStateUnknown
 )
 
 func (c ConnectionState) String() string {
@@ -60,6 +63,9 @@ const (
 
 	// GatheringStateComplete indicates candidate gatering has been completed
 	GatheringStateComplete
+
+	// GatheringStateUnknown probably indicates an error
+	GatheringStateUnknown
 )
 
 func (t GatheringState) String() string {

--- a/ice_test.go
+++ b/ice_test.go
@@ -11,7 +11,7 @@ func TestConnectedState_String(t *testing.T) {
 		connectionState ConnectionState
 		expectedString  string
 	}{
-		{ConnectionState(Unknown), "Invalid"},
+		{ConnectionStateUnknown, "Invalid"},
 		{ConnectionStateNew, "New"},
 		{ConnectionStateChecking, "Checking"},
 		{ConnectionStateConnected, "Connected"},
@@ -35,7 +35,7 @@ func TestGatheringState_String(t *testing.T) {
 		gatheringState GatheringState
 		expectedString string
 	}{
-		{GatheringState(Unknown), ErrUnknownType.Error()},
+		{GatheringStateUnknown, ErrUnknownType.Error()},
 		{GatheringStateNew, "new"},
 		{GatheringStateGathering, "gathering"},
 		{GatheringStateComplete, "complete"},

--- a/url_test.go
+++ b/url_test.go
@@ -56,6 +56,7 @@ func TestParseURL(t *testing.T) {
 			{"stun:[::1]:123a", ErrPort},
 			{"google.de", ErrSchemeType},
 			{"stun:", ErrHost},
+			{"stan:", ErrSchemeType},
 			{"stun:google.de:abc", ErrPort},
 			{"stun:google.de?transport=udp", ErrSTUNQuery},
 			{"stuns:google.de?transport=udp", ErrSTUNQuery},


### PR DESCRIPTION
This constant tends to cause collisions with enumerations, and is
in general a source of bugs

#### Description

#### Reference issue
Related to pion/webrtc#1293
