### PR TITLE
Fix goroutine leak for closing while gathering

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -114,6 +114,7 @@ type Agent struct {
 	err          atomicError
 
 	gatherCandidateCancel func()
+	gatherCandidateDone   chan struct{}
 
 	chanCandidate     chan Candidate
 	chanCandidatePair chan *CandidatePair
@@ -907,6 +908,9 @@ func (a *Agent) Close() error {
 
 	a.afterRun(func(context.Context) {
 		a.gatherCandidateCancel()
+		if a.gatherCandidateDone != nil {
+			<-a.gatherCandidateDone
+		}
 	})
 	a.err.Store(ErrClosed)
 


### PR DESCRIPTION
The "gatherCandidates()" function could previously leak after
close, because the WaitGroup was left unchecked.

```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 883 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
goroutine 883 [IO wait]:
internal/poll.runtime_pollWait(0x47f5dd8, 0x72)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc0000f8a18, 0xc000080[50](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:50)0, 0x0)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/internal/poll/fd_poll_runtime.go:84 +0xbd
internal/poll.(*pollDesc).waitRead(...)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).ReadFrom(0xc0000f8a00, {0xc000080500, 0x500, 0x500})
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/internal/poll/fd_unix.go:223 +0x4[51](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:51)
net.(*netFD).readFrom(0xc0000f8a00, {0xc000080500, 0x500, 0x500})
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/net/fd_posix.go:62 +0x5d
net.(*UDPConn).readFrom(0xc0000107b0, {0xc000080500, 0x500, 0x500}, 0xc00036a810)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/net/udpsock_posix.go:47 +0x92
net.(*UDPConn).readFromUDP(0xc0000107b0, {0xc000080500, 0x500, 0x500}, 0x500)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/net/udpsock.go:116 +0x8d
net.(*UDPConn).ReadFrom(0xc000080500, {0xc000080500, 0x500, 0x500})
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/net/udpsock.go:125 +0xaa
github.com/pion/ice/v2.getXORMappedAddr.func2({0xc000080500, 0x500, 0x500})
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/util.go:97 +0x67
github.com/pion/ice/v2.stunRequest(0xc0002e1b80, 0xc0002e1bd8)
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/util.go:124 +0x12d
github.com/pion/ice/v2.getXORMappedAddr({0x1b29fa0, 0xc0000107b0}, {0x1b1d180, 0xc00036a780}, 0x12a05f200)
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/util.go:95 +0x1f3
github.com/pion/ice/v2.(*Agent).gatherCandidatesSrflx.func1({0x1, {0x19e4c88, 0x11}, 0x4b66, {0x0, 0x0}, {0x0, 0x0}, 0x1}, {0x19d3f57, ...})
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:363 +0x6b1
created by github.com/pion/ice/v2.(*Agent).gatherCandidatesSrflx
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:347 +0x191

 Goroutine 833 in state semacquire, with sync.runtime_Semacquire on top of the stack:
goroutine 833 [semacquire]:
sync.runtime_Semacquire(0xc000318884)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/runtime/sema.go:[56](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:56) +0x25
sync.(*WaitGroup).Wait(0xc000318884)
	/Users/runner/hostedtoolcache/go/1.17.7/x[64](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:64)/src/sync/waitgroup.go:130 +0xea
github.com/pion/ice/v2.(*Agent).gatherCandidatesSrflx(0xc00013db80, {0x1b22bf8, 0xc0001c9b80}, {0xc0000a2318, 0x1, 0x0}, {0xc0001eba40, 0x2, 0x0})
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:396 +0x1[70](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:70)
github.com/pion/ice/v2.(*Agent).gatherCandidates.func2()
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:100 +0xd7
created by github.com/pion/ice/v2.(*Agent).gatherCandidates
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:99 +0x5dc

 Goroutine 8[71](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:71) in state semacquire, with sync.runtime_Semacquire on top of the stack:
goroutine 871 [semacquire]:
sync.runtime_Semacquire(0xc000318834)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/runtime/sema.go:56 +0x25
sync.(*WaitGroup).Wait(0xc000318834)
	/Users/runner/hostedtoolcache/go/1.17.7/x64/src/sync/waitgroup.go:130 +0xea
github.com/pion/ice/v2.(*Agent).gatherCandidates(0xc00013db80, {0x1b22bf8, 0xc0001c9b80})
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:120 +0x792
created by github.com/pion/ice/v2.(*Agent).GatherCandidates.func1
	/Users/runner/go/pkg/mod/github.com/pion/ice/v2@v2.1.20/gather.go:[75](https://github.com/coder/coder/runs/5275517811?check_suite_focus=true#step:7:75) +0x207
]
```