### PR TITLE
Always send KeepAlives

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -594,9 +594,7 @@ func (a *Agent) checkKeepalive() {
 		return
 	}
 
-	if (a.keepaliveInterval != 0) &&
-		((time.Since(selectedPair.Local.LastSent()) > a.keepaliveInterval) ||
-			(time.Since(selectedPair.Remote.LastReceived()) > a.keepaliveInterval)) {
+	if a.keepaliveInterval != 0 {
 		// We use binding request instead of indication to support refresh consent schemas
 		// see https://tools.ietf.org/html/rfc7675
 		a.selector.PingCandidate(selectedPair.Local, selectedPair.Remote)


### PR DESCRIPTION
Pion incorrectly resets the consent timer when sending any traffic. 
The consent timer must only be reset on STUN traffic.

RFC 7675
> Consent expires after 30 seconds.  That is, if a valid STUN binding
> response has not been received from the remote peer's transport
> address in 30 seconds, the endpoint MUST cease transmission on that
> 5-tuple.  STUN consent responses received after consent expiry do not
> re-establish consent and may be discarded or cause an ICMP error.