### PR TITLE
Clear selected pair on ICE failed

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -15,6 +15,7 @@ Artur Shellunts <shellunts.artur@gmail.com>
 Assad Obaid <assad@lap5cg901003r.se.axis.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
+boks1971 <raja.gobi@tutanota.com>
 buptczq <czq@qq.com>
 cgojin <gongjin21@hotmail.com>
 Chao Yuan <yuanchao0310@163.com>

--- a/agent.go
+++ b/agent.go
@@ -494,6 +494,10 @@ func (a *Agent) updateConnectionState(newState ConnectionState) {
 	if a.connectionState != newState {
 		// Connection has gone to failed, release all gathered candidates
 		if newState == ConnectionStateFailed {
+			a.removeUfragFromMux()
+			a.checklist = make([]*CandidatePair, 0)
+			a.pendingBindingRequests = make([]bindingRequest, 0)
+			a.setSelectedPair(nil)
 			a.deleteAllCandidates()
 		}
 


### PR DESCRIPTION
When ICE times out and fails, all candidates are deleted.

That means all the candidates are closed and their underlying conns are clsoed.

But, the selected pair could still be valid. On a subsequenct `Write`, ICE transport conn will get the selected pair and write to the pair. As the pair is still valid, write will flow through to the local candidate `writeTo`.

But, as all candidates and their underlying conns are closed, `Write` will return a `io.ErrClosedPipe` error.

There are cases where it is not ignored and causes a broken pipe after an ICERestart.

When the `Write` error propagates back to sctp/association, the writeLoop is exited.

So, sending data channel traffic after a successful ICERestart still fails as the SCTP association errored out and write loop exited.

I have copied the changes that are done when ICERestart happens to when ICE state is set to failed (except for gathering state and resetting ufrag/pwd). In my testing, it is working well, i. e. can continue data channel after ICE Restart whereas previously it was failing every time. But, I am not sure of all the implications of this change.