### PR TITLE
UDPMuxSink for UDPMux allows to inspect packets before being dropped

### DIFF
--- a/udp_mux.go
+++ b/udp_mux.go
@@ -82,6 +82,10 @@ type UDPMuxParams struct {
 	// in case a un UDPConn is passed which does not
 	// bind to a specific local address.
 	Net transport.Net
+	// OnUnhandledPacket is called synchronously when a packet cannot be routed
+	// to a muxed connection. It must not block. The data slice is reused after
+	// the callback returns and must be copied if it is retained.
+	OnUnhandledPacket func(data []byte, addr netip.AddrPort)
 }
 
 // NewUDPMuxDefault creates an implementation of UDPMux.
@@ -598,6 +602,9 @@ func (m *UDPMuxDefault) connWorker() { //nolint:cyclop
 		}
 
 		if destinationConn == nil {
+			if m.params.OnUnhandledPacket != nil {
+				m.params.OnUnhandledPacket(buf[:n], srcAddr)
+			}
 			m.params.Logger.Tracef("Dropping packet from %s", srcAddrPort)
 
 			continue

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -111,6 +111,50 @@ func TestUDPMux(t *testing.T) {
 	}
 }
 
+func TestUDPMuxOnUnhandledPacket(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(10 * time.Second).Stop()
+
+	type droppedPacket struct {
+		data []byte
+		addr netip.AddrPort
+	}
+
+	dropped := make(chan droppedPacket, 1)
+	udpConn, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+
+	mux := NewUDPMuxDefault(UDPMuxParams{
+		UDPConn: udpConn,
+		OnUnhandledPacket: func(data []byte, addr netip.AddrPort) {
+			dropped <- droppedPacket{
+				data: append([]byte(nil), data...),
+				addr: addr,
+			}
+		},
+	})
+	defer func() {
+		_ = mux.Close()
+		_ = udpConn.Close()
+	}()
+
+	remote, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer func() { _ = remote.Close() }()
+
+	payload := []byte("unroutable packet")
+	_, err = remote.WriteToUDP(payload, mux.LocalAddr().(*net.UDPAddr)) //nolint:forcetypeassert
+	require.NoError(t, err)
+
+	select {
+	case packet := <-dropped:
+		require.Equal(t, payload, packet.data)
+		require.Equal(t, remote.LocalAddr().(*net.UDPAddr).AddrPort(), packet.addr) //nolint:forcetypeassert
+	case <-time.After(time.Second):
+		require.FailNow(t, "OnUnhandledPacket was not called")
+	}
+}
+
 func testMuxConnection(t *testing.T, udpMux *UDPMuxDefault, networkNet transport.Net, testCase udpMuxTestCase, ufrag string) { //nolint:lll
 	t.Helper()
 


### PR DESCRIPTION
#### Description
This is one of the features that helped us to build a distributed version of Pion.

Inspecting UDPMux discarded packets makes it possible to evaluate and restore a PeerConnection if needed