### PR TITLE
No log newlines

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -610,7 +610,7 @@ func (a *Agent) pingAllCandidates() {
 		}
 
 		if p.bindingRequestCount > a.maxBindingRequests {
-			a.log.Tracef("max requests reached for pair %s, marking it as failed\n", p)
+			a.log.Tracef("max requests reached for pair %s, marking it as failed", p)
 			p.state = CandidatePairStateFailed
 		} else {
 			a.selector.PingCandidate(p.Local, p.Remote)
@@ -961,7 +961,7 @@ func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) Cand
 }
 
 func (a *Agent) sendBindingRequest(m *stun.Message, local, remote Candidate) {
-	a.log.Tracef("ping STUN from %s to %s\n", local.String(), remote.String())
+	a.log.Tracef("ping STUN from %s to %s", local.String(), remote.String())
 
 	a.invalidatePendingBindingRequests(time.Now())
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{

--- a/gather.go
+++ b/gather.go
@@ -161,7 +161,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 			if _mappedIP, err := a.extIPMapper.findExternalIP(ip.String()); err == nil {
 				mappedIP = _mappedIP
 			} else {
-				a.log.Warnf("1:1 NAT mapping is enabled but no external IP is found for %s\n", ip.String())
+				a.log.Warnf("1:1 NAT mapping is enabled but no external IP is found for %s", ip.String())
 			}
 		}
 
@@ -181,11 +181,11 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 			switch network {
 			case tcp:
 				// Handle ICE TCP passive mode
-				a.log.Debugf("GetConn by ufrag: %s\n", a.localUfrag)
+				a.log.Debugf("GetConn by ufrag: %s", a.localUfrag)
 				conn, err = a.tcpMux.GetConnByUfrag(a.localUfrag, mappedIP.To4() == nil)
 				if err != nil {
 					if !errors.Is(err, ErrTCPMuxNotInitialized) {
-						a.log.Warnf("error getting tcp conn by ufrag: %s %s %s\n", network, ip, a.localUfrag)
+						a.log.Warnf("error getting tcp conn by ufrag: %s %s %s", network, ip, a.localUfrag)
 					}
 					continue
 				}
@@ -193,7 +193,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 				if tcpConn, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 					port = tcpConn.Port
 				} else {
-					a.log.Warnf("failed to get port of conn from TCPMux: %s %s %s\n", network, ip, a.localUfrag)
+					a.log.Warnf("failed to get port of conn from TCPMux: %s %s %s", network, ip, a.localUfrag)
 					continue
 				}
 				tcpType = TCPTypePassive
@@ -202,14 +202,14 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 			case udp:
 				conn, err = listenUDPInPortRange(a.net, a.log, int(a.portmax), int(a.portmin), network, &net.UDPAddr{IP: ip, Port: 0})
 				if err != nil {
-					a.log.Warnf("could not listen %s %s\n", network, ip)
+					a.log.Warnf("could not listen %s %s", network, ip)
 					continue
 				}
 
 				if udpConn, ok := conn.LocalAddr().(*net.UDPAddr); ok {
 					port = udpConn.Port
 				} else {
-					a.log.Warnf("failed to get port of UDPAddr from ListenUDPInPortRange: %s %s %s\n", network, ip, a.localUfrag)
+					a.log.Warnf("failed to get port of UDPAddr from ListenUDPInPortRange: %s %s %s", network, ip, a.localUfrag)
 					continue
 				}
 			}
@@ -223,13 +223,13 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 
 			c, err := NewCandidateHost(&hostConfig)
 			if err != nil {
-				closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host candidate: %s %s %d: %v\n", network, mappedIP, port, err))
+				closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host candidate: %s %s %d: %v", network, mappedIP, port, err))
 				continue
 			}
 
 			if a.mDNSMode == MulticastDNSModeQueryAndGather {
 				if err = c.setIP(ip); err != nil {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host candidate: %s %s %d: %v\n", network, mappedIP, port, err))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host candidate: %s %s %d: %v", network, mappedIP, port, err))
 					continue
 				}
 			}
