### PR TITLE
Fix IPv6 formatting in Candidate.String()

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -344,7 +344,7 @@ func (c *candidateBase) Equal(other Candidate) bool {
 
 // String makes the candidateBase printable
 func (c *candidateBase) String() string {
-	return fmt.Sprintf("%s %s %s:%d%s", c.NetworkType(), c.Type(), c.Address(), c.Port(), c.relatedAddress)
+	return fmt.Sprintf("%s %s %s%s", c.NetworkType(), c.Type(), net.JoinHostPort(c.Address(), strconv.Itoa(c.Port())), c.relatedAddress)
 }
 
 // LastReceived returns a time.Time indicating the last time


### PR DESCRIPTION
A `Candidate` with IPv6 address was formatted similar to `fe80::1:51820`.
`net.JoinHostPort` will add `[` `]` around the address if it's IPv6, so it would look like `[fe80::1]:51820` instead.