### PR TITLE
Take TCP Family into account before connecting

### DIFF
--- a/active_tcp_test.go
+++ b/active_tcp_test.go
@@ -244,7 +244,7 @@ func TestActiveTCP_Respect_NetworkTypes(t *testing.T) {
 	}()
 
 	cfg := &AgentConfig{
-		NetworkTypes:    []NetworkType{NetworkTypeUDP4, NetworkTypeUDP6},
+		NetworkTypes:    []NetworkType{NetworkTypeUDP4, NetworkTypeUDP6, NetworkTypeTCP6},
 		InterfaceFilter: problematicNetworkInterfaces,
 		IncludeLoopback: true,
 	}

--- a/agent.go
+++ b/agent.go
@@ -704,14 +704,17 @@ func (a *Agent) addRemoteCandidate(c Candidate) {
 		}
 	}
 
-	tcpNetworkTypeFound := false
-	for _, networkType := range a.networkTypes {
-		if networkType.IsTCP() {
-			tcpNetworkTypeFound = true
+	acceptRemotePassiveTCPCandidate := false
+	// Assert that TCP4 or TCP6 is a enabled NetworkType locally
+	if !a.disableActiveTCP && c.TCPType() == TCPTypePassive {
+		for _, networkType := range a.networkTypes {
+			if c.NetworkType() == networkType {
+				acceptRemotePassiveTCPCandidate = true
+			}
 		}
 	}
 
-	if !a.disableActiveTCP && tcpNetworkTypeFound && c.TCPType() == TCPTypePassive {
+	if acceptRemotePassiveTCPCandidate {
 		a.addRemotePassiveTCPCandidate(c)
 	}
 


### PR DESCRIPTION
Before if a user disabled TCPv6 (but enabled TCPv4) we would incorrectly start TCP connections over TCPv6 still.

Resolves pion/webrtc#2782