### PR TITLE
Fix race condition when closing agent after gather

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -893,10 +893,10 @@ func (a *Agent) Close() error {
 	done := make(chan struct{})
 
 	a.afterRun(func(context.Context) {
+		a.gatherCandidateCancel()
 		close(done)
 	})
 
-	a.gatherCandidateCancel()
 	a.err.Store(ErrClosed)
 
 	a.tcpMux.RemoveConnByUfrag(a.localUfrag)


### PR DESCRIPTION
This fixes a data race where `gatherCandidateCancel` could be overwritten during cancel.

This may not fix the actual race, because I assume `gatherCandidates` shouldn't run at all after `Close`, but I'm not sure. cc: @Sean-Der 

Here's output from the race that occurs:
```
==================
WARNING: DATA RACE
Write at 0x00c000e6f710 by goroutine 385:
  sync/atomic.CompareAndSwapInt32()
      /usr/local/goboring/src/runtime/race_amd64.s:334 +0xb
  sync/atomic.CompareAndSwapInt32()
      <autogenerated>:1 +0x1e
  context.(*cancelCtx).cancel()
      /usr/local/goboring/src/context/context.go:401 +0x84
  context.WithCancel.func1()
      /usr/local/goboring/src/context/context.go:238 +0x4f
  github.com/pion/ice/v2.(*Agent).Close()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/ice/v2/agent.go:899 +0xf2
  github.com/pion/webrtc/v3.(*ICEGatherer).Close()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/webrtc/v3/icegatherer.go:184 +0xd9
  github.com/pion/webrtc/v3.(*ICETransport).Stop()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/webrtc/v3/icetransport.go:197 +0x176
  github.com/pion/webrtc/v3.(*PeerConnection).Close()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/webrtc/v3/peerconnection.go:1905 +0x724
  github.com/coder/coder/peer.(*Conn).closeWithError()
      /home/coder/Projects/coder/coder/peer/conn.go:494 +0x38c
  github.com/coder/coder/peer.(*Conn).CloseWithError()
      /home/coder/Projects/coder/coder/peer/conn.go:460 +0xc7
  github.com/coder/coder/peer_test.TestConn.func9()
      /home/coder/Projects/coder/coder/peer/conn_test.go:201 +0xb6
  testing.tRunner()
      /usr/local/goboring/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/goboring/src/testing/testing.go:1306 +0x47

Previous write at 0x00c000e6f710 by goroutine 31:
  context.WithCancel()
      /usr/local/goboring/src/context/context.go:236 +0xa4
  github.com/pion/ice/v2.(*Agent).GatherCandidates.func1()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/ice/v2/gather.go:72 +0x11e
  github.com/pion/ice/v2.(*Agent).taskLoop()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/ice/v2/agent.go:223 +0x145
  github.com/pion/ice/v2.NewAgent·dwrap·2()
      /home/coder/Projects/coder/coder/vendor/github.com/pion/ice/v2/agent.go:351 +0x39
```

This does fix the race in my code, and `goleak` detects no unwanted goroutines.