### PR TITLE
Update lint rules, force testify/assert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/active_tcp_test.go
+++ b/active_tcp_test.go
@@ -147,7 +147,7 @@ func TestActiveTCP(t *testing.T) {
 			req.NoError(err)
 			req.NotNil(activeAgent)
 
-			passiveAgentConn, activeAgenConn := connect(passiveAgent, activeAgent)
+			passiveAgentConn, activeAgenConn := connect(t, passiveAgent, activeAgent)
 			req.NotNil(passiveAgentConn)
 			req.NotNil(activeAgenConn)
 
@@ -220,7 +220,7 @@ func TestActiveTCP_NonBlocking(t *testing.T) {
 	require.NoError(t, aAgent.AddRemoteCandidate(invalidCandidate))
 	require.NoError(t, bAgent.AddRemoteCandidate(invalidCandidate))
 
-	connect(aAgent, bAgent)
+	connect(t, aAgent, bAgent)
 
 	<-isConnected
 }
@@ -284,7 +284,7 @@ func TestActiveTCP_Respect_NetworkTypes(t *testing.T) {
 	require.NoError(t, aAgent.AddRemoteCandidate(invalidCandidate))
 	require.NoError(t, bAgent.AddRemoteCandidate(invalidCandidate))
 
-	connect(aAgent, bAgent)
+	connect(t, aAgent, bAgent)
 
 	<-isConnected
 	require.NoError(t, tcpListener.Close())

--- a/agent_handlers_test.go
+++ b/agent_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/transport/v3/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConnectionStateNotifier(t *testing.T) {
@@ -33,7 +34,7 @@ func TestConnectionStateNotifier(t *testing.T) {
 			}
 			select {
 			case <-updates:
-				t.Errorf("received more updates than expected")
+				t.Errorf("received more updates than expected") // nolint
 			case <-time.After(1 * time.Second):
 			}
 			close(done)
@@ -53,14 +54,11 @@ func TestConnectionStateNotifier(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			for i := 0; i < 10000; i++ {
-				x := <-updates
-				if x != ConnectionState(i) {
-					t.Errorf("expected %d got %d", x, i)
-				}
+				assert.Equal(t, ConnectionState(i), <-updates)
 			}
 			select {
 			case <-updates:
-				t.Errorf("received more updates than expected")
+				t.Errorf("received more updates than expected") // nolint
 			case <-time.After(1 * time.Second):
 			}
 			close(done)

--- a/agent_udpmux_test.go
+++ b/agent_udpmux_test.go
@@ -71,7 +71,7 @@ func TestMuxAgent(t *testing.T) {
 				require.NoError(t, agent.Close())
 			}()
 
-			conn, muxedConn := connect(agent, muxedA)
+			conn, muxedConn := connect(t, agent, muxedA)
 
 			pair := muxedA.getSelectedPair()
 			require.NotNil(t, pair)

--- a/candidate_relay_test.go
+++ b/candidate_relay_test.go
@@ -80,7 +80,7 @@ func TestRelayOnlyConnection(t *testing.T) {
 	bNotifier, bConnected := onConnected()
 	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
 
-	connect(aAgent, bAgent)
+	connect(t, aAgent, bAgent)
 	<-aConnected
 	<-bConnected
 }

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -73,7 +73,7 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 	bNotifier, bConnected := onConnected()
 	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
 
-	connect(aAgent, bAgent)
+	connect(t, aAgent, bAgent)
 	<-aConnected
 	<-bConnected
 }

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -176,9 +176,7 @@ func TestCandidatePriority(t *testing.T) {
 			WantPriority: 16777215,
 		},
 	} {
-		if got, want := test.Candidate.Priority(), test.WantPriority; got != want {
-			t.Fatalf("Candidate(%v).Priority() = %d, want %d", test.Candidate, got, want)
-		}
+		require.Equal(t, test.Candidate.Priority(), test.WantPriority)
 	}
 }
 
@@ -271,9 +269,7 @@ func mustCandidateHost(t *testing.T, conf *CandidateHostConfig) Candidate {
 	t.Helper()
 
 	cand, err := NewCandidateHost(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return cand
 }
@@ -286,9 +282,7 @@ func mustCandidateHostWithExtensions(
 	t.Helper()
 
 	cand, err := NewCandidateHost(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cand.setExtensions(extensions)
 
@@ -299,9 +293,7 @@ func mustCandidateRelay(t *testing.T, conf *CandidateRelayConfig) Candidate {
 	t.Helper()
 
 	cand, err := NewCandidateRelay(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return cand
 }
@@ -314,9 +306,7 @@ func mustCandidateRelayWithExtensions(
 	t.Helper()
 
 	cand, err := NewCandidateRelay(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cand.setExtensions(extensions)
 
@@ -327,9 +317,7 @@ func mustCandidateServerReflexive(t *testing.T, conf *CandidateServerReflexiveCo
 	t.Helper()
 
 	cand, err := NewCandidateServerReflexive(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return cand
 }
@@ -342,9 +330,7 @@ func mustCandidateServerReflexiveWithExtensions(
 	t.Helper()
 
 	cand, err := NewCandidateServerReflexive(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cand.setExtensions(extensions)
 
@@ -359,9 +345,7 @@ func mustCandidatePeerReflexiveWithExtensions(
 	t.Helper()
 
 	cand, err := NewCandidatePeerReflexive(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cand.setExtensions(extensions)
 
@@ -603,7 +587,7 @@ func TestCandidateWriteTo(t *testing.T) {
 	})
 	require.NoError(t, err, "error creating test TCP listener")
 
-	conn, err := net.DialTCP("tcp", nil, listener.Addr().(*net.TCPAddr))
+	conn, err := net.DialTCP("tcp", nil, listener.Addr().(*net.TCPAddr)) // nolint
 	require.NoError(t, err, "error dialing test TCP connection")
 
 	loggerFactory := logging.NewDefaultLoggerFactory()
@@ -1049,9 +1033,7 @@ func TestCandidateGetExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		candidate.setExtensions(extensions)
 
@@ -1086,9 +1068,7 @@ func TestCandidateGetExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		candidate.setExtensions(extensions)
 
@@ -1111,9 +1091,7 @@ func TestCandidateGetExtension(t *testing.T) {
 			Foundation: "750",
 			TCPType:    TCPTypeActive,
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		tcpType, ok := candidate.GetExtension("tcptype")
 
@@ -1136,9 +1114,7 @@ func TestCandidateGetExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		tcpType, ok = candidate2.GetExtension("tcptype")
 
@@ -1163,9 +1139,7 @@ func TestBaseCandidateMarshalExtensions(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		candidate.setExtensions(extensions)
 
@@ -1181,9 +1155,7 @@ func TestBaseCandidateMarshalExtensions(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		value := candidate.marshalExtensions()
 		require.Equal(t, "", value)
@@ -1198,9 +1170,7 @@ func TestBaseCandidateMarshalExtensions(t *testing.T) {
 			Foundation: "750",
 			TCPType:    TCPTypeActive,
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		value := candidate.marshalExtensions()
 		require.Equal(t, "tcptype active", value)
@@ -1296,9 +1266,7 @@ func TestBaseCandidateExtensionsEqual(t *testing.T) {
 				Priority:   500,
 				Foundation: "750",
 			})
-			if err != nil {
-				t.Error(err)
-			}
+			require.NoError(t, err)
 
 			cand.setExtensions(testCase.extensions1)
 
@@ -1316,9 +1284,7 @@ func TestCandidateAddExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"a", "b"}))
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"c", "d"}))
@@ -1335,9 +1301,7 @@ func TestCandidateAddExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"a", "b"}))
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"a", "d"}))
@@ -1355,9 +1319,7 @@ func TestCandidateAddExtension(t *testing.T) {
 			Foundation: "750",
 			TCPType:    TCPTypeActive,
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		ext, ok := candidate.GetExtension("tcptype")
 		require.True(t, ok)
@@ -1380,9 +1342,7 @@ func TestCandidateAddExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"tcptype", "active"}))
 