@@ -238,7 +238,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 				if closeErr := c.close(); closeErr != nil {
 					a.log.Warnf("Failed to close candidate: %v", closeErr)
 				}
-				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
+				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
 			}
 		}
 	}
@@ -274,7 +274,7 @@ func (a *Agent) gatherCandidatesLocalUDPMux(ctx context.Context) error {
 
 		udpAddr, ok := conn.LocalAddr().(*net.UDPAddr)
 		if !ok {
-			closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host mux candidate: %s failed to cast\n", candidateIP))
+			closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host mux candidate: %s failed to cast", candidateIP))
 			return nil
 		}
 
@@ -287,7 +287,7 @@ func (a *Agent) gatherCandidatesLocalUDPMux(ctx context.Context) error {
 
 		c, err := NewCandidateHost(&hostConfig)
 		if err != nil {
-			closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host mux candidate: %s %d: %v\n", candidateIP, udpAddr.Port, err))
+			closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create host mux candidate: %s %d: %v", candidateIP, udpAddr.Port, err))
 			// already logged error
 			return nil
 		}
@@ -319,19 +319,19 @@ func (a *Agent) gatherCandidatesSrflxMapped(ctx context.Context, networkTypes []
 
 			conn, err := listenUDPInPortRange(a.net, a.log, int(a.portmax), int(a.portmin), network, &net.UDPAddr{IP: nil, Port: 0})
 			if err != nil {
-				a.log.Warnf("Failed to listen %s: %v\n", network, err)
+				a.log.Warnf("Failed to listen %s: %v", network, err)
 				return
 			}
 
 			laddr, ok := conn.LocalAddr().(*net.UDPAddr)
 			if !ok {
-				closeConnAndLog(conn, a.log, "1:1 NAT mapping is enabled but LocalAddr is not a UDPAddr\n")
+				closeConnAndLog(conn, a.log, "1:1 NAT mapping is enabled but LocalAddr is not a UDPAddr")
 				return
 			}
 
 			mappedIP, err := a.extIPMapper.findExternalIP(laddr.IP.String())
 			if err != nil {
-				closeConnAndLog(conn, a.log, fmt.Sprintf("1:1 NAT mapping is enabled but no external IP is found for %s\n", laddr.IP.String()))
+				closeConnAndLog(conn, a.log, fmt.Sprintf("1:1 NAT mapping is enabled but no external IP is found for %s", laddr.IP.String()))
 				return
 			}
 
@@ -345,7 +345,7 @@ func (a *Agent) gatherCandidatesSrflxMapped(ctx context.Context, networkTypes []
 			}
 			c, err := NewCandidateServerReflexive(&srflxConfig)
 			if err != nil {
-				closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v\n",
+				closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v",
 					network,
 					mappedIP.String(),
 					laddr.Port,
@@ -357,7 +357,7 @@ func (a *Agent) gatherCandidatesSrflxMapped(ctx context.Context, networkTypes []
 				if closeErr := c.close(); closeErr != nil {
 					a.log.Warnf("Failed to close candidate: %v", closeErr)
 				}
-				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
+				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
 			}
 		}()
 	}
@@ -386,13 +386,13 @@ func (a *Agent) gatherCandidatesSrflxUDPMux(ctx context.Context, urls []*URL, ne
 
 				xoraddr, err := a.udpMuxSrflx.GetXORMappedAddr(serverAddr, stunGatherTimeout)
 				if err != nil {
-					a.log.Warnf("could not get server reflexive address %s %s: %v\n", network, url, err)
+					a.log.Warnf("could not get server reflexive address %s %s: %v", network, url, err)
 					return
 				}
 
 				conn, err := a.udpMuxSrflx.GetConnForURL(a.localUfrag, url.String(), isIPv6)
 				if err != nil {
-					a.log.Warnf("could not find connection in UDPMuxSrflx %s %s: %v\n", network, url, err)
+					a.log.Warnf("could not find connection in UDPMuxSrflx %s %s: %v", network, url, err)
 					return
 				}
 
@@ -401,7 +401,7 @@ func (a *Agent) gatherCandidatesSrflxUDPMux(ctx context.Context, urls []*URL, ne
 
 				laddr, ok := conn.LocalAddr().(*net.UDPAddr)
 				if !ok {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: cast failed\n", network, ip, port))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: cast failed", network, ip, port))
 					return
 				}
 
@@ -415,7 +415,7 @@ func (a *Agent) gatherCandidatesSrflxUDPMux(ctx context.Context, urls []*URL, ne
 				}
 				c, err := NewCandidateServerReflexive(&srflxConfig)
 				if err != nil {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v\n", network, ip, port, err))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v", network, ip, port, err))
 					return
 				}
 
