### PR TITLE
IpMapper return locIP if corresponding map not set

### DIFF
--- a/external_ip_mapper.go
+++ b/external_ip_mapper.go
@@ -17,6 +17,7 @@ func validateIPString(ipStr string) (net.IP, bool, error) {
 type ipMapping struct {
 	ipSole net.IP            // when non-nil, this is the sole external IP for one local IP assumed
 	ipMap  map[string]net.IP // local-to-external IP mapping (k: local, v: external)
+	valid  bool              // if not set any external IP, valid is false
 }
 
 func (m *ipMapping) setSoleIP(ip net.IP) error {
@@ -25,6 +26,7 @@ func (m *ipMapping) setSoleIP(ip net.IP) error {
 	}
 
 	m.ipSole = ip
+	m.valid = true
 
 	return nil
 }
@@ -42,11 +44,16 @@ func (m *ipMapping) addIPMapping(locIP, extIP net.IP) error {
 	}
 
 	m.ipMap[locIPStr] = extIP
+	m.valid = true
 
 	return nil
 }
 
 func (m *ipMapping) findExternalIP(locIP net.IP) (net.IP, error) {
+	if !m.valid {
+		return locIP, nil
+	}
+
 	if m.ipSole != nil {
 		return m.ipSole, nil
 	}

--- a/external_ip_mapper_test.go
+++ b/external_ip_mapper_test.go
@@ -289,8 +289,9 @@ func TestExternalIPMapper(t *testing.T) {
 		assert.NoError(t, err, "should succeed")
 
 		// attempt to find IPv6 that does not exist in the map
-		_, err = m.findExternalIP("fe80::1")
-		assert.Error(t, err, "should fail")
+		extIP, err := m.findExternalIP("fe80::1")
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, "fe80::1", extIP.String(), "should match")
 
 		m, err = newExternalIPMapper(CandidateTypeUnspecified, []string{
 			"2200::1",
@@ -298,7 +299,8 @@ func TestExternalIPMapper(t *testing.T) {
 		assert.NoError(t, err, "should succeed")
 
 		// attempt to find IPv4 that does not exist in the map
-		_, err = m.findExternalIP("10.0.0.1")
-		assert.Error(t, err, "should fail")
+		extIP, err = m.findExternalIP("10.0.0.1")
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, "10.0.0.1", extIP.String(), "should match")
 	})
 }


### PR DESCRIPTION
#### Description
If we only set v4 or v6 NAT1to1Mapping, then findExternalIP will failed for the unset ip mapper, the gatherer will complain 1:1 NAT mapping is enabled but no external IP is found, cause that candidate for udp can't be gathered.

#### Reference issue
Fixes #...