@@ -1401,9 +1361,7 @@ func TestCandidateAddExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.Error(t, candidate.AddExtension(CandidateExtension{"", ""}))
 
@@ -1424,9 +1382,7 @@ func TestCandidateRemoveExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"a", "b"}))
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"c", "d"}))
@@ -1445,9 +1401,7 @@ func TestCandidateRemoveExtension(t *testing.T) {
 			Priority:   500,
 			Foundation: "750",
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"a", "b"}))
 		require.NoError(t, candidate.AddExtension(CandidateExtension{"c", "d"}))
@@ -1467,9 +1421,7 @@ func TestCandidateRemoveExtension(t *testing.T) {
 			Foundation: "750",
 			TCPType:    TCPTypeActive,
 		})
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		// tcptype extension should be removed, even if it's not in the extensions list (Not Parsed)
 		require.True(t, candidate.RemoveExtension("tcptype"))

--- a/candidatepair_test.go
+++ b/candidatepair_test.go
@@ -115,9 +115,7 @@ func TestCandidatePairPriority(t *testing.T) {
 			WantPriority: 72057593987596287,
 		},
 	} {
-		if got, want := test.Pair.priority(), test.WantPriority; got != want {
-			t.Fatalf("CandidatePair(%v).Priority() = %d, want %d", test.Pair, got, want)
-		}
+		require.Equal(t, test.Pair.priority(), test.WantPriority)
 	}
 }
 
