### PR TITLE
Don't allocate new error inside TaskLoop

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,11 @@
 
 package ice
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/pion/ice/v3/internal/taskloop"
+)
 
 var (
 	// ErrUnknownType indicates an error with Unknown info.
@@ -36,7 +40,7 @@ var (
 	ErrProtoType = errors.New("invalid transport protocol type")
 
 	// ErrClosed indicates the agent is closed
-	ErrClosed = errors.New("the agent is closed")
+	ErrClosed = taskloop.ErrClosed
 
 	// ErrNoCandidatePairs indicates agent does not have a valid candidate pair
 	ErrNoCandidatePairs = errors.New("no candidate pairs available")

--- a/internal/taskloop/taskloop.go
+++ b/internal/taskloop/taskloop.go
@@ -13,8 +13,8 @@ import (
 	atomicx "github.com/pion/ice/v3/internal/atomic"
 )
 
-// errClosed indicates that the loop has been stopped
-var errClosed = errors.New("the agent is closed")
+// ErrClosed indicates that the loop has been stopped
+var ErrClosed = errors.New("the agent is closed")
 
 type task struct {
 	fn   func(context.Context)
@@ -68,7 +68,7 @@ func (l *Loop) Close() error {
 		return err
 	}
 
-	l.err.Store(errClosed)
+	l.err.Store(ErrClosed)
 
 	close(l.done)
 	<-l.taskLoopDone
@@ -104,7 +104,7 @@ func (l *Loop) Done() <-chan struct{} {
 func (l *Loop) Err() error {
 	select {
 	case <-l.done:
-		return errClosed
+		return ErrClosed
 	default:
 		return nil
 	}


### PR DESCRIPTION
Libraries use errors.Is to catch this error. Allocating a new one inside internal breaks that