### PR TITLE
Fix udpmux not work on AWS/ECS

### DIFF
--- a/udp_mux.go
+++ b/udp_mux.go
@@ -365,13 +365,12 @@ func (m *UDPMuxDefault) connWorker() { //nolint:gocognit
 		var destinationConn *udpMuxedConn
 		m.addressMapMu.Lock()
 		if conns, ok := m.addressMap[addr.String()]; ok {
-			if localHost.IsUnspecified() {
+			destinationConn, ok = conns[ipAddr(localHost.String())]
+			if !ok {
 				for _, c := range conns {
 					destinationConn = c
 					break
 				}
-			} else {
-				destinationConn = conns[ipAddr(localHost.String())]
 			}
 		}
 		m.addressMapMu.Unlock()


### PR DESCRIPTION
ECS network might not set destination address of udp packet to local address, so we can't only rely on it to dispatch packet.

related to https://github.com/livekit/livekit/pull/1036 user report