### PR TITLE
Revert "Avoid allocation storing last active time"

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -31,8 +31,8 @@ type candidateBase struct {
 
 	resolvedAddr net.Addr
 
-	lastSent     atomic.Int64
-	lastReceived atomic.Int64
+	lastSent     atomic.Value
+	lastReceived atomic.Value
 	conn         net.PacketConn
 
 	currAgent *Agent
@@ -409,27 +409,27 @@ func (c *candidateBase) String() string {
 // LastReceived returns a time.Time indicating the last time
 // this candidate was received
 func (c *candidateBase) LastReceived() time.Time {
-	if lastReceived := c.lastReceived.Load(); lastReceived != 0 {
-		return time.Unix(0, lastReceived)
+	if lastReceived, ok := c.lastReceived.Load().(time.Time); ok {
+		return lastReceived
 	}
 	return time.Time{}
 }
 
 func (c *candidateBase) setLastReceived(t time.Time) {
-	c.lastReceived.Store(t.UnixNano())
+	c.lastReceived.Store(t)
 }
 
 // LastSent returns a time.Time indicating the last time
 // this candidate was sent
 func (c *candidateBase) LastSent() time.Time {
-	if lastSent := c.lastSent.Load(); lastSent != 0 {
-		return time.Unix(0, lastSent)
+	if lastSent, ok := c.lastSent.Load().(time.Time); ok {
+		return lastSent
 	}
 	return time.Time{}
 }
 
 func (c *candidateBase) setLastSent(t time.Time) {
-	c.lastSent.Store(t.UnixNano())
+	c.lastSent.Store(t)
 }
 
 func (c *candidateBase) seen(outbound bool) {

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -186,7 +186,7 @@ func TestCandidateLastSent(t *testing.T) {
 	require.Equal(t, candidate.LastSent(), time.Time{})
 	now := time.Now()
 	candidate.setLastSent(now)
-	require.EqualValues(t, 0, now.Sub(candidate.LastSent()))
+	require.Equal(t, candidate.LastSent(), now)
 }
 
 func TestCandidateLastReceived(t *testing.T) {
@@ -194,7 +194,7 @@ func TestCandidateLastReceived(t *testing.T) {
 	require.Equal(t, candidate.LastReceived(), time.Time{})
 	now := time.Now()
 	candidate.setLastReceived(now)
-	require.EqualValues(t, 0, now.Sub(candidate.LastReceived()))
+	require.Equal(t, candidate.LastReceived(), now)
 }
 
 func TestCandidateFoundation(t *testing.T) {


### PR DESCRIPTION
This reverts commit edb69295c04429931ede6a3df01d49520a1b31dc.

In that commit, active time was changed from time.Time to
Unix time in order to avoid allocations. Unfortunately, that
has the side effect of discarding the monotonic component of
time.Time, and therefore makes our code vulnerable to stepping
of the system clock.

This carries over #698 to v3.  Fixes #697.