@@ -423,7 +423,7 @@ func (a *Agent) gatherCandidatesSrflxUDPMux(ctx context.Context, urls []*URL, ne
 					if closeErr := c.close(); closeErr != nil {
 						a.log.Warnf("Failed to close candidate: %v", closeErr)
 					}
-					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
+					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
 				}
 			}(*urls[i], networkType.String(), networkType.IsIPv6())
 		}
@@ -453,7 +453,7 @@ func (a *Agent) gatherCandidatesSrflx(ctx context.Context, urls []*URL, networkT
 
 				conn, err := listenUDPInPortRange(a.net, a.log, int(a.portmax), int(a.portmin), network, &net.UDPAddr{IP: nil, Port: 0})
 				if err != nil {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to listen for %s: %v\n", serverAddr.String(), err))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to listen for %s: %v", serverAddr.String(), err))
 					return
 				}
 				// If the agent closes midway through the connection
@@ -471,7 +471,7 @@ func (a *Agent) gatherCandidatesSrflx(ctx context.Context, urls []*URL, networkT
 
 				xoraddr, err := getXORMappedAddr(conn, serverAddr, stunGatherTimeout)
 				if err != nil {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("could not get server reflexive address %s %s: %v\n", network, url, err))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("could not get server reflexive address %s %s: %v", network, url, err))
 					return
 				}
 
@@ -489,7 +489,7 @@ func (a *Agent) gatherCandidatesSrflx(ctx context.Context, urls []*URL, networkT
 				}
 				c, err := NewCandidateServerReflexive(&srflxConfig)
 				if err != nil {
-					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v\n", network, ip, port, err))
+					closeConnAndLog(conn, a.log, fmt.Sprintf("Failed to create server reflexive candidate: %s %s %d: %v", network, ip, port, err))
 					return
 				}
 
@@ -497,7 +497,7 @@ func (a *Agent) gatherCandidatesSrflx(ctx context.Context, urls []*URL, networkT
 					if closeErr := c.close(); closeErr != nil {
 						a.log.Warnf("Failed to close candidate: %v", closeErr)
 					}
-					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
+					a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
 				}
 			}(*urls[i], networkType.String())
 		}
