### PR TITLE
Add `GetRemoteCandidates()`

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -838,6 +838,24 @@ func (a *Agent) addCandidate(ctx context.Context, c Candidate, candidateConn net
 	})
 }
 
+// GetRemoteCandidates returns the remote candidates
+func (a *Agent) GetRemoteCandidates() ([]Candidate, error) {
+	var res []Candidate
+
+	err := a.run(a.context(), func(ctx context.Context, agent *Agent) {
+		var candidates []Candidate
+		for _, set := range agent.remoteCandidates {
+			candidates = append(candidates, set...)
+		}
+		res = candidates
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // GetLocalCandidates returns the local candidates
 func (a *Agent) GetLocalCandidates() ([]Candidate, error) {
 	var res []Candidate

--- a/agent_test.go
+++ b/agent_test.go
@@ -1322,6 +1322,74 @@ func TestGetRemoteCredentials(t *testing.T) {
 	assert.NoError(t, a.Close())
 }
 
+func TestGetRemoteCandidates(t *testing.T) {
+	var config AgentConfig
+
+	a, err := NewAgent(&config)
+	if err != nil {
+		t.Fatalf("Error constructing ice.Agent: %v", err)
+	}
+
+	expectedCandidates := []Candidate{}
+
+	for i := 0; i < 5; i++ {
+		cfg := CandidateHostConfig{
+			Network:   "udp",
+			Address:   "192.168.0.2",
+			Port:      1000 + i,
+			Component: 1,
+		}
+
+		cand, errCand := NewCandidateHost(&cfg)
+		assert.NoError(t, errCand)
+
+		expectedCandidates = append(expectedCandidates, cand)
+
+		a.addRemoteCandidate(cand)
+	}
+
+	actualCandidates, err := a.GetRemoteCandidates()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedCandidates, actualCandidates)
+
+	assert.NoError(t, a.Close())
+}
+
+func TestGetLocalCandidates(t *testing.T) {
+	var config AgentConfig
+
+	a, err := NewAgent(&config)
+	if err != nil {
+		t.Fatalf("Error constructing ice.Agent: %v", err)
+	}
+
+	dummyConn := &net.UDPConn{}
+	expectedCandidates := []Candidate{}
+
+	for i := 0; i < 5; i++ {
+		cfg := CandidateHostConfig{
+			Network:   "udp",
+			Address:   "192.168.0.2",
+			Port:      1000 + i,
+			Component: 1,
+		}
+
+		cand, errCand := NewCandidateHost(&cfg)
+		assert.NoError(t, errCand)
+
+		expectedCandidates = append(expectedCandidates, cand)
+
+		err = a.addCandidate(context.Background(), cand, dummyConn)
+		assert.NoError(t, err)
+	}
+
+	actualCandidates, err := a.GetLocalCandidates()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedCandidates, actualCandidates)
+
+	assert.NoError(t, a.Close())
+}
+
 func TestCloseInConnectionStateCallback(t *testing.T) {
 	report := test.CheckRoutines(t)
 	defer report()


### PR DESCRIPTION
This is analogue to `GetLocalCandidates()` and provides the user with the ability to get a slice of previously added remote candidates without keeping track of them in the application code.

