### PR TITLE
Change writeTo failed log level to info

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -300,7 +300,7 @@ func (c *candidateBase) close() error {
 func (c *candidateBase) writeTo(raw []byte, dst Candidate) (int, error) {
 	n, err := c.conn.WriteTo(raw, dst.addr())
 	if err != nil {
-		c.agent().log.Warnf("%s: %v", errSendPacket, err)
+		c.agent().log.Infof("%s: %v", errSendPacket, err)
 		return n, nil
 	}
 	c.seen(true)


### PR DESCRIPTION
In #252 decide to ignore the writeTo failed error with a log, application can choose callback and query state for the connection state. But if application keep sending packet during try ice restart to recover from ICEFailed, the warn log is annoying since the error is not critical and no need to process. So change it to info.

#### Description
When application get ice failed and try negotiation with ice restart to recover from failed state, but keep sending packets during recover, there will be a bunch of `use of closed network connection` warn log. 
#### Reference issue
#252
