### PR TITLE
Escape spaces in IPv6 ZoneID with %20

### DIFF
--- a/candidate_host.go
+++ b/candidate_host.go
@@ -52,8 +52,12 @@ func NewCandidateHost(config *CandidateHostConfig) (*CandidateHost, error) {
 		network: config.Network,
 	}
 
-	if !strings.HasSuffix(config.Address, ".local") {
-		ipAddr, err := netip.ParseAddr(config.Address)
+	if !strings.HasSuffix(c.candidateBase.address, ".local") {
+		if addr, zoneID, found := strings.Cut(c.candidateBase.address, "%"); found {
+			c.candidateBase.address = addr + "%" + strings.ReplaceAll(zoneID, " ", "%20")
+		}
+
+		ipAddr, err := netip.ParseAddr(c.candidateBase.address)
 		if err != nil {
 			return nil, err
 		}

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -309,6 +309,17 @@ func TestCandidateMarshal(t *testing.T) {
 		},
 		{
 			mustCandidateHost(&CandidateHostConfig{
+				Network:    NetworkTypeUDP6.String(),
+				Address:    "fcd9:e3b8:12ce:9fc5:74a5:c6bb:d8b:e08a%Local connection",
+				Port:       53987,
+				Priority:   500,
+				Foundation: "750",
+			}),
+			"750 1 udp 500 fcd9:e3b8:12ce:9fc5:74a5:c6bb:d8b:e08a%Local%20connection 53987 typ host",
+			false,
+		},
+		{
+			mustCandidateHost(&CandidateHostConfig{
 				Network: NetworkTypeUDP4.String(),
 				Address: "10.0.75.1",
 				Port:    53634,


### PR DESCRIPTION
Link-local IPv6 addresses may have ZoneID attached at the end. ZoneId is name of corresponding network interface. On Windows usually it is "Local connection". Space in ZoneID causes problem when ICE candidate is parsed so it has to be escaped. It looks that there is no escaping defined specifically for SDP; the closest one is RFC 6874 for URI. This fix partially uses this approach and replaces spaces with %20.

#### Description

#### Reference issue
Fixes #...
