### PR TITLE
[Cherrypick] Match libwebrtc protocol priority

### DIFF
--- a/candidate_relay.go
+++ b/candidate_relay.go
@@ -70,6 +70,23 @@ func NewCandidateRelay(config *CandidateRelayConfig) (*CandidateRelay, error) {
 	}, nil
 }
 
+// LocalPreference returns the local preference for this candidate
+func (c *CandidateRelay) LocalPreference() uint16 {
+	// These preference values come from libwebrtc
+	// https://github.com/mozilla/libwebrtc/blob/1389c76d9c79839a2ca069df1db48aa3f2e6a1ac/p2p/base/turn_port.cc#L61
+	var relayPreference uint16
+	switch c.relayProtocol {
+	case relayProtocolTLS, relayProtocolDTLS:
+		relayPreference = 2
+	case tcp:
+		relayPreference = 1
+	default:
+		relayPreference = 0
+	}
+
+	return c.candidateBase.LocalPreference() + relayPreference
+}
+
 // RelayProtocol returns the protocol used between the endpoint and the relay server.
 func (c *CandidateRelay) RelayProtocol() string {
 	return c.relayProtocol

--- a/gather.go
+++ b/gather.go
@@ -616,7 +616,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) { /
 
 				relAddr = conn.LocalAddr().(*net.UDPAddr).IP.String() //nolint:forcetypeassert
 				relPort = conn.LocalAddr().(*net.UDPAddr).Port        //nolint:forcetypeassert
-				relayProtocol = "dtls"
+				relayProtocol = relayProtocolDTLS
 				locConn = &fakenet.PacketConn{Conn: conn}
 			case url.Proto == stun.ProtoTypeTCP && url.Scheme == stun.SchemeTypeTURNS:
 				tcpAddr, resolvErr := a.net.ResolveTCPAddr(NetworkTypeTCP4.String(), turnServerAddr)
@@ -646,7 +646,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) { /
 
 				relAddr = conn.LocalAddr().(*net.TCPAddr).IP.String() //nolint:forcetypeassert
 				relPort = conn.LocalAddr().(*net.TCPAddr).Port        //nolint:forcetypeassert
-				relayProtocol = "tls"
+				relayProtocol = relayProtocolTLS
 				locConn = turn.NewSTUNConn(conn)
 			default:
 				a.log.Warnf("Unable to handle URL in gatherCandidatesRelay %v", url)

--- a/ice.go
+++ b/ice.go
@@ -83,3 +83,8 @@ func (t GatheringState) String() string {
 		return ErrUnknownType.Error()
 	}
 }
+
+const (
+	relayProtocolDTLS = "dtls"
+	relayProtocolTLS  = "tls"
+)


### PR DESCRIPTION
Cherrypick from master (since we will keep using v2 for some time)

#### Description
Match libwebrtc's TURN protocol priority (TCP vs UDP vs TLS)

#### Reference issue
Fixes reproducibility issues as seen in the field
