### PR TITLE
Add option to include loopback candidate

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -130,6 +130,7 @@ type Agent struct {
 
 	interfaceFilter func(string) bool
 	ipFilter        func(net.IP) bool
+	includeLoopback bool
 
 	insecureSkipVerify bool
 
@@ -317,6 +318,8 @@ func NewAgent(config *AgentConfig) (*Agent, error) { //nolint:gocognit
 		ipFilter: config.IPFilter,
 
 		insecureSkipVerify: config.InsecureSkipVerify,
+
+		includeLoopback: config.IncludeLoopback,
 	}
 
 	a.tcpMux = config.TCPMux

--- a/agent_config.go
+++ b/agent_config.go
@@ -165,8 +165,11 @@ type AgentConfig struct {
 	// dial interface in order to support corporate proxies
 	ProxyDialer proxy.Dialer
 
-	// Accept aggressive nomination in RFC 5245 for compatible with chrome and other browsers
+	// Deprecated: AcceptAggressiveNomination always enabled.
 	AcceptAggressiveNomination bool
+
+	// Include loopback addresses in the candidate list.
+	IncludeLoopback bool
 }
 
 // initWithDefaults populates an agent and falls back to defaults if fields are unset

--- a/gather.go
+++ b/gather.go
@@ -149,7 +149,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 		delete(networks, udp)
 	}
 
-	localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, networkTypes)
+	localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, networkTypes, a.includeLoopback)
 	if err != nil {
 		a.log.Warnf("failed to iterate local interfaces, host candidates will not be gathered %s", err)
 		return

--- a/gather_vnet_test.go
+++ b/gather_vnet_test.go
@@ -29,7 +29,7 @@ func TestVNetGather(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if len(localIPs) > 0 {
 			t.Fatal("should return no local IP")
 		} else if err != nil {
@@ -69,7 +69,7 @@ func TestVNetGather(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if len(localIPs) == 0 {
 			t.Fatal("should have one local IP")
 		} else if err != nil {
@@ -112,7 +112,7 @@ func TestVNetGather(t *testing.T) {
 			t.Fatalf("Failed to create agent: %s", err)
 		}
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if len(localIPs) == 0 {
 			t.Fatal("localInterfaces found no interfaces, unable to test")
 		} else if err != nil {
@@ -385,7 +385,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if err != nil {
 			t.Fatal(err)
 		} else if len(localIPs) != 0 {
@@ -405,7 +405,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if err != nil {
 			t.Fatal(err)
 		} else if len(localIPs) != 0 {
@@ -425,7 +425,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4})
+		localIPs, err := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, []NetworkType{NetworkTypeUDP4}, false)
 		if err != nil {
 			t.Fatal(err)
 		} else if len(localIPs) == 0 {

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -78,7 +78,7 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 		}
 		if len(networks) > 0 {
 			muxNet := vnet.NewNet(nil)
-			ips, err := localInterfaces(muxNet, nil, nil, networks)
+			ips, err := localInterfaces(muxNet, nil, nil, networks, true)
 			if err == nil {
 				for _, ip := range ips {
 					localAddrsForUnspecified = append(localAddrsForUnspecified, &net.UDPAddr{IP: ip, Port: addr.Port})

--- a/udp_mux_multi.go
+++ b/udp_mux_multi.go
@@ -81,7 +81,7 @@ func NewMultiUDPMuxFromPort(port int, opts ...UDPMuxFromPortOption) (*MultiUDPMu
 		opt.apply(&params)
 	}
 	muxNet := vnet.NewNet(nil)
-	ips, err := localInterfaces(muxNet, params.ifFilter, params.ipFilter, params.networks)
+	ips, err := localInterfaces(muxNet, params.ifFilter, params.ipFilter, params.networks, params.includeLoopback)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +130,7 @@ type multiUDPMuxFromPortParam struct {
 	readBufferSize  int
 	writeBufferSize int
 	logger          logging.LeveledLogger
+	includeLoopback bool
 }
 
 type udpMuxFromPortOption struct {
@@ -190,6 +191,15 @@ func UDPMuxFromPortWithLogger(logger logging.LeveledLogger) UDPMuxFromPortOption
 	return &udpMuxFromPortOption{
 		f: func(p *multiUDPMuxFromPortParam) {
 			p.logger = logger
+		},
+	}
+}
+
+// UDPMuxFromPortWithLoopback set loopback interface should be included
+func UDPMuxFromPortWithLoopback() UDPMuxFromPortOption {
+	return &udpMuxFromPortOption{
+		f: func(p *multiUDPMuxFromPortParam) {
+			p.includeLoopback = true
 		},
 	}
 }

--- a/util.go
+++ b/util.go
@@ -132,7 +132,7 @@ func stunRequest(read func([]byte) (int, error), write func([]byte) (int, error)
 	return res, nil
 }
 
-func localInterfaces(vnet *vnet.Net, interfaceFilter func(string) bool, ipFilter func(net.IP) bool, networkTypes []NetworkType) ([]net.IP, error) { //nolint:gocognit
+func localInterfaces(vnet *vnet.Net, interfaceFilter func(string) bool, ipFilter func(net.IP) bool, networkTypes []NetworkType, includeLoopback bool) ([]net.IP, error) { //nolint:gocognit
 	ips := []net.IP{}
 	ifaces, err := vnet.Interfaces()
 	if err != nil {
@@ -154,7 +154,7 @@ func localInterfaces(vnet *vnet.Net, interfaceFilter func(string) bool, ipFilter
 		if iface.Flags&net.FlagUp == 0 {
 			continue // interface down
 		}
-		if iface.Flags&net.FlagLoopback != 0 {
+		if (iface.Flags&net.FlagLoopback != 0) && !includeLoopback {
 			continue // loopback interface
 		}
 
@@ -175,7 +175,7 @@ func localInterfaces(vnet *vnet.Net, interfaceFilter func(string) bool, ipFilter
 			case *net.IPAddr:
 				ip = addr.IP
 			}
-			if ip == nil || ip.IsLoopback() {
+			if ip == nil || (ip.IsLoopback() && !includeLoopback) {
 				continue
 			}
 


### PR DESCRIPTION
#### Description
User report that VM's public ip has been mapped to loopback interface, but pion doesn't listen/collect the loopback interface cause it can't establish the connection. This PR adds an option to enable loopback interface candidates.

#### Reference issue
Fixes #494 