@@ -125,9 +123,7 @@ func TestCandidatePairEquality(t *testing.T) {
 	pairA := newCandidatePair(hostCandidate(), srflxCandidate(), true)
 	pairB := newCandidatePair(hostCandidate(), srflxCandidate(), false)
 
-	if !pairA.equal(pairB) {
-		t.Fatalf("Expected %v to equal %v", pairA, pairB)
-	}
+	require.True(t, pairA.equal(pairB))
 }
 
 func TestNilCandidatePairString(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -136,7 +136,6 @@ var (
 	errParseRelatedAddr              = errors.New("failed to parse related addresses")
 	errParseExtension                = errors.New("failed to parse extension")
 	errParseTCPType                  = errors.New("failed to parse TCP type")
-	errRead                          = errors.New("failed to read")
 	errUDPMuxDisabled                = errors.New("UDPMux is not enabled")
 	errUnknownRole                   = errors.New("unknown role")
 	errWrite                         = errors.New("failed to write")

--- a/gather_test.go
+++ b/gather_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/url"
-	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -78,19 +77,13 @@ func TestListenUDP(t *testing.T) {
 		require.NoError(t, err)
 
 		p, _ := strconv.Atoi(port)
-		if p < portMin || p > portMax {
-			t.Fatalf("listenUDP with port restriction [%d, %d] listened on incorrect port (%s)", portMin, portMax, port)
-		}
+		require.False(t, p < portMin || p > portMax)
 		result = append(result, p)
 		portRange = append(portRange, portMin+i)
 	}
-	if sort.IntsAreSorted(result) {
-		t.Fatalf("listenUDP with port restriction [%d, %d], ports result should be random", portMin, portMax)
-	}
+	require.False(t, sort.IntsAreSorted(result))
 	sort.Ints(result)
-	if !reflect.DeepEqual(result, portRange) {
-		t.Fatalf("listenUDP with port restriction [%d, %d], got:%v, want:%v", portMin, portMax, result, portRange)
-	}
+	require.Equal(t, result, portRange)
 	_, err = listenUDPInPortRange(agent.net, agent.log, portMax, portMin, udp, &net.UDPAddr{IP: ip, Port: 0})
 	require.Equal(t, err, ErrPort, "listenUDP with port restriction [%d, %d], did not return ErrPort", portMin, portMax)
 }

--- a/icecontrol_test.go
+++ b/icecontrol_test.go
@@ -4,69 +4,52 @@
 package ice
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestControlled_GetFrom(t *testing.T) { //nolint:dupl
 	m := new(stun.Message)
 	var attrCtr AttrControlled
-	if err := attrCtr.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-		t.Error("unexpected error")
-	}
-	if err := m.Build(stun.BindingRequest, &attrCtr); err != nil {
-		t.Error(err)
-	}
+	require.ErrorIs(t, stun.ErrAttributeNotFound, attrCtr.GetFrom(m))
+	require.NoError(t, m.Build(stun.BindingRequest, &attrCtr))
+
 	m1 := new(stun.Message)
-	if _, err := m1.Write(m.Raw); err != nil {
-		t.Error(err)
-	}
+	_, err := m1.Write(m.Raw)
+	require.NoError(t, err)
+
 	var c1 AttrControlled
-	if err := c1.GetFrom(m1); err != nil {
-		t.Error(err)
-	}
-	if c1 != attrCtr {
-		t.Error("not equal")
-	}
+	require.NoError(t, c1.GetFrom(m1))
+	require.Equal(t, c1, attrCtr)
+
 	t.Run("IncorrectSize", func(t *testing.T) {
 		m3 := new(stun.Message)
 		m3.Add(stun.AttrICEControlled, make([]byte, 100))
 		var c2 AttrControlled
-		if err := c2.GetFrom(m3); !stun.IsAttrSizeInvalid(err) {
-			t.Error("should error")
-		}
+		require.True(t, stun.IsAttrSizeInvalid(c2.GetFrom(m3)))
 	})
 }
 
 func TestControlling_GetFrom(t *testing.T) { //nolint:dupl
 	m := new(stun.Message)
 	var attrCtr AttrControlling
-	if err := attrCtr.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-		t.Error("unexpected error")
-	}
-	if err := m.Build(stun.BindingRequest, &attrCtr); err != nil {
-		t.Error(err)
-	}
+	require.ErrorIs(t, stun.ErrAttributeNotFound, attrCtr.GetFrom(m))
+	require.NoError(t, m.Build(stun.BindingRequest, &attrCtr))
+
 	m1 := new(stun.Message)
