### PR TITLE
fix: UDPMux memory leaks

### DIFF
--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -112,9 +112,6 @@ func (c *udpMuxedConn) Close() error {
 		err = c.buffer.Close()
 		close(c.closedChan)
 	})
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.addresses = nil
 	return err
 }
 


### PR DESCRIPTION
This PR fixes memory leaks I noticed with my SFU deployment.

- Clients performing an early termination/cancelation would cause `udpMuxedConn` to
leak addresses into `UDPMuxDefault`.
  - A call to `(udpMuxedConn).Close()` would set `(udpMuxedConn).addresses` to `nil`, which prevented their deletion from `(UDPMuxDefault).addressMap`
- Small refacto of `UDPMuxDefault` that replaces `removeConn` by `RemoveConnByUfrag`
- Before that the gatherer would ignore some host candidates
  - I can submit the `gather.go` updates in a separate PR if it helps land this one faster 