### PR TITLE
Improve performance of UDPMux map lookups

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -133,6 +133,8 @@ var (
 	errWriteSTUNMessage              = errors.New("failed to send STUN message")
 	errWriteSTUNMessageToIceConn     = errors.New("failed to write STUN message to ICE connection")
 	errXORMappedAddrTimeout          = errors.New("timeout while waiting for XORMappedAddr")
+	errFailedToCastUDPAddr           = errors.New("failed to cast net.Addr to net.UDPAddr")
+	errInvalidIPAddress              = errors.New("invalid ip address")
 
 	// UDPMuxDefault should not listen on unspecified address, but to keep backward compatibility, don't return error now.
 	// will be used in the future.

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"strings"
 	"sync"
@@ -36,7 +37,7 @@ type UDPMuxDefault struct {
 	connsIPv4, connsIPv6 map[string]*udpMuxedConn
 
 	addressMapMu sync.RWMutex
-	addressMap   map[string]*udpMuxedConn
+	addressMap   map[ipPort]*udpMuxedConn
 
 	// Buffer pool to recycle buffers for net.UDPAddr encodes/decodes
 	pool *sync.Pool
@@ -51,8 +52,9 @@ const maxAddrSize = 512
 
 // UDPMuxParams are parameters for UDPMux.
 type UDPMuxParams struct {
-	Logger  logging.LeveledLogger
-	UDPConn net.PacketConn
+	Logger        logging.LeveledLogger
+	UDPConn       net.PacketConn
+	UDPConnString string
 
 	// Required for gathering local addresses
 	// in case a un UDPConn is passed which does not
@@ -103,9 +105,10 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 			}
 		}
 	}
+	params.UDPConnString = params.UDPConn.LocalAddr().String()
 
 	m := &UDPMuxDefault{
-		addressMap: map[string]*udpMuxedConn{},
+		addressMap: map[ipPort]*udpMuxedConn{},
 		params:     params,
 		connsIPv4:  make(map[string]*udpMuxedConn),
 		connsIPv6:  make(map[string]*udpMuxedConn),
@@ -142,7 +145,7 @@ func (m *UDPMuxDefault) GetListenAddresses() []net.Addr {
 // creates the connection if an existing one can't be found
 func (m *UDPMuxDefault) GetConn(ufrag string, addr net.Addr) (net.PacketConn, error) {
 	// don't check addr for mux using unspecified address
-	if len(m.localAddrsForUnspecified) == 0 && m.params.UDPConn.LocalAddr().String() != addr.String() {
+	if len(m.localAddrsForUnspecified) == 0 && m.params.UDPConnString != addr.String() {
 		return nil, errInvalidAddress
 	}
 
@@ -246,7 +249,7 @@ func (m *UDPMuxDefault) writeTo(buf []byte, rAddr net.Addr) (n int, err error) {
 	return m.params.UDPConn.WriteTo(buf, rAddr)
 }
 
-func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr string) {
+func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr ipPort) {
 	if m.IsClosed() {
 		return
 	}
@@ -260,7 +263,7 @@ func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr string) 
 	}
 	m.addressMap[addr] = conn
 
-	m.params.Logger.Debugf("Registered %s for %s", addr, conn.params.Key)
+	m.params.Logger.Debugf("Registered %s for %s", addr.addr.String(), conn.params.Key)
 }
 
 func (m *UDPMuxDefault) createMuxedConn(key string) *udpMuxedConn {
@@ -296,15 +299,20 @@ func (m *UDPMuxDefault) connWorker() {
 			return
 		}
 
-		udpAddr, ok := addr.(*net.UDPAddr)
+		netUDPAddr, ok := addr.(*net.UDPAddr)
 		if !ok {
 			logger.Errorf("Underlying PacketConn did not return a UDPAddr")
+			return
+		}
+		udpAddr, err := newIPPort(netUDPAddr.IP, uint16(netUDPAddr.Port))
+		if err != nil {
+			logger.Errorf("Failed to create a new IP/Port host pair")
 			return
 		}
 
 		// If we have already seen this address dispatch to the appropriate destination
 		m.addressMapMu.Lock()
-		destinationConn := m.addressMap[addr.String()]
+		destinationConn := m.addressMap[udpAddr]
 		m.addressMapMu.Unlock()
 
 		// If we haven't seen this address before but is a STUN packet lookup by ufrag
@@ -325,7 +333,7 @@ func (m *UDPMuxDefault) connWorker() {
 			}
 
 			ufrag := strings.Split(string(attr), ":")[0]
-			isIPv6 := udpAddr.IP.To4() == nil
+			isIPv6 := netUDPAddr.IP.To4() == nil
 
 			m.mu.Lock()
 			destinationConn, _ = m.getConn(ufrag, isIPv6)
@@ -333,11 +341,11 @@ func (m *UDPMuxDefault) connWorker() {
 		}
 
 		if destinationConn == nil {
-			m.params.Logger.Tracef("Dropping packet from %s, addr: %s", udpAddr.String(), addr.String())
+			m.params.Logger.Tracef("Dropping packet from %s, addr: %s", udpAddr.addr.String(), addr.String())
 			continue
 		}
 
-		if err = destinationConn.writePacket(buf[:n], udpAddr); err != nil {
+		if err = destinationConn.writePacket(buf[:n], netUDPAddr); err != nil {
 			m.params.Logger.Errorf("Failed to write packet: %v", err)
 		}
 	}
@@ -360,4 +368,24 @@ func newBufferHolder(size int) *bufferHolder {
 	return &bufferHolder{
 		buf: make([]byte, size),
 	}
+}
+
+type ipPort struct {
+	addr netip.Addr
+	port uint16
+}
+
+// newIPPort create a custom type of address based on netip.Addr and
+// port. The underlying ip address passed is converted to IPv6 format
+// to simplify ip address handling
+func newIPPort(ip net.IP, port uint16) (ipPort, error) {
+	n, ok := netip.AddrFromSlice(ip.To16())
+	if !ok {
+		return ipPort{}, errInvalidIPAddress
+	}
+
+	return ipPort{
+		addr: n,
+		port: port,
+	}, nil
 }


### PR DESCRIPTION
#### Description
UDPMux is using a map to lookup addresses of each packets. Unfortunately the key is based on a string and each time we want to check the map, a conversion of the UDP address to string is made (.String()) which is expensive.
This CR replace the string key by a binary key called ipPort. This structure contains a netip.Addr field and ipPort could be used as a map key
