### PR TITLE
fix: use global id generator to reduce allocations

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Adam Kiss <masterada@gmail.com>
 adwpc <adwpc@hotmail.com>
 Aleksandr Razumov <ar@gortc.io>
 aler9 <46489434+aler9@users.noreply.github.com>
+Anshul <malikanshul29@gmail.com>
 Antoine Baché <antoine@tenten.app>
 Artur Shellunts <shellunts.artur@gmail.com>
 Assad Obaid <assad@lap5cg901003r.se.axis.com>

--- a/candidate_peer_reflexive.go
+++ b/candidate_peer_reflexive.go
@@ -39,9 +39,8 @@ func NewCandidatePeerReflexive(config *CandidatePeerReflexiveConfig) (*Candidate
 	}
 
 	candidateID := config.CandidateID
-	candidateIDGenerator := newCandidateIDGenerator()
 	if candidateID == "" {
-		candidateID = candidateIDGenerator.Generate()
+		candidateID = globalCandidateIDGenerator.Generate()
 	}
 
 	return &CandidatePeerReflexive{


### PR DESCRIPTION
#### newCandidateIDGenerator allocates lot of memory into heap.

Reference: https://github.com/pion/randutil/pull/25