### PR TITLE
UDPMuxParams use net.PacketConn instead of UDPConn

### DIFF
--- a/udp_mux.go
+++ b/udp_mux.go
@@ -42,7 +42,7 @@ const maxAddrSize = 512
 // UDPMuxParams are parameters for UDPMux.
 type UDPMuxParams struct {
 	Logger  logging.LeveledLogger
-	UDPConn *net.UDPConn
+	UDPConn net.PacketConn
 }
 
 // NewUDPMuxDefault creates an implementation of UDPMux


### PR DESCRIPTION
UDPConn satisifies the net.PacketConn interface. Allows us to pass in
structures that satisfy the interface, but aren't a UDPConn
