### PR TITLE
Fix connection close log

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -32,7 +32,7 @@ func closeConnAndLog(c io.Closer, log logging.LeveledLogger, msg string, args ..
 		return
 	}
 
-	log.Warnf(msg)
+	log.Warnf(msg, args...)
 	if err := c.Close(); err != nil {
 		log.Warnf("Failed to close connection: %v", err)
 	}


### PR DESCRIPTION
Printf arguments weren't passed to the logger.
