### PR TITLE
Fix type of CandidatePairState constants

### DIFF
--- a/candidatepair_state.go
+++ b/candidatepair_state.go
@@ -9,7 +9,7 @@ type CandidatePairState int
 const (
 	// CandidatePairStateWaiting means a check has not been performed for
 	// this pair
-	CandidatePairStateWaiting = iota + 1
+	CandidatePairStateWaiting CandidatePairState = iota + 1
 
 	// CandidatePairStateInProgress means a check has been sent for this pair,
 	// but the transaction is in progress.


### PR DESCRIPTION
Fixes #571 

@Sean-Der This is another unfortunate instance of an untyped enum. What do you think about fixing this instance as well?

It will break the API, however just like already had to do for the `ConnectionState` enum.

See also: https://github.com/pion/webrtc/pull/2471#issuecomment-1546976185