@@ -536,7 +536,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 			switch {
 			case url.Proto == ProtoTypeUDP && url.Scheme == SchemeTypeTURN:
 				if locConn, err = a.net.ListenPacket(network, "0.0.0.0:0"); err != nil {
-					a.log.Warnf("Failed to listen %s: %v\n", network, err)
+					a.log.Warnf("Failed to listen %s: %v", network, err)
 					return
 				}
 
@@ -547,7 +547,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				(url.Scheme == SchemeTypeTURN || url.Scheme == SchemeTypeTURNS):
 				conn, connectErr := a.proxyDialer.Dial(NetworkTypeTCP4.String(), TURNServerAddr)
 				if connectErr != nil {
-					a.log.Warnf("Failed to Dial TCP Addr %s via proxy dialer: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to Dial TCP Addr %s via proxy dialer: %v", TURNServerAddr, connectErr)
 					return
 				}
 
@@ -563,13 +563,13 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 			case url.Proto == ProtoTypeTCP && url.Scheme == SchemeTypeTURN:
 				tcpAddr, connectErr := net.ResolveTCPAddr(NetworkTypeTCP4.String(), TURNServerAddr)
 				if connectErr != nil {
-					a.log.Warnf("Failed to resolve TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to resolve TCP Addr %s: %v", TURNServerAddr, connectErr)
 					return
 				}
 
 				conn, connectErr := net.DialTCP(NetworkTypeTCP4.String(), nil, tcpAddr)
 				if connectErr != nil {
-					a.log.Warnf("Failed to Dial TCP Addr %s: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to Dial TCP Addr %s: %v", TURNServerAddr, connectErr)
 					return
 				}
 
@@ -580,7 +580,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 			case url.Proto == ProtoTypeUDP && url.Scheme == SchemeTypeTURNS:
 				udpAddr, connectErr := net.ResolveUDPAddr(network, TURNServerAddr)
 				if connectErr != nil {
-					a.log.Warnf("Failed to resolve UDP Addr %s: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to resolve UDP Addr %s: %v", TURNServerAddr, connectErr)
 					return
 				}
 
@@ -589,7 +589,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 					InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
 				})
 				if connectErr != nil {
-					a.log.Warnf("Failed to Dial DTLS Addr %s: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to Dial DTLS Addr %s: %v", TURNServerAddr, connectErr)
 					return
 				}
 
@@ -602,7 +602,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 					InsecureSkipVerify: a.insecureSkipVerify, //nolint:gosec
 				})
 				if connectErr != nil {
-					a.log.Warnf("Failed to Dial TLS Addr %s: %v\n", TURNServerAddr, connectErr)
+					a.log.Warnf("Failed to Dial TLS Addr %s: %v", TURNServerAddr, connectErr)
 					return
 				}
 				RelAddr = conn.LocalAddr().(*net.TCPAddr).IP.String() //nolint:forcetypeassert
@@ -610,7 +610,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				relayProtocol = "tls"
 				locConn = turn.NewSTUNConn(conn)
 			default:
-				a.log.Warnf("Unable to handle URL in gatherCandidatesRelay %v\n", url)
+				a.log.Warnf("Unable to handle URL in gatherCandidatesRelay %v", url)
 				return
 			}
 
@@ -623,20 +623,20 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				Net:            a.net,
 			})
 			if err != nil {
-				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to build new turn.Client %s %s\n", TURNServerAddr, err))
+				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to build new turn.Client %s %s", TURNServerAddr, err))
 				return
 			}
 
 			if err = client.Listen(); err != nil {
 				client.Close()
-				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to listen on turn.Client %s %s\n", TURNServerAddr, err))
+				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to listen on turn.Client %s %s", TURNServerAddr, err))
 				return
 			}
 
 			relayConn, err := client.Allocate()
 			if err != nil {
 				client.Close()
-				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to allocate on turn.Client %s %s\n", TURNServerAddr, err))
+				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to allocate on turn.Client %s %s", TURNServerAddr, err))
 				return
 			}
 
@@ -664,7 +664,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				relayConnClose()
 
 				client.Close()
-				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to create relay candidate: %s %s: %v\n", network, raddr.String(), err))
+				closeConnAndLog(locConn, a.log, fmt.Sprintf("Failed to create relay candidate: %s %s: %v", network, raddr.String(), err))
 				return
 			}
 
@@ -674,7 +674,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*URL) { //noli
 				if closeErr := candidate.close(); closeErr != nil {
 					a.log.Warnf("Failed to close candidate: %v", closeErr)
 				}
-				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v\n", err)
+				a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
 			}
 		}(*urls[i])
 	}

