### PR TITLE
tests: Clean up Agents more aggressively

### DIFF
--- a/agent_get_best_available_candidate_pair_test.go
+++ b/agent_get_best_available_candidate_pair_test.go
@@ -13,19 +13,12 @@ import (
 )
 
 func TestNoBestAvailableCandidatePairAfterAgentConstruction(t *testing.T) {
-	agent := setupTest(t)
-
-	require.Nil(t, agent.getBestAvailableCandidatePair())
-
-	tearDownTest(t, agent)
-}
-
-func setupTest(t *testing.T) *Agent {
 	agent, err := NewAgent(&AgentConfig{})
 	require.NoError(t, err)
-	return agent
-}
 
-func tearDownTest(t *testing.T, agent *Agent) {
-	require.NoError(t, agent.Close())
+	defer func() {
+		require.NoError(t, agent.Close())
+	}()
+
+	require.Nil(t, agent.getBestAvailableCandidatePair())
 }

--- a/agent_get_best_valid_candidate_pair_test.go
+++ b/agent_get_best_valid_candidate_pair_test.go
@@ -14,6 +14,9 @@ import (
 
 func TestAgentGetBestValidCandidatePair(t *testing.T) {
 	f := setupTestAgentGetBestValidCandidatePair(t)
+	defer func() {
+		require.NoError(t, f.sut.Close())
+	}()
 
 	remoteCandidatesFromLowestPriorityToHighest := []Candidate{f.relayRemote, f.srflxRemote, f.prflxRemote, f.hostRemote}
 
@@ -26,8 +29,6 @@ func TestAgentGetBestValidCandidatePair(t *testing.T) {
 
 		require.Equal(t, actualBestPair.String(), expectedBestPair.String())
 	}
-
-	require.NoError(t, f.sut.Close())
 }
 
 func setupTestAgentGetBestValidCandidatePair(t *testing.T) *TestAgentGetBestValidCandidatePairFixture {

--- a/agent_on_selected_candidate_pair_change_test.go
+++ b/agent_on_selected_candidate_pair_change_test.go
@@ -15,6 +15,9 @@ import (
 
 func TestOnSelectedCandidatePairChange(t *testing.T) {
 	agent, candidatePair := fixtureTestOnSelectedCandidatePairChange(t)
+	defer func() {
+		require.NoError(t, agent.Close())
+	}()
 
 	callbackCalled := make(chan struct{}, 1)
 	err := agent.OnSelectedCandidatePairChange(func(_, _ Candidate) {
@@ -28,7 +31,6 @@ func TestOnSelectedCandidatePairChange(t *testing.T) {
 	require.NoError(t, err)
 
 	<-callbackCalled
-	require.NoError(t, agent.Close())
 }
 
 func fixtureTestOnSelectedCandidatePairChange(t *testing.T) (*Agent, *CandidatePair) {

--- a/candidate_relay_test.go
+++ b/candidate_relay_test.go
@@ -43,6 +43,9 @@ func TestRelayOnlyConnection(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
 
 	cfg := &AgentConfig{
 		NetworkTypes: supportedNetworkTypes(),
@@ -61,12 +64,18 @@ func TestRelayOnlyConnection(t *testing.T) {
 
 	aAgent, err := NewAgent(cfg)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, aAgent.Close())
+	}()
 
 	aNotifier, aConnected := onConnected()
 	require.NoError(t, aAgent.OnConnectionStateChange(aNotifier))
 
 	bAgent, err := NewAgent(cfg)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, bAgent.Close())
+	}()
 
 	bNotifier, bConnected := onConnected()
 	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
@@ -74,8 +83,4 @@ func TestRelayOnlyConnection(t *testing.T) {
 	connect(aAgent, bAgent)
 	<-aConnected
 	<-bConnected
-
-	require.NoError(t, aAgent.Close())
-	require.NoError(t, bAgent.Close())
-	require.NoError(t, server.Close())
 }

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -39,6 +39,9 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
 
 	cfg := &AgentConfig{
 		NetworkTypes: []NetworkType{NetworkTypeUDP4},
@@ -54,12 +57,18 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 
 	aAgent, err := NewAgent(cfg)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, aAgent.Close())
+	}()
 
 	aNotifier, aConnected := onConnected()
 	require.NoError(t, aAgent.OnConnectionStateChange(aNotifier))
 
 	bAgent, err := NewAgent(cfg)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, bAgent.Close())
+	}()
 
 	bNotifier, bConnected := onConnected()
 	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
@@ -67,8 +76,4 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 	connect(aAgent, bAgent)
 	<-aConnected
 	<-bConnected
-
-	require.NoError(t, aAgent.Close())
-	require.NoError(t, bAgent.Close())
-	require.NoError(t, server.Close())
 }

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -493,6 +493,9 @@ func TestDisconnectedToConnected(t *testing.T) {
 		CheckInterval:       &keepaliveInterval,
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, controllingAgent.Close())
+	}()
 
 	controlledAgent, err := NewAgent(&AgentConfig{
 		NetworkTypes:        supportedNetworkTypes(),
@@ -503,6 +506,9 @@ func TestDisconnectedToConnected(t *testing.T) {
 		CheckInterval:       &keepaliveInterval,
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, controlledAgent.Close())
+	}()
 
 	controllingStateChanges := make(chan ConnectionState, 100)
 	require.NoError(t, controllingAgent.OnConnectionStateChange(func(c ConnectionState) {
@@ -538,8 +544,6 @@ func TestDisconnectedToConnected(t *testing.T) {
 	blockUntilStateSeen(ConnectionStateConnected, controlledStateChanges)
 
 	require.NoError(t, wan.Stop())
-	require.NoError(t, controllingAgent.Close())
-	require.NoError(t, controlledAgent.Close())
 }
 
 // Agent.Write should use the best valid pair if a selected pair is not yet available
@@ -593,6 +597,9 @@ func TestWriteUseValidPair(t *testing.T) {
 		Net:              net0,
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, controllingAgent.Close())
+	}()
 
 	controlledAgent, err := NewAgent(&AgentConfig{
 		NetworkTypes:     supportedNetworkTypes(),
@@ -600,6 +607,9 @@ func TestWriteUseValidPair(t *testing.T) {
 		Net:              net1,
 	})
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, controlledAgent.Close())
+	}()
 
 	gatherAndExchangeCandidates(controllingAgent, controlledAgent)
 
@@ -630,6 +640,4 @@ func TestWriteUseValidPair(t *testing.T) {
 	require.Equal(t, readBuf, testMessage)
 
 	require.NoError(t, wan.Stop())
-	require.NoError(t, controllingAgent.Close())
-	require.NoError(t, controlledAgent.Close())
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pion/mdns/v2 v2.0.7
 	github.com/pion/randutil v0.1.0
 	github.com/pion/stun/v2 v2.0.0
-	github.com/pion/transport/v3 v3.0.5
+	github.com/pion/transport/v3 v3.0.6
 	github.com/pion/turn/v3 v3.0.3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1A
 github.com/pion/transport/v2 v2.2.4 h1:41JJK6DZQYSeVLxILA2+F4ZkKb4Xd/tFJZRFZQ9QAlo=
 github.com/pion/transport/v2 v2.2.4/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=
 github.com/pion/transport/v3 v3.0.1/go.mod h1:UY7kiITrlMv7/IKgd5eTUcaahZx5oUN3l9SzK5f5xE0=
-github.com/pion/transport/v3 v3.0.5 h1:ofVrcbPNqVPuKaTO5AMFnFuJ1ZX7ElYiWzC5PCf9YVQ=
-github.com/pion/transport/v3 v3.0.5/go.mod h1:HvJr2N/JwNJAfipsRleqwFoR3t/pWyHeZUs89v3+t5s=
+github.com/pion/transport/v3 v3.0.6 h1:k1mQU06bmmX143qSWgXFqSH1KUJceQvIUuVH/K5ELWw=
+github.com/pion/transport/v3 v3.0.6/go.mod h1:HvJr2N/JwNJAfipsRleqwFoR3t/pWyHeZUs89v3+t5s=
 github.com/pion/turn/v3 v3.0.3 h1:1e3GVk8gHZLPBA5LqadWYV60lmaKUaHCkm9DX9CkGcE=
 github.com/pion/turn/v3 v3.0.3/go.mod h1:vw0Dz420q7VYAF3J4wJKzReLHIo2LGp4ev8nXQexYsc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -49,12 +49,18 @@ func TestMulticastDNSOnlyConnection(t *testing.T) {
 
 			aAgent, err := NewAgent(cfg)
 			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, aAgent.Close())
+			}()
 
 			aNotifier, aConnected := onConnected()
 			require.NoError(t, aAgent.OnConnectionStateChange(aNotifier))
 
 			bAgent, err := NewAgent(cfg)
 			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, bAgent.Close())
+			}()
 
 			bNotifier, bConnected := onConnected()
 			require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
@@ -62,9 +68,6 @@ func TestMulticastDNSOnlyConnection(t *testing.T) {
 			connect(aAgent, bAgent)
 			<-aConnected
 			<-bConnected
-
-			require.NoError(t, aAgent.Close())
-			require.NoError(t, bAgent.Close())
 		})
 	}
 }
