### PR TITLE
docs(agent_config.go): update KeepaliveInterval default value to 2 sec

### DIFF
--- a/agent_config.go
+++ b/agent_config.go
@@ -91,7 +91,7 @@ type AgentConfig struct {
 
 	// KeepaliveInterval determines how often should we send ICE
 	// keepalives (should be less then connectiontimeout above)
-	// when this is nil, it defaults to 10 seconds.
+	// when this is nil, it defaults to 2 seconds.
 	// A keepalive interval of 0 means we never send keepalive packets
 	KeepaliveInterval *time.Duration
 


### PR DESCRIPTION
Update documentation for KeepaliveInterval to match defaultKeepaliveInterval constant

#### Description

#### Reference issue
Fixes #...
