### PR TITLE
refactor: use named return val for IP/if filter

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -138,8 +138,8 @@ type Agent struct {
 	udpMux      UDPMux
 	udpMuxSrflx UniversalUDPMux
 
-	interfaceFilter func(string) bool
-	ipFilter        func(net.IP) bool
+	interfaceFilter func(string) (keep bool)
+	ipFilter        func(net.IP) (keep bool)
 	includeLoopback bool
 
 	insecureSkipVerify bool

--- a/agent_config.go
+++ b/agent_config.go
@@ -148,11 +148,11 @@ type AgentConfig struct {
 
 	// InterfaceFilter is a function that you can use in order to whitelist or blacklist
 	// the interfaces which are used to gather ICE candidates.
-	InterfaceFilter func(string) bool
+	InterfaceFilter func(string) (keep bool)
 
 	// IPFilter is a function that you can use in order to whitelist or blacklist
 	// the ips which are used to gather ICE candidates.
-	IPFilter func(net.IP) bool
+	IPFilter func(net.IP) (keep bool)
 
 	// InsecureSkipVerify controls if self-signed certificates are accepted when connecting
 	// to TURN servers via TLS or DTLS

--- a/gather_vnet_test.go
+++ b/gather_vnet_test.go
@@ -387,7 +387,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 	t.Run("InterfaceFilter should exclude the interface", func(t *testing.T) {
 		a, err := NewAgent(&AgentConfig{
 			Net: nw,
-			InterfaceFilter: func(interfaceName string) bool {
+			InterfaceFilter: func(interfaceName string) (keep bool) {
 				require.Equal(t, "eth0", interfaceName)
 				return false
 			},
@@ -408,7 +408,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 	t.Run("IPFilter should exclude the IP", func(t *testing.T) {
 		a, err := NewAgent(&AgentConfig{
 			Net: nw,
-			IPFilter: func(ip net.IP) bool {
+			IPFilter: func(ip net.IP) (keep bool) {
 				require.Equal(t, net.IP{1, 2, 3, 1}, ip)
 				return false
 			},
@@ -429,7 +429,7 @@ func TestVNetGatherWithInterfaceFilter(t *testing.T) {
 	t.Run("InterfaceFilter should not exclude the interface", func(t *testing.T) {
 		a, err := NewAgent(&AgentConfig{
 			Net: nw,
-			InterfaceFilter: func(interfaceName string) bool {
+			InterfaceFilter: func(interfaceName string) (keep bool) {
 				require.Equal(t, "eth0", interfaceName)
 				return true
 			},

--- a/net.go
+++ b/net.go
@@ -39,8 +39,8 @@ func isZeros(ip net.IP) bool {
 //nolint:gocognit
 func localInterfaces(
 	n transport.Net,
-	interfaceFilter func(string) bool,
-	ipFilter func(net.IP) bool,
+	interfaceFilter func(string) (keep bool),
+	ipFilter func(net.IP) (keep bool),
 	networkTypes []NetworkType,
 	includeLoopback bool,
 ) ([]*transport.Interface, []netip.Addr, error) {

--- a/net_test.go
+++ b/net_test.go
@@ -45,7 +45,7 @@ func TestCreateAddr(t *testing.T) {
 	require.Equal(t, &net.TCPAddr{IP: ipv6.AsSlice(), Port: port}, createAddr(NetworkTypeTCP6, ipv6, port))
 }
 
-func problematicNetworkInterfaces(s string) bool {
+func problematicNetworkInterfaces(s string) (keep bool) {
 	defaultDockerBridgeNetwork := strings.Contains(s, "docker")
 	customDockerBridgeNetwork := strings.Contains(s, "br-")
 

--- a/udp_mux_multi.go
+++ b/udp_mux_multi.go
@@ -141,8 +141,8 @@ type UDPMuxFromPortOption interface {
 }
 
 type multiUDPMuxFromPortParam struct {
-	ifFilter        func(string) bool
-	ipFilter        func(ip net.IP) bool
+	ifFilter        func(string) (keep bool)
+	ipFilter        func(ip net.IP) (keep bool)
 	networks        []NetworkType
 	readBufferSize  int
 	writeBufferSize int
@@ -160,7 +160,7 @@ func (o *udpMuxFromPortOption) apply(p *multiUDPMuxFromPortParam) {
 }
 
 // UDPMuxFromPortWithInterfaceFilter set the filter to filter out interfaces that should not be used
-func UDPMuxFromPortWithInterfaceFilter(f func(string) bool) UDPMuxFromPortOption {
+func UDPMuxFromPortWithInterfaceFilter(f func(string) (keep bool)) UDPMuxFromPortOption {
 	return &udpMuxFromPortOption{
 		f: func(p *multiUDPMuxFromPortParam) {
 			p.ifFilter = f
@@ -169,7 +169,7 @@ func UDPMuxFromPortWithInterfaceFilter(f func(string) bool) UDPMuxFromPortOption
 }
 
 // UDPMuxFromPortWithIPFilter set the filter to filter out IP addresses that should not be used
-func UDPMuxFromPortWithIPFilter(f func(ip net.IP) bool) UDPMuxFromPortOption {
+func UDPMuxFromPortWithIPFilter(f func(ip net.IP) (keep bool)) UDPMuxFromPortOption {
 	return &udpMuxFromPortOption{
 		f: func(p *multiUDPMuxFromPortParam) {
 			p.ipFilter = f


### PR DESCRIPTION
#### Description

This should make it clear that you need to return `true` to keep it and `false` to exclude.

Similar MR in pion/webrtc: https://github.com/pion/webrtc/pull/2958.

#### Reference issue
None
