### PR TITLE
Return io.EOF from closed udpMuxedConn

### DIFF
--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -77,7 +77,7 @@ func (c *udpMuxedConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
 
 		if c.state == udpMuxedConnClosed {
 			c.mu.Unlock()
-			return 0, nil, io.ErrClosedPipe
+			return 0, nil, io.EOF
 		}
 
 		c.state = udpMuxedConnWaiting
@@ -86,7 +86,7 @@ func (c *udpMuxedConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
 		select {
 		case <-c.notify:
 		case <-c.closedChan:
-			return 0, nil, io.ErrClosedPipe
+			return 0, nil, io.EOF
 		}
 	}
 }


### PR DESCRIPTION
write returns `io.ErrClosedPipe` but read returns `io.EOF`...