-	if _, err := m1.Write(m.Raw); err != nil {
-		t.Error(err)
-	}
+	_, err := m1.Write(m.Raw)
+	require.NoError(t, err)
+
 	var c1 AttrControlling
-	if err := c1.GetFrom(m1); err != nil {
-		t.Error(err)
-	}
-	if c1 != attrCtr {
-		t.Error("not equal")
-	}
+	require.NoError(t, c1.GetFrom(m1))
+	require.Equal(t, c1, attrCtr)
 	t.Run("IncorrectSize", func(t *testing.T) {
 		m3 := new(stun.Message)
 		m3.Add(stun.AttrICEControlling, make([]byte, 100))
 		var c2 AttrControlling
-		if err := c2.GetFrom(m3); !stun.IsAttrSizeInvalid(err) {
-			t.Error("should error")
-		}
+		require.True(t, stun.IsAttrSizeInvalid(c2.GetFrom(m3)))
 	})
 }
 
@@ -74,70 +57,49 @@ func TestControl_GetFrom(t *testing.T) { //nolint:cyclop
 	t.Run("Blank", func(t *testing.T) {
 		m := new(stun.Message)
 		var c AttrControl
-		if err := c.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-			t.Error("unexpected error")
-		}
+		require.ErrorIs(t, stun.ErrAttributeNotFound, c.GetFrom(m))
 	})
 	t.Run("Controlling", func(t *testing.T) { //nolint:dupl
 		m := new(stun.Message)
 		var attCtr AttrControl
-		if err := attCtr.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-			t.Error("unexpected error")
-		}
+		require.ErrorIs(t, stun.ErrAttributeNotFound, attCtr.GetFrom(m))
 		attCtr.Role = Controlling
 		attCtr.Tiebreaker = 4321
-		if err := m.Build(stun.BindingRequest, &attCtr); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, m.Build(stun.BindingRequest, &attCtr))
 		m1 := new(stun.Message)
