### PR TITLE
Add aggressive nomination when nominateOnBindingSuccess

### DIFF
--- a/selection.go
+++ b/selection.go
@@ -230,8 +230,11 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)
 	if p.nominateOnBindingSuccess {
-		if selectedPair := s.agent.getSelectedPair(); selectedPair == nil {
+		if selectedPair := s.agent.getSelectedPair(); selectedPair == nil ||
+			(selectedPair != p && selectedPair.priority() <= p.priority()) {
 			s.agent.setSelectedPair(p)
+		} else if selectedPair != p {
+			s.log.Tracef("ignore nominate new pair %s, already nominated pair %s", p, selectedPair)
 		}
 	}
 }


### PR DESCRIPTION
#### Description

we are not working in case aggressive nomination in firefox in vpn 

#### Reference issue
related PR
https://github.com/pion/ice/pull/441
https://github.com/pion/ice/pull/446


I thinks Fix is missing.

Add aggressive nomination when nominateOnBindingSuccess

Now in case aggressive nomination in firefox we are working well 