### PR TITLE
Avoid priv. ports

### DIFF
--- a/net.go
+++ b/net.go
@@ -106,7 +106,7 @@ func listenUDPInPortRange(n transport.Net, log logging.LeveledLogger, portMax, p
 	var i, j int
 	i = portMin
 	if i == 0 {
-		i = 1
+		i = 1024 // avoid priveleged ports in the 1-1023 range.
 	}
 	j = portMax
 	if j == 0 {


### PR DESCRIPTION
#### Description

Avoid the priveleged port range when selecting a port to listen/bind to.

#### Reference issue
Fixes #651 
