### PR TITLE
Avoid unnecessary turn address resolution in the turn client

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -690,6 +690,8 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 				relAddr       string
 				relPort       int
 				relayProtocol string
+
+				omitTurnServerAddr bool
 			)
 
 			switch {
@@ -721,6 +723,11 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 				}
 				locConn = turn.NewSTUNConn(conn)
 
+				// We don't need to resolve address of the turn server, since we are using
+				// proxy dialer.
+				if _, err = a.net.ResolveUDPAddr("udp4", turnServerAddr); err != nil {
+					omitTurnServerAddr = true
+				}
 			case url.Proto == stun.ProtoTypeTCP && url.Scheme == stun.SchemeTypeTURN:
 				tcpAddr, connectErr := a.net.ResolveTCPAddr(NetworkTypeTCP4.String(), turnServerAddr)
 				if connectErr != nil {
@@ -815,14 +822,18 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 				return
 			}
 
-			client, err := turn.NewClient(&turn.ClientConfig{
-				TURNServerAddr: turnServerAddr,
-				Conn:           locConn,
-				Username:       url.Username,
-				Password:       url.Password,
-				LoggerFactory:  a.loggerFactory,
-				Net:            a.net,
-			})
+			clientCfg := &turn.ClientConfig{
+				Conn:          locConn,
+				Username:      url.Username,
+				Password:      url.Password,
+				LoggerFactory: a.loggerFactory,
+				Net:           a.net,
+			}
+			if !omitTurnServerAddr {
+				clientCfg.TURNServerAddr = turnServerAddr
+			}
+
+			client, err := turn.NewClient(clientCfg)
 			if err != nil {
 				closeConnAndLog(locConn, a.log, "failed to create new TURN client %s %s", turnServerAddr, err)
 

--- a/gather.go
+++ b/gather.go
@@ -1046,11 +1046,12 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 
 					turnServerAddr := net.JoinHostPort(url.Host, strconv.Itoa(url.Port))
 					var (
-						locConn       net.PacketConn
-						err           error
-						relAddr       string
-						relPort       int
-						relayProtocol string
+						locConn             net.PacketConn
+						err                 error
+						relAddr             string
+						relPort             int
+						relayProtocol       string
+						needsTURNServerAddr bool
 					)
 
 					switch {
@@ -1064,6 +1065,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 						relAddr = locConn.LocalAddr().(*net.UDPAddr).IP.String() //nolint:forcetypeassert
 						relPort = locConn.LocalAddr().(*net.UDPAddr).Port        //nolint:forcetypeassert
 						relayProtocol = udp
+						needsTURNServerAddr = true
 					case a.proxyDialer != nil && urlProto == stun.ProtoTypeTCP &&
 						(url.Scheme == stun.SchemeTypeTURN || url.Scheme == stun.SchemeTypeTURNS):
 						conn, connectErr := a.proxyDialer.Dial(network, turnServerAddr)
@@ -1187,14 +1189,18 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 						factory = defaultTurnClient
 					}
 
-					client, err := factory(&turn.ClientConfig{
-						TURNServerAddr: turnServerAddr,
-						Conn:           locConn,
-						Username:       url.Username,
-						Password:       url.Password,
-						LoggerFactory:  a.loggerFactory,
-						Net:            a.net,
-					})
+					clientConfig := &turn.ClientConfig{
+						Conn:          locConn,
+						Username:      url.Username,
+						Password:      url.Password,
+						LoggerFactory: a.loggerFactory,
+						Net:           a.net,
+					}
+					if needsTURNServerAddr {
+						clientConfig.TURNServerAddr = turnServerAddr
+					}
+
+					client, err := factory(clientConfig)
 					if err != nil {
 						closeConnAndLog(locConn, a.log, "failed to create new TURN client %s %s", turnServerAddr, err)
 

--- a/gather_test.go
+++ b/gather_test.go
@@ -777,6 +777,17 @@ type relayGatherNet struct {
 	addr *net.UDPAddr
 }
 
+type unresolvableRelayGatherNet struct {
+	*relayGatherNet
+	resolveUDPCalls atomic.Int32
+}
+
+func (n *unresolvableRelayGatherNet) ResolveUDPAddr(string, string) (*net.UDPAddr, error) {
+	n.resolveUDPCalls.Add(1)
+
+	return nil, errors.New("DNS unavailable") //nolint:err113 // test
+}
+
 func newRelayGatherNet(addr *net.UDPAddr) *relayGatherNet {
 	if addr == nil {
 		addr = &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1)}
@@ -1880,6 +1891,54 @@ func TestGatherCandidatesRelayTURNOverTCPProducesUDPRelayCandidate(t *testing.T)
 	case <-time.After(time.Second):
 		require.FailNow(t, "expected relay candidate for TURN over TCP")
 	}
+}
+
+func TestGatherCandidatesRelayProxySkipsTURNResolution(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	turnNet := &unresolvableRelayGatherNet{
+		relayGatherNet: newRelayGatherNet(&net.UDPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 50000}),
+	}
+	agent, err := NewAgentWithOptions(
+		WithNet(turnNet),
+		WithNetworkTypes([]NetworkType{NetworkTypeUDP4, NetworkTypeTCP4}),
+		WithCandidateTypes([]CandidateType{CandidateTypeRelay}),
+		WithUrls([]*stun.URI{
+			{
+				Scheme:   stun.SchemeTypeTURN,
+				Host:     "unresolvable.invalid",
+				Port:     3478,
+				Username: "username",
+				Password: "password",
+				Proto:    stun.ProtoTypeTCP,
+			},
+		}),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, agent.Close()) }()
+
+	agent.proxyDialer = &relayTCPProxyDialer{
+		localAddr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 55000},
+	}
+	clientConfig := make(chan *turn.ClientConfig, 1)
+	agent.turnClientFactory = func(cfg *turn.ClientConfig) (turnClient, error) {
+		clientConfig <- cfg
+
+		return nil, errors.New("stop after capturing config") //nolint:err113 // test
+	}
+
+	agent.gatherCandidatesRelay(context.Background(), agent.urls)
+
+	var config *turn.ClientConfig
+	select {
+	case config = <-clientConfig:
+	case <-time.After(time.Second):
+		require.FailNow(t, "TURN client was not created")
+	}
+	require.Empty(t, config.TURNServerAddr)
+	require.Same(t, turnNet, config.Net)
+	require.Zero(t, turnNet.resolveUDPCalls.Load())
 }
 
 func buildSimpleVNet(t *testing.T) (*vnet.Router, *vnet.Net) {


### PR DESCRIPTION
#### Description

The `turn.NewClient` function in the library currently requires TURN server addresses passed to it to be resolvable. This causes an error when using a proxy, as the TURN address might only be resolvable by the proxy server itself, not by the client application initiating the connection.

To avoid this error in proxy scenarios, this PR modifies the initialization to omit the TURN address when creating the `turn.Client`.

Blocker:
This change depends on functionality introduced in `pion/turn` Pull Request [#450](https://github.com/pion/turn/pull/450).