### PR TITLE
Fix Callback ordering for ConnectionState

### DIFF
--- a/agent_handlers_test.go
+++ b/agent_handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/transport/v3/test"
+	"github.com/pion/transport/v2/test"
 )
 
 func TestConnectionStateNotifier(t *testing.T) {
@@ -15,15 +15,15 @@ func TestConnectionStateNotifier(t *testing.T) {
 		report := test.CheckRoutines(t)
 		defer report()
 		updates := make(chan struct{}, 1)
-		c := &connectionStateNotifier{
-			NotificationFunc: func(_ ConnectionState) {
+		c := &handlerNotifier{
+			connectionStateFunc: func(_ ConnectionState) {
 				updates <- struct{}{}
 			},
 		}
 		// Enqueue all updates upfront to ensure that it
 		// doesn't block
 		for i := 0; i < 10000; i++ {
-			c.Enqueue(ConnectionStateNew)
+			c.EnqueueConnectionState(ConnectionStateNew)
 		}
 		done := make(chan struct{})
 		go func() {
@@ -43,8 +43,8 @@ func TestConnectionStateNotifier(t *testing.T) {
 		report := test.CheckRoutines(t)
 		defer report()
 		updates := make(chan ConnectionState)
-		c := &connectionStateNotifier{
-			NotificationFunc: func(cs ConnectionState) {
+		c := &handlerNotifier{
+			connectionStateFunc: func(cs ConnectionState) {
 				updates <- cs
 			},
 		}
@@ -64,7 +64,7 @@ func TestConnectionStateNotifier(t *testing.T) {
 			close(done)
 		}()
 		for i := 0; i < 10000; i++ {
-			c.Enqueue(ConnectionState(i))
+			c.EnqueueConnectionState(ConnectionState(i))
 		}
 		<-done
 	})

--- a/agent_handlers_test.go
+++ b/agent_handlers_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package ice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/transport/v3/test"
+)
+
+func TestConnectionStateNotifier(t *testing.T) {
+	t.Run("TestManyUpdates", func(t *testing.T) {
+		report := test.CheckRoutines(t)
+		defer report()
+		updates := make(chan struct{}, 1)
+		c := &connectionStateNotifier{
+			NotificationFunc: func(_ ConnectionState) {
+				updates <- struct{}{}
+			},
+		}
+		// Enqueue all updates upfront to ensure that it
+		// doesn't block
+		for i := 0; i < 10000; i++ {
+			c.Enqueue(ConnectionStateNew)
+		}
+		done := make(chan struct{})
+		go func() {
+			for i := 0; i < 10000; i++ {
+				<-updates
+			}
+			select {
+			case <-updates:
+				t.Errorf("received more updates than expected")
+			case <-time.After(1 * time.Second):
+			}
+			close(done)
+		}()
+		<-done
+	})
+	t.Run("TestUpdateOrdering", func(t *testing.T) {
+		report := test.CheckRoutines(t)
+		defer report()
+		updates := make(chan ConnectionState)
+		c := &connectionStateNotifier{
+			NotificationFunc: func(cs ConnectionState) {
+				updates <- cs
+			},
+		}
+		done := make(chan struct{})
+		go func() {
+			for i := 0; i < 10000; i++ {
+				x := <-updates
+				if x != ConnectionState(i) {
+					t.Errorf("expected %d got %d", x, i)
+				}
+			}
+			select {
+			case <-updates:
+				t.Errorf("received more updates than expected")
+			case <-time.After(1 * time.Second):
+			}
+			close(done)
+		}()
+		for i := 0; i < 10000; i++ {
+			c.Enqueue(ConnectionState(i))
+		}
+		<-done
+	})
+}

--- a/selection_test.go
+++ b/selection_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/pion/stun"
-	"github.com/pion/transport/v3/test"
+	"github.com/pion/transport/v2/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
This is already fixed on master. I've cherry picked 2 commits: https://github.com/pion/ice/commit/d17be4df3b49c712adf6c2c9ab08a5c4c87676f5 & https://github.com/pion/ice/commit/67cc918a518d3b3dd1887b07434331dabc846702

Since `pion/webrtc/v3` depends on `pion/ice/v2` it'd be nice if we can have a `v2` release with these two commits. 