### PR TITLE
Enable any type alias in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,12 @@ linters-settings:
       - w io.Writer
       - r io.Reader
       - b []byte
-
+  revive:
+    rules:
+      # Prefer 'any' type alias over 'interface{}' for Go 1.18+ compatibility
+      - name: use-any
+        severity: warning
+        disabled: false
 linters:
   enable:
     - asciicheck       # Simple linter to check that your code does not contain non-ASCII identifiers


### PR DESCRIPTION
Add detection of the any type in the CI review.


