### PR TITLE
Only propagate connection closure errors for the last connection.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -46,6 +46,7 @@ Michael MacDonald <mike.macdonald@savantsystems.com>
 Mikhail Bragin <misha@wiretrustee.com>
 Miroslav Šedivý <sedivy.miro@gmail.com>
 Nevio Vesic <nevio@subspace.com>
+Ondrej Sery <sery.ondra@gmail.com>
 Ori Bernstein <ori@eigenstate.org>
 Raja Subramanian <raja.gobi@tutanota.com>
 Rasmus Hanning <rasmus@hanning.se>


### PR DESCRIPTION
#### Description

Safari and iOS Chrome (WebKit) sometimes opens multiple TCP connections that end up being part of the same `tcpPacketConn` object in `TCPMuxDefault`. After some time, the extra connection is closed even thought the main one is still operational. In this case, the entire peer connection gets disconnected. Instead, we probably only want to close the entire connection only once there is no other open TCP connection (this PR).

To be honest, I am not sure why Safari and iOS Chrome do this. However, there is probably no chance fixing it there.

#### Log

Attaching a log of the duplicite connection that ends up in the same `tcpPacketConn` made by iOS Chrome:

```
ice INFO: 2023/09/05 09:43:21 Listening TCP on 0.0.0.0:443
pc INFO: 2023/09/05 09:45:35 signaling state changed to have-remote-offer
ice WARNING: 2023/09/05 09:45:35 Remote mDNS candidate added, but mDNS is disabled: (ed21691b-019d-463b-b886-431beca78eb2.local)
ice WARNING: 2023/09/05 09:45:35 Remote mDNS candidate added, but mDNS is disabled: (841e3f8c-3a67-4510-b333-bfb3182f24cf.local)
ice INFO: 2023/09/05 09:45:35 Ignoring remote candidate with tcpType active: udp4 host ed21691b-019d-463b-b886-431beca78eb2.local:9
ice WARNING: 2023/09/05 09:45:35 Remote mDNS candidate added, but mDNS is disabled: (030d6551-9311-4c9c-b31e-a1a31c0d3357.local)
ice WARNING: 2023/09/05 09:45:35 Remote mDNS candidate added, but mDNS is disabled: (4afe3c2f-aaaa-4d4e-9fee-e954d8e1f46c.local)
ice INFO: 2023/09/05 09:45:35 Ignoring remote candidate with tcpType active: udp4 host ed21691b-019d-463b-b886-431beca78eb2.local:9
ice DEBUG: 09:45:35.632916 agent.go:397: Started agent: isControlling? false, remoteUfrag: "GGzY", remotePwd: "*************"
pc INFO: 2023/09/05 09:45:35 signaling state changed to stable
ice INFO: 2023/09/05 09:45:35 Setting new connection state: Checking
ice WARNING: 2023/09/05 09:45:35 Failed to ping without candidate pairs. Connection is not possible yet.
pc INFO: 2023/09/05 09:45:35 ICE connection state changed: checking
pc INFO: 2023/09/05 09:45:35 peer connection state changed: connecting
ice DEBUG: 09:45:35.633141 gather.go:183: GetConn by ufrag: ItQRFFqisdhjWIKi
ice WARNING: 2023/09/05 09:45:35 Failed to ping without candidate pairs. Connection is not possible yet.
ice DEBUG: 09:45:35.668676 tcp_mux.go:88: Accepted connection from: 176.222.224.167:56798 to 100.65.107.240:443
ice DEBUG: 09:45:35.669445 tcp_mux.go:194: Message attribute: USERNAME: 0x49745152464671697364686a57494b693a47477a59
ice DEBUG: 09:45:35.669472 tcp_mux.go:194: Message attribute: 0xc057: 0x0001000a
ice DEBUG: 09:45:35.669494 tcp_mux.go:194: Message attribute: ICE-CONTROLLING: 0x94c252acb9d12b88
ice DEBUG: 09:45:35.669501 tcp_mux.go:194: Message attribute: USE-CANDIDATE: 0x
ice DEBUG: 09:45:35.669506 tcp_mux.go:194: Message attribute: PRIORITY: 0x507f1eff
ice DEBUG: 09:45:35.669518 tcp_mux.go:194: Message attribute: MESSAGE-INTEGRITY: 0x6da267994029de3011ae306451e06ec3dc203bfe
ice DEBUG: 09:45:35.669526 tcp_mux.go:194: Message attribute: FINGERPRINT: 0x02d274e5
ice DEBUG: 09:45:35.669531 tcp_mux.go:205: Ufrag: ItQRFFqisdhjWIKi
ice INFO: 2023/09/05 09:45:35 Added connection: tcp remote 176.222.224.167:56798 to local 100.65.107.240:443, map[string]net.Conn{}
ice DEBUG: 09:45:35.669680 agent.go:1126: Adding a new peer-reflexive candidate: tcp4 prflx 176.222.224.167:56798 related :0
ice DEBUG: 09:45:35.670750 tcp_mux.go:88: Accepted connection from: 176.222.224.167:56799 to 100.65.107.240:443
ice INFO: 2023/09/05 09:45:35 Setting new connection state: Connected
pc INFO: 2023/09/05 09:45:35 ICE connection state changed: connected
dtls DEBUG: 09:45:35.717953 conn.go:755: CipherSuite not initialized, queuing packet
dtls DEBUG: 09:45:35.717986 conn.go:678: received packet of next epoch, queuing packet
pc INFO: 2023/09/05 09:45:35 peer connection state changed: connected
sctp DEBUG: 09:45:35.718821 association.go:995: [0x4000efc780] state change: 'Closed' => 'CookieWait'
sctp DEBUG: 09:45:35.718831 association.go:370: [0x4000efc780] sending INIT
sctp DEBUG: 09:45:35.718866 association.go:531: [0x4000efc780] readLoop entered
sctp DEBUG: 09:45:35.718874 association.go:557: [0x4000efc780] writeLoop entered
sctp DEBUG: 09:45:35.741174 association.go:1059: [0x4000efc780] chunkInit received in state 'CookieWait'
sctp DEBUG: 09:45:35.741205 association.go:1092: [0x4000efc780] use ForwardTSN (on init)
sctp DEBUG: 09:45:35.741228 association.go:1134: [0x4000efc780] chunkInitAck received in state 'CookieWait'
sctp DEBUG: 09:45:35.741235 association.go:1156: [0x4000efc780] initial rwnd=5242880
sctp DEBUG: 09:45:35.741241 association.go:1177: [0x4000efc780] use ForwardTSN (on initAck)
sctp DEBUG: 09:45:35.741245 association.go:396: [0x4000efc780] sending COOKIE-ECHO
sctp DEBUG: 09:45:35.741254 association.go:995: [0x4000efc780] state change: 'CookieWait' => 'CookieEchoed'
sctp DEBUG: 09:45:35.757907 association.go:1228: [0x4000efc780] COOKIE-ECHO received in state 'CookieEchoed'
sctp DEBUG: 09:45:35.757943 association.go:995: [0x4000efc780] state change: 'CookieEchoed' => 'Established'
sctp DEBUG: 09:45:35.757955 association.go:1268: [0x4000efc780] COOKIE-ACK received in state 'Established'
sctp DEBUG: 09:45:35.758121 stream.go:199: [1:0x4000efc780] reassemblyQueue readable=true
sctp DEBUG: 09:45:35.758140 stream.go:201: [1:0x4000efc780] readNotifier.signal()
sctp DEBUG: 09:45:35.758144 stream.go:203: [1:0x4000efc780] readNotifier.signal() done
ice DEBUG: 09:45:35.819149 tcp_mux.go:194: Message attribute: USERNAME: 0x49745152464671697364686a57494b693a47477a59
ice DEBUG: 09:45:35.819179 tcp_mux.go:194: Message attribute: 0xc057: 0x0001000a
ice DEBUG: 09:45:35.819193 tcp_mux.go:194: Message attribute: ICE-CONTROLLING: 0x94c252acb9d12b88
ice DEBUG: 09:45:35.819220 tcp_mux.go:194: Message attribute: USE-CANDIDATE: 0x
ice DEBUG: 09:45:35.819225 tcp_mux.go:194: Message attribute: PRIORITY: 0x507f1eff
ice DEBUG: 09:45:35.819231 tcp_mux.go:194: Message attribute: MESSAGE-INTEGRITY: 0xe49ae5896ba2d3945f3f9f6df43b8d8250dd75b9
ice DEBUG: 09:45:35.819241 tcp_mux.go:194: Message attribute: FINGERPRINT: 0x2bfed698
ice DEBUG: 09:45:35.819246 tcp_mux.go:205: Ufrag: ItQRFFqisdhjWIKi
ice INFO: 2023/09/05 09:45:35 Added connection: tcp remote 176.222.224.167:56799 to local 100.65.107.240:443, map[string]net.Conn{"176.222.224.167:56798":(*ice.bufferedConn)(0x40012c14a0)}
ice DEBUG: 09:45:35.819368 agent.go:1126: Adding a new peer-reflexive candidate: tcp4 prflx 176.222.224.167:56799 related :0
sctp DEBUG: 09:45:35.959910 association.go:781: [0x4000efc780] sending SACK: SACK cumTsnAck=52496632 arwnd=1048576 dupTsn=[]
ice WARNING: 2023/09/05 09:46:05 Failed to read streaming packet: EOF
ice INFO: 2023/09/05 09:46:05 Removing connection: tcp remote 176.222.224.167:56799 to local 100.65.107.240:443, map[string]net.Conn{"176.222.224.167:56798":(*ice.bufferedConn)(0x40012c14a0), "176.222.224.167:56799":(*ice.bufferedConn)(0x40010d6600)}
ice WARNING: 2023/09/05 09:46:05 Failed to read from candidate tcp4 host 3.74.159.137:443: EOF
ice INFO: 2023/09/05 09:46:11 Setting new connection state: Disconnected
pc INFO: 2023/09/05 09:46:11 ICE connection state changed: disconnected
pc INFO: 2023/09/05 09:46:11 peer connection state changed: disconnected
sctp DEBUG: 09:46:11.829554 stream.go:345: [1:0x4000efc780] Close: state=open
sctp DEBUG: 09:46:11.829563 stream.go:353: [1:0x4000efc780] state change: open => closing
sctp DEBUG: 09:46:11.829601 association.go:446: [0x4000efc780] closing association..
sctp DEBUG: 09:46:11.829609 association.go:464: [0x4000efc780] closing association..
sctp DEBUG: 09:46:11.829613 association.go:995: [0x4000efc780] state change: 'Established' => 'Closed'
sctp DEBUG: 09:46:11.829714 association.go:553: [0x4000efc780] readLoop exited EOF
sctp DEBUG: 09:46:11.829729 association.go:523: [0x4000efc780] association closed
sctp DEBUG: 09:46:11.829734 association.go:524: [0x4000efc780] stats nDATAs (in) : 1
sctp DEBUG: 09:46:11.829738 association.go:525: [0x4000efc780] stats nSACKs (in) : 0
sctp DEBUG: 09:46:11.829741 association.go:526: [0x4000efc780] stats nT3Timeouts : 0
sctp DEBUG: 09:46:11.829745 association.go:527: [0x4000efc780] stats nAckTimeouts: 1
sctp DEBUG: 09:46:11.829748 association.go:528: [0x4000efc780] stats nFastRetrans: 0
sctp DEBUG: 09:46:11.829742 association.go:593: [0x4000efc780] writeLoop exited
sctp DEBUG: 09:46:11.829757 association.go:453: [0x4000efc780] association closed
sctp DEBUG: 09:46:11.829765 stream.go:345: [1:0x4000efc780] Close: state=closing
sctp DEBUG: 09:46:11.829766 association.go:454: [0x4000efc780] stats nDATAs (in) : 1
sctp DEBUG: 09:46:11.829786 association.go:455: [0x4000efc780] stats nSACKs (in) : 0
sctp DEBUG: 09:46:11.829789 association.go:456: [0x4000efc780] stats nT3Timeouts : 0
sctp DEBUG: 09:46:11.829792 association.go:457: [0x4000efc780] stats nAckTimeouts: 1
sctp DEBUG: 09:46:11.829796 association.go:458: [0x4000efc780] stats nFastRetrans: 0
pc WARNING: 2023/09/05 09:46:11 Failed to accept RTCP stream is already closed
pc WARNING: 2023/09/05 09:46:11 Failed to accept RTP stream is already closed
ice WARNING: 2023/09/05 09:46:11 Failed to read streaming packet: read tcp4 100.65.107.240:443->176.222.224.167:56798: use of closed network connection
ice WARNING: 2023/09/05 09:46:11 failed to close connection: close tcp4 100.65.107.240:443->176.222.224.167:56798: use of closed network connection
ice INFO: 2023/09/05 09:46:11 Removing connection: tcp remote 176.222.224.167:56798 to local 100.65.107.240:443, map[string]net.Conn{}
ice INFO: 2023/09/05 09:46:11 Setting new connection state: Closed
pc INFO: 2023/09/05 09:46:11 peer connection state changed: closed
pc INFO: 2023/09/05 09:46:11 ICE connection state changed: closed
```