### PR TITLE
Allow multiple agent.Close

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -861,14 +861,14 @@ func (a *Agent) GracefulClose() error {
 
 func (a *Agent) close(graceful bool) error {
 	// the loop is safe to wait on no matter what
-	err := a.loop.Close()
+	a.loop.Close()
 
 	// but we are in less control of the notifiers, so we will
 	// pass through `graceful`.
 	a.connectionStateNotifier.Close(graceful)
 	a.candidateNotifier.Close(graceful)
 	a.selectedCandidatePairNotifier.Close(graceful)
-	return err
+	return nil
 }
 
 // Remove all candidates. This closes any listening sockets

--- a/internal/taskloop/taskloop.go
+++ b/internal/taskloop/taskloop.go
@@ -63,17 +63,15 @@ func (l *Loop) runLoop(onClose func()) {
 
 // Close stops the loop after finishing the execution of the current task.
 // Other pending tasks will not be executed.
-func (l *Loop) Close() error {
+func (l *Loop) Close() {
 	if err := l.Err(); err != nil {
-		return err
+		return
 	}
 
 	l.err.Store(ErrClosed)
 
 	close(l.done)
 	<-l.taskLoopDone
-
-	return nil
 }
 
 // Run serially executes the submitted callback.


### PR DESCRIPTION
There's a case in webrtc GracefulClose (https://github.com/pion/webrtc/pull/2847/files#diff-61936a3824ea2f65378ca63d509769a4dc6b52a1685845f764089fe03de2f4c3R213-R216) where it would be beneficial to wait for the ICE agent to gracefully close but due to how Mux works, it's hard to thread it through without calling GracefulClose and then Close on the agent. That makes an error happen that doesn't seem necessary. If you close twice, that feels okay.