-		if _, err := m1.Write(m.Raw); err != nil {
-			t.Error(err)
-		}
+		_, err := m1.Write(m.Raw)
+		require.NoError(t, err)
 		var c1 AttrControl
-		if err := c1.GetFrom(m1); err != nil {
-			t.Error(err)
-		}
-		if c1 != attCtr {
-			t.Error("not equal")
-		}
+		require.NoError(t, c1.GetFrom(m1))
+		require.Equal(t, c1, attCtr)
 		t.Run("IncorrectSize", func(t *testing.T) {
 			m3 := new(stun.Message)
 			m3.Add(stun.AttrICEControlling, make([]byte, 100))
 			var c2 AttrControl
-			if err := c2.GetFrom(m3); !stun.IsAttrSizeInvalid(err) {
-				t.Error("should error")
-			}
+			err := c2.GetFrom(m3)
+			require.True(t, stun.IsAttrSizeInvalid(err))
 		})
 	})
 	t.Run("Controlled", func(t *testing.T) { //nolint:dupl
 		m := new(stun.Message)
 		var attrCtrl AttrControl
-		if err := attrCtrl.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-			t.Error("unexpected error")
-		}
+		require.ErrorIs(t, stun.ErrAttributeNotFound, attrCtrl.GetFrom(m))
 		attrCtrl.Role = Controlled
 		attrCtrl.Tiebreaker = 1234
-		if err := m.Build(stun.BindingRequest, &attrCtrl); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, m.Build(stun.BindingRequest, &attrCtrl))
 		m1 := new(stun.Message)
-		if _, err := m1.Write(m.Raw); err != nil {
-			t.Error(err)
-		}
+		_, err := m1.Write(m.Raw)
+		require.NoError(t, err)
+
 		var c1 AttrControl
-		if err := c1.GetFrom(m1); err != nil {
-			t.Error(err)
-		}
-		if c1 != attrCtrl {
-			t.Error("not equal")
-		}
+		require.NoError(t, c1.GetFrom(m1))
+		require.Equal(t, c1, attrCtrl)
 		t.Run("IncorrectSize", func(t *testing.T) {
 			m3 := new(stun.Message)
 			m3.Add(stun.AttrICEControlling, make([]byte, 100))
 			var c2 AttrControl
-			if err := c2.GetFrom(m3); !stun.IsAttrSizeInvalid(err) {
-				t.Error("should error")
-			}
+			err := c2.GetFrom(m3)
+			require.True(t, stun.IsAttrSizeInvalid(err))
 		})
 	})
 }

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -65,7 +65,7 @@ func TestMulticastDNSOnlyConnection(t *testing.T) {
 			bNotifier, bConnected := onConnected()
 			require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
 
-			connect(aAgent, bAgent)
+			connect(t, aAgent, bAgent)
 			<-aConnected
 			<-bConnected
 		})
@@ -124,7 +124,7 @@ func TestMulticastDNSMixedConnection(t *testing.T) {
 			bNotifier, bConnected := onConnected()
 			require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
 
-			connect(aAgent, bAgent)
+			connect(t, aAgent, bAgent)
 			<-aConnected
 			<-bConnected
 		})
