### PR TITLE
Optimize slice allocation in UDPMuxDefault

### DIFF
--- a/udp_mux.go
+++ b/udp_mux.go
@@ -95,12 +95,13 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault { //nolint:cyclop
 
 			_, addrs, err := localInterfaces(params.Net, nil, nil, networks, true)
 			if err == nil {
-				for _, addr := range addrs {
-					localAddrsForUnspecified = append(localAddrsForUnspecified, &net.UDPAddr{
+				localAddrsForUnspecified = make([]net.Addr, len(addrs))
+				for i, addr := range addrs {
+					localAddrsForUnspecified[i] = &net.UDPAddr{
 						IP:   addr.AsSlice(),
 						Port: udpAddr.Port,
 						Zone: addr.Zone(),
-					})
+					}
 				}
 			} else {
 				params.Logger.Errorf("Failed to get local interfaces for unspecified addr: %v", err)


### PR DESCRIPTION
Pre-allocate localAddrsForUnspecified slice with known capacity and use index assignment instead of append to avoid multiple slice reallocations.
