### PR TITLE
Fix TestUnspecifiedUDPMux

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Adam Kiss <masterada@gmail.com>
 adwpc <adwpc@hotmail.com>
 Aleksandr Razumov <ar@gortc.io>
 Antoine Baché <antoine@tenten.app>
+Artur Shellunts <shellunts.artur@gmail.com>
 Assad Obaid <assad@lap5cg901003r.se.axis.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>

--- a/udp_mux_multi_test.go
+++ b/udp_mux_multi_test.go
@@ -116,7 +116,9 @@ func TestUnspecifiedUDPMux(t *testing.T) {
 
 	muxPort := 7778
 	udpMuxMulti, err := NewMultiUDPMuxFromPort(muxPort, UDPMuxFromPortWithInterfaceFilter(func(s string) bool {
-		return !strings.Contains(s, "docker")
+		defaultDockerBridgeNetwork := strings.Contains(s, "docker")
+		customDockerBridgeNetwork := strings.Contains(s, "br-")
+		return !defaultDockerBridgeNetwork && !customDockerBridgeNetwork
 	}))
 	require.NoError(t, err)
 


### PR DESCRIPTION
filter out all docker bridge networks, not only default one

Fixes #523 