@@ -195,7 +195,5 @@ func TestGenerateMulticastDNSName(t *testing.T) {
 		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}.local+$`,
 	).MatchString
 
-	if !isMDNSName(name) {
-		t.Fatalf("mDNS name must be UUID v4 + \".local\" suffix, got %s", name)
-	}
+	require.True(t, isMDNSName(name))
 }

--- a/net_test.go
+++ b/net_test.go
@@ -13,25 +13,11 @@ import (
 )
 
 func TestIsSupportedIPv6Partial(t *testing.T) {
-	if isSupportedIPv6Partial(net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}) {
-		t.Errorf("isSupportedIPv6Partial returned true with IPv4-compatible IPv6 address")
-	}
-
-	if isSupportedIPv6Partial(net.ParseIP("fec0::2333")) {
-		t.Errorf("isSupportedIPv6Partial returned true with IPv6 site-local unicast address")
-	}
-
-	if !isSupportedIPv6Partial(net.ParseIP("fe80::2333")) {
-		t.Errorf("isSupportedIPv6Partial returned false with IPv6 link-local address")
-	}
-
-	if !isSupportedIPv6Partial(net.ParseIP("ff02::2333")) {
-		t.Errorf("isSupportedIPv6Partial returned false with IPv6 link-local multicast address")
-	}
-
-	if !isSupportedIPv6Partial(net.ParseIP("2001::1")) {
-		t.Errorf("isSupportedIPv6Partial returned false with IPv6 global unicast address")
-	}
+	require.False(t, isSupportedIPv6Partial(net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}))
+	require.False(t, isSupportedIPv6Partial(net.ParseIP("fec0::2333")))
+	require.True(t, isSupportedIPv6Partial(net.ParseIP("fe80::2333")))
+	require.True(t, isSupportedIPv6Partial(net.ParseIP("ff02::2333")))
+	require.True(t, isSupportedIPv6Partial(net.ParseIP("2001::1")))
 }
 
 func TestCreateAddr(t *testing.T) {
@@ -67,7 +53,7 @@ func mustAddr(t *testing.T, ip net.IP) netip.Addr {
 	t.Helper()
 	addr, ok := netip.AddrFromSlice(ip)
 	if !ok {
-		t.Fatal(ipConvertError{ip})
+		t.Fatal(ipConvertError{ip}) // nolint
 	}
 
 	return addr

--- a/networktype_test.go
+++ b/networktype_test.go
@@ -46,13 +46,8 @@ func TestNetworkTypeParsing_Success(t *testing.T) {
 		},
 	} {
 		actual, err := determineNetworkType(test.inNetwork, mustAddr(t, test.inIP))
-		if err != nil {
-			t.Errorf("NetworkTypeParsing failed: %v", err)
-		}
-		if actual != test.expected {
-			t.Errorf("NetworkTypeParsing: '%s' -- input:%s expected:%s actual:%s",
-				test.name, test.inNetwork, test.expected, actual)
-		}
+		require.NoError(t, err)
+		require.Equal(t, test.expected, actual)
 	}
 }
 
@@ -70,11 +65,8 @@ func TestNetworkTypeParsing_Failure(t *testing.T) {
 			ipv6,
 		},
 	} {
-		actual, err := determineNetworkType(test.inNetwork, mustAddr(t, test.inIP))
-		if err == nil {
-			t.Errorf("NetworkTypeParsing should fail: '%s' -- input:%s actual:%s",
-				test.name, test.inNetwork, actual)
-		}
+		_, err := determineNetworkType(test.inNetwork, mustAddr(t, test.inIP))
+		require.Error(t, err)
 	}
 }
 

--- a/priority_test.go
+++ b/priority_test.go
@@ -4,38 +4,29 @@
 package ice
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPriority_GetFrom(t *testing.T) { //nolint:dupl
 	m := new(stun.Message)
 	var priority PriorityAttr
-	if err := priority.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-		t.Error("unexpected error")
-	}
-	if err := m.Build(stun.BindingRequest, &priority); err != nil {
-		t.Error(err)
-	}
+	require.ErrorIs(t, stun.ErrAttributeNotFound, priority.GetFrom(m))
+	require.NoError(t, m.Build(stun.BindingRequest, &priority))
+
 	m1 := new(stun.Message)
-	if _, err := m1.Write(m.Raw); err != nil {
-		t.Error(err)
-	}
+	_, err := m1.Write(m.Raw)
+	require.NoError(t, err)
+
 	var p1 PriorityAttr
-	if err := p1.GetFrom(m1); err != nil {
-		t.Error(err)
-	}
-	if p1 != priority {
-		t.Error("not equal")
-	}
+	require.NoError(t, p1.GetFrom(m1))
+	require.Equal(t, p1, priority)
 	t.Run("IncorrectSize", func(t *testing.T) {
 		m3 := new(stun.Message)
 		m3.Add(stun.AttrPriority, make([]byte, 100))
 		var p2 PriorityAttr
-		if err := p2.GetFrom(m3); !stun.IsAttrSizeInvalid(err) {
-			t.Error("should error")
-		}
+		require.True(t, stun.IsAttrSizeInvalid(p2.GetFrom(m3)))
 	})
 }

--- a/rand_test.go
+++ b/rand_test.go
@@ -67,15 +67,10 @@ func TestRandomGeneratorCollision(t *testing.T) {
 				}
 				wg.Wait()
 
-				if len(rands) != num {
-					t.Fatal("Failed to generate randoms")
-				}
-
+				require.Len(t, rands, num)
 				for i := 0; i < num; i++ {
 					for j := i + 1; j < num; j++ {
-						if rands[i] == rands[j] {
-							t.Fatalf("generateRandString caused collision: %s == %s", rands[i], rands[j])
-						}
+						require.NotEqual(t, rands[i], rands[j])
 					}
 				}
 			}

--- a/selection_test.go
+++ b/selection_test.go
@@ -97,7 +97,7 @@ func TestBindingRequestHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, controlledAgent.OnConnectionStateChange(bNotifier))
 
-	controlledConn, controllingConn := connect(controlledAgent, controllingAgent)
+	controlledConn, controllingConn := connect(t, controlledAgent, controllingAgent)
 	<-aConnected
 	<-bConnected
 

--- a/tcp_mux_multi_test.go
+++ b/tcp_mux_multi_test.go
@@ -61,7 +61,7 @@ func TestMultiTCPMux_Recv(t *testing.T) {
 				defer func() {
 					_ = pktConn.Close()
 				}()
-				conn, err := net.DialTCP("tcp", nil, pktConn.LocalAddr().(*net.TCPAddr))
+				conn, err := net.DialTCP("tcp", nil, pktConn.LocalAddr().(*net.TCPAddr)) // nolint
 				require.NoError(t, err, "error dialing test TCP connection")
 
 				msg := stun.New()

--- a/tcp_mux_test.go
+++ b/tcp_mux_test.go
@@ -51,7 +51,7 @@ func TestTCPMux_Recv(t *testing.T) {
 
 			require.NotNil(t, tcpMux.LocalAddr(), "tcpMux.LocalAddr() is nil")
 
-			conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr))
+			conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr)) // nolint
 			require.NoError(t, err, "error dialing test TCP connection")
 
 			msg := stun.New()
@@ -150,7 +150,7 @@ func TestTCPMux_FirstPacketTimeout(t *testing.T) {
 
 	require.NotNil(t, tcpMux.LocalAddr(), "tcpMux.LocalAddr() is nil")
 
-	conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr))
+	conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr)) // nolint
 	require.NoError(t, err, "error dialing test TCP connection")
 	defer func() {
 		_ = conn.Close()
@@ -192,7 +192,7 @@ func TestTCPMux_NoLeakForConnectionFromStun(t *testing.T) {
 	require.NotNil(t, tcpMux.LocalAddr(), "tcpMux.LocalAddr() is nil")
 
 	t.Run("close connection from stun msg after timeout", func(t *testing.T) {
-		conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr))
+		conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr)) // nolint
 		require.NoError(t, err, "error dialing test TCP connection")
 		defer func() {
 			_ = conn.Close()
@@ -217,7 +217,7 @@ func TestTCPMux_NoLeakForConnectionFromStun(t *testing.T) {
 	})
 
 	t.Run("connection keep alive if access by user", func(t *testing.T) {
-		conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr))
+		conn, err := net.DialTCP("tcp", nil, tcpMux.LocalAddr().(*net.TCPAddr)) // nolint
 		require.NoError(t, err, "error dialing test TCP connection")
 		defer func() {
 			_ = conn.Close()

--- a/transport_vnet_test.go
+++ b/transport_vnet_test.go
@@ -53,7 +53,7 @@ func TestRemoteLocalAddr(t *testing.T) {
 	})
 
 	t.Run("Remote/Local Pair Match between Agents", func(t *testing.T) {
-		ca, cb := pipeWithVNet(builtVnet,
+		ca, cb := pipeWithVNet(t, builtVnet,
 			&agentTestConfig{
 				urls: []*stun.URI{stunServerURL},
 			},

--- a/udp_mux_multi_test.go
+++ b/udp_mux_multi_test.go
@@ -103,7 +103,7 @@ func testMultiUDPMuxConnections(t *testing.T, udpMuxMulti *MultiUDPMuxDefault, u
 
 	// Try talking with each PacketConn
 	for _, pktConn := range pktConns {
-		remoteConn, err := net.DialUDP(network, nil, pktConn.LocalAddr().(*net.UDPAddr))
+		remoteConn, err := net.DialUDP(network, nil, pktConn.LocalAddr().(*net.UDPAddr)) // nolint
 		require.NoError(t, err, "error dialing test UDP connection")
 		testMuxConnectionPair(t, pktConn, remoteConn, ufrag)
 	}

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -252,7 +252,7 @@ func verifyPacket(t *testing.T, b []byte, nextSeq uint32) {
 
 func TestUDPMux_Agent_Restart(t *testing.T) {
 	oneSecond := time.Second
-	connA, connB := pipe(&AgentConfig{
+	connA, connB := pipe(t, &AgentConfig{
 		DisconnectedTimeout: &oneSecond,
 		FailedTimeout:       &oneSecond,
 	})
@@ -279,7 +279,7 @@ func TestUDPMux_Agent_Restart(t *testing.T) {
 
 	require.NoError(t, connA.agent.SetRemoteCredentials(ufragB, pwdB))
 	require.NoError(t, connB.agent.SetRemoteCredentials(ufragA, pwdA))
-	gatherAndExchangeCandidates(connA.agent, connB.agent)
+	gatherAndExchangeCandidates(t, connA.agent, connB.agent)
 
 	// Wait until both have gone back to connected
 	<-aConnected

--- a/udp_mux_universal_test.go
+++ b/udp_mux_universal_test.go
@@ -51,7 +51,7 @@ func testMuxSrflxConnection(t *testing.T, udpMux *UniversalUDPMuxDefault, ufrag 
 		_ = pktConn.Close()
 	}()
 
-	remoteConn, err := net.DialUDP(network, nil, &net.UDPAddr{
+	remoteConn, err := net.DialUDP(network, nil, &net.UDPAddr{ // nolint
 		Port: udpMux.LocalAddr().(*net.UDPAddr).Port,
 	})
 	require.NoError(t, err, "error dialing test UDP connection")

--- a/usecandidate_test.go
+++ b/usecandidate_test.go
@@ -7,21 +7,16 @@ import (
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUseCandidateAttr_AddTo(t *testing.T) {
 	m := new(stun.Message)
-	if UseCandidate().IsSet(m) {
-		t.Error("should not be set")
-	}
-	if err := m.Build(stun.BindingRequest, UseCandidate()); err != nil {
-		t.Error(err)
-	}
+	require.False(t, UseCandidate().IsSet(m))
+	require.NoError(t, m.Build(stun.BindingRequest, UseCandidate()))
+
 	m1 := new(stun.Message)
-	if _, err := m1.Write(m.Raw); err != nil {
-		t.Error(err)
-	}
-	if !UseCandidate().IsSet(m1) {
-		t.Error("should be set")
-	}
+	_, err := m1.Write(m.Raw)
+	require.NoError(t, err)
+	require.True(t, UseCandidate().IsSet(m1))
 }


### PR DESCRIPTION
Use testify's assert package instead of the standard library's testing package.