### PR TITLE
Reduce critical section when writing with TCPMux.

### DIFF
--- a/tcp_packet_conn.go
+++ b/tcp_packet_conn.go
@@ -149,9 +149,9 @@ func (t *tcpPacketConn) ReadFrom(b []byte) (n int, raddr net.Addr, err error) {
 // WriteTo is for active and s-o candidates.
 func (t *tcpPacketConn) WriteTo(buf []byte, raddr net.Addr) (n int, err error) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	conn, ok := t.conns[raddr.String()]
+	t.mu.Unlock()
+
 	if !ok {
 		return 0, io.ErrClosedPipe
 		// conn, err := net.DialTCP(tcp, nil, raddr.(*net.TCPAddr))


### PR DESCRIPTION
To avoid one bad connection causing locked processes/cascading failures.

When the connection is stuck, writes will not timeout and will end up holding the lock forever. Attempts to close the connections will be stuck waiting for the mutex.