### PR TITLE
Allow cancelling TURN Allocate phase, which can block for ~7.8s if TURN server is not responding.

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -836,7 +836,17 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 				return
 			}
 
+			allocDoneCh := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					client.Close()
+				case <-allocDoneCh:
+				}
+			}()
+
 			relayConn, err := client.Allocate()
+			close(allocDoneCh)
 			if err != nil {
 				client.Close()
 				closeConnAndLog(locConn, a.log, "failed to allocate on TURN client %s %s", turnServerAddr, err)

--- a/gather_vnet_test.go
+++ b/gather_vnet_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
@@ -434,4 +435,51 @@ func TestVNetGather_TURNConnectionLeak(t *testing.T) {
 	}()
 
 	aAgent.gatherCandidatesRelay(context.Background(), []*stun.URI{turnServerURL})
+}
+
+func TestVNetGather_TURNAllocationAbort(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	// configure unreachable TURN server
+	turnServerURL := &stun.URI{
+		Scheme:   stun.SchemeTypeTURN,
+		Host:     vnetSTUNServerIP,
+		Port:     vnetSTUNServerPort,
+		Username: "user",
+		Password: "pass",
+		Proto:    stun.ProtoTypeUDP,
+	}
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	router, err := vnet.NewRouter(&vnet.RouterConfig{
+		CIDR:          "10.0.0.0/24",
+		LoggerFactory: loggerFactory,
+	})
+	require.NoError(t, err)
+
+	nw, err := vnet.NewNet(&vnet.NetConfig{})
+	require.NoError(t, err)
+	require.NoError(t, router.AddNet(nw))
+
+	cfg0 := &AgentConfig{
+		Urls: []*stun.URI{
+			turnServerURL,
+		},
+		NetworkTypes:     supportedNetworkTypes(),
+		MulticastDNSMode: MulticastDNSModeDisabled,
+		Net:              nw,
+	}
+	aAgent, err := NewAgent(cfg0)
+	require.NoError(t, err, "should succeed")
+	defer func() {
+		require.NoError(t, aAgent.Close())
+	}()
+
+	// if not canceled, gatherCandidatesRelay() will block for ~7.8s
+	defer test.TimeOut(time.Second * 1).Stop()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelFunc()
+
+	aAgent.gatherCandidatesRelay(ctx, []*stun.URI{turnServerURL})
 }


### PR DESCRIPTION
#### Description

Although [Agent.GatherCandidates()](https://github.com/pion/ice/blob/753c2a0fe868006a9e8d341feb11fc6a5d54a45d/gather.go#L39) have a cancellable context, the [turn.Client.Allocate()](https://github.com/pion/turn/blob/61a25e754f7a9c4e6ba5a4b8ee18579899985339/client.go#L325) processing does not use it and can hang for about 7.8 seconds if the TURN server is unreachable.
This happens because Allocate() completes only after the ALLOCATE request retry limit is reached.
Ultimately, PeerConnection.Close() will block while waiting for unnecessary allocation to complete.

PR fixes this behavior by cancelling ALLOCATE phase if context was cancelled.

Caveat: If cancelled, Client.Allocate will nevertheless return error ("transaction closed") which is logged as warning [here](https://github.com/pion/ice/blob/753c2a0fe868006a9e8d341feb11fc6a5d54a45d/gather.go#L842).


