### PR TITLE
Close connection if candidates already exist

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -824,6 +824,9 @@ func (a *Agent) addCandidate(ctx context.Context, c Candidate, candidateConn net
 				if err := c.close(); err != nil {
 					a.log.Warnf("Failed to close duplicate candidate: %v", err)
 				}
+				if err := candidateConn.Close(); err != nil {
+					a.log.Warnf("Failed to close duplicate candidate connection: %v", err)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
#### Description
When duplicate candidates have been added (both NATMapping and UDPMux enabled), the candidate connection should be closed with the ignored candidate, otherwise, resource is leaked.

#### Reference issue
Fixes #...