@@ -100,6 +103,9 @@ func TestMulticastDNSMixedConnection(t *testing.T) {
 				InterfaceFilter:  problematicNetworkInterfaces,
 			})
 			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, aAgent.Close())
+			}()
 
 			aNotifier, aConnected := onConnected()
 			require.NoError(t, aAgent.OnConnectionStateChange(aNotifier))
@@ -111,6 +117,9 @@ func TestMulticastDNSMixedConnection(t *testing.T) {
 				InterfaceFilter:  problematicNetworkInterfaces,
 			})
 			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, bAgent.Close())
+			}()
 
 			bNotifier, bConnected := onConnected()
 			require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
@@ -118,9 +127,6 @@ func TestMulticastDNSMixedConnection(t *testing.T) {
 			connect(aAgent, bAgent)
 			<-aConnected
 			<-bConnected
-
-			require.NoError(t, aAgent.Close())
-			require.NoError(t, bAgent.Close())
 		})
 	}
 }
@@ -165,6 +171,9 @@ func TestMulticastDNSStaticHostName(t *testing.T) {
 				InterfaceFilter:      problematicNetworkInterfaces,
 			})
 			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, agent.Close())
+			}()
 
 			correctHostName, resolveFunc := context.WithCancel(context.Background())
 			require.NoError(t, agent.OnCandidate(func(c Candidate) {
@@ -175,7 +184,6 @@ func TestMulticastDNSStaticHostName(t *testing.T) {
 
 			require.NoError(t, agent.GatherCandidates())
 			<-correctHostName.Done()
-			require.NoError(t, agent.Close())
 		})
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -324,6 +324,7 @@ func TestConnStats(t *testing.T) {
 	if _, err := ca.Write(make([]byte, 10)); err != nil {
 		t.Fatal("unexpected error trying to write")
 	}
+	defer closePipe(t, ca, cb)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -343,17 +344,5 @@ func TestConnStats(t *testing.T) {
 
 	if cb.BytesReceived() != 10 {
 		t.Fatal("bytes received don't match")
-	}
-
-	err := ca.Close()
-	if err != nil {
-		// We should never get here.
-		panic(err)
-	}
-
-	err = cb.Close()
-	if err != nil {
-		// We should never get here.
-		panic(err)
 	}
 }

--- a/transport_vnet_test.go
+++ b/transport_vnet_test.go
@@ -61,6 +61,7 @@ func TestRemoteLocalAddr(t *testing.T) {
 				urls: []*stun.URI{stunServerURL},
 			},
 		)
+		defer closePipe(t, ca, cb)
 
 		aRAddr := ca.RemoteAddr()
 		aLAddr := ca.LocalAddr()
@@ -86,9 +87,5 @@ func TestRemoteLocalAddr(t *testing.T) {
 		require.Equal(t, bRAddr.String(),
 			fmt.Sprintf("%s:%d", vnetGlobalIPA, aLAddr.(*net.UDPAddr).Port), //nolint:forcetypeassert
 		)
-
-		// Close
-		require.NoError(t, ca.Close())
-		require.NoError(t, cb.Close())
 	})
 }

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -250,6 +250,7 @@ func TestUDPMux_Agent_Restart(t *testing.T) {
 		DisconnectedTimeout: &oneSecond,
 		FailedTimeout:       &oneSecond,
 	})
+	defer closePipe(t, connA, connB)
 
 	aNotifier, aConnected := onConnected()
 	require.NoError(t, connA.agent.OnConnectionStateChange(aNotifier))
@@ -277,7 +278,4 @@ func TestUDPMux_Agent_Restart(t *testing.T) {
 	// Wait until both have gone back to connected
 	<-aConnected
 	<-bConnected
-
-	require.NoError(t, connA.agent.Close())
-	require.NoError(t, connB.agent.Close())
 }


### PR DESCRIPTION
this will clear the noise for when a test starts up with unexpected goroutine(s)