--- a/gather.go
+++ b/gather.go
@@ -144,7 +144,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 	// when UDPMux is enabled, skip other UDP candidates
 	if a.udpMux != nil {
 		if err := a.gatherCandidatesLocalUDPMux(ctx); err != nil {
-			a.log.Warnf("could not create host candidate for UDPMux")
+			a.log.Warnf("could not create host candidate for UDPMux: %s", err)
 		}
 		delete(networks, udp)
 	}

--- a/selection.go
+++ b/selection.go
@@ -84,7 +84,7 @@ func (s *controllingSelector) nominatePair(pair *CandidatePair) {
 		return
 	}
 
-	s.log.Tracef("ping STUN (nominate candidate pair) from %s to %s\n", pair.Local.String(), pair.Remote.String())
+	s.log.Tracef("ping STUN (nominate candidate pair) from %s to %s", pair.Local.String(), pair.Remote.String())
 	s.agent.sendBindingRequest(msg, pair.Local, pair.Remote)
 }
 
@@ -101,9 +101,9 @@ func (s *controllingSelector) HandleBindingRequest(m *stun.Message, local, remot
 	if p.state == CandidatePairStateSucceeded && s.nominatedPair == nil && s.agent.getSelectedPair() == nil {
 		bestPair := s.agent.getBestAvailableCandidatePair()
 		if bestPair == nil {
-			s.log.Tracef("No best pair available\n")
+			s.log.Tracef("No best pair available")
 		} else if bestPair.equal(p) && s.isNominatable(p.Local) && s.isNominatable(p.Remote) {
-			s.log.Tracef("The candidate (%s, %s) is the best candidate available, marking it as nominated\n",
+			s.log.Tracef("The candidate (%s, %s) is the best candidate available, marking it as nominated",
 				p.Local.String(), p.Remote.String())
 			s.nominatedPair = p
 			s.nominatePair(p)

--- a/tcp_mux.go
+++ b/tcp_mux.go
@@ -86,11 +86,11 @@ func NewTCPMuxDefault(params TCPMuxParams) *TCPMuxDefault {
 }
 
 func (m *TCPMuxDefault) start() {
-	m.params.Logger.Infof("Listening TCP on %s\n", m.params.Listener.Addr())
+	m.params.Logger.Infof("Listening TCP on %s", m.params.Listener.Addr())
 	for {
 		conn, err := m.params.Listener.Accept()
 		if err != nil {
-			m.params.Logger.Infof("Error accepting connection: %s\n", err)
+			m.params.Logger.Infof("Error accepting connection: %s", err)
 			return
 		}
 
@@ -173,29 +173,29 @@ func (m *TCPMuxDefault) handleConn(conn net.Conn) {
 	copy(msg.Raw, buf)
 	if err = msg.Decode(); err != nil {
 		m.closeAndLogError(conn)
-		m.params.Logger.Warnf("Failed to handle decode ICE from %s to %s: %v\n", conn.RemoteAddr(), conn.LocalAddr(), err)
+		m.params.Logger.Warnf("Failed to handle decode ICE from %s to %s: %v", conn.RemoteAddr(), conn.LocalAddr(), err)
 		return
 	}
 
 	if m == nil || msg.Type.Method != stun.MethodBinding { // not a stun
 		m.closeAndLogError(conn)
-		m.params.Logger.Warnf("Not a STUN message from %s to %s\n", conn.RemoteAddr(), conn.LocalAddr())
+		m.params.Logger.Warnf("Not a STUN message from %s to %s", conn.RemoteAddr(), conn.LocalAddr())
 		return
 	}
 
 	for _, attr := range msg.Attributes {
-		m.params.Logger.Debugf("msg attr: %s\n", attr.String())
+		m.params.Logger.Debugf("msg attr: %s", attr.String())
 	}
 
 	attr, err := msg.Get(stun.AttrUsername)
 	if err != nil {
 		m.closeAndLogError(conn)
-		m.params.Logger.Warnf("No Username attribute in STUN message from %s to %s\n", conn.RemoteAddr(), conn.LocalAddr())
+		m.params.Logger.Warnf("No Username attribute in STUN message from %s to %s", conn.RemoteAddr(), conn.LocalAddr())
 		return
 	}
 
 	ufrag := strings.Split(string(attr), ":")[0]
-	m.params.Logger.Debugf("Ufrag: %s\n", ufrag)
+	m.params.Logger.Debugf("Ufrag: %s", ufrag)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -203,7 +203,7 @@ func (m *TCPMuxDefault) handleConn(conn net.Conn) {
 	host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
 	if err != nil {
 		m.closeAndLogError(conn)
-		m.params.Logger.Warnf("Failed to get host in STUN message from %s to %s\n", conn.RemoteAddr(), conn.LocalAddr())
+		m.params.Logger.Warnf("Failed to get host in STUN message from %s to %s", conn.RemoteAddr(), conn.LocalAddr())
 		return
 	}
 
@@ -215,7 +215,7 @@ func (m *TCPMuxDefault) handleConn(conn net.Conn) {
 
 	if err := packetConn.AddConn(conn, buf); err != nil {
 		m.closeAndLogError(conn)
-		m.params.Logger.Warnf("Error adding conn to tcpPacketConn from %s to %s: %s\n", conn.RemoteAddr(), conn.LocalAddr(), err)
+		m.params.Logger.Warnf("Error adding conn to tcpPacketConn from %s to %s: %s", conn.RemoteAddr(), conn.LocalAddr(), err)
 		return
 	}
 }

--- a/tcp_packet_conn.go
+++ b/tcp_packet_conn.go
@@ -86,7 +86,7 @@ func (t *tcpPacketConn) startReading(conn net.Conn) {
 		n, err := readStreamingPacket(conn, buf)
 		// t.params.Logger.Infof("readStreamingPacket read %d bytes", n)
 		if err != nil {
-			t.params.Logger.Infof("%w: %s\n", errReadingStreamingPacket, err)
+			t.params.Logger.Infof("%w: %s", errReadingStreamingPacket, err)
 			t.handleRecv(streamingPacket{nil, conn.RemoteAddr(), err})
 			t.removeConn(conn)
 			return
@@ -167,7 +167,7 @@ func (t *tcpPacketConn) WriteTo(buf []byte, raddr net.Addr) (n int, err error) {
 
 	n, err = writeStreamingPacket(conn, buf)
 	if err != nil {
-		t.params.Logger.Tracef("%w %s\n", errWriting, raddr)
+		t.params.Logger.Tracef("%w %s", errWriting, raddr)
 		return n, err
 	}
 

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -268,13 +268,13 @@ func (m *UDPMuxDefault) connWorker() {
 			}
 
 			if err = msg.Decode(); err != nil {
-				m.params.Logger.Warnf("Failed to handle decode ICE from %s: %v\n", addr.String(), err)
+				m.params.Logger.Warnf("Failed to handle decode ICE from %s: %v", addr.String(), err)
 				continue
 			}
 
 			attr, stunAttrErr := msg.Get(stun.AttrUsername)
 			if stunAttrErr != nil {
-				m.params.Logger.Warnf("No Username attribute in STUN message from %s\n", addr.String())
+				m.params.Logger.Warnf("No Username attribute in STUN message from %s", addr.String())
 				continue
 			}
 

--- a/udp_mux_universal.go
+++ b/udp_mux_universal.go
@@ -102,7 +102,7 @@ func (c *udpConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 		}
 
 		if err = msg.Decode(); err != nil {
-			c.logger.Warnf("Failed to handle decode ICE from %s: %v\n", addr.String(), err)
+			c.logger.Warnf("Failed to handle decode ICE from %s: %v", addr.String(), err)
 			return n, addr, nil
 		}
 


### PR DESCRIPTION
This PR harmonizes the use of newlines in log statements.

My custom logger was a little confused by a mix of logging statements with and without newlines.