### PR TITLE
Re-enable ipv6 UDP mux tests in i386.

### DIFF
--- a/udp_mux_multi_test.go
+++ b/udp_mux_multi_test.go
@@ -63,11 +63,7 @@ func TestMultiUDPMux(t *testing.T) {
 		testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag2", udp4)
 	}()
 
-	// Skip ipv6 test on i386
-	const ptrSize = 32 << (^uintptr(0) >> 63)
-	if ptrSize != 32 {
-		testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag3", udp6)
-	}
+	testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag3", udp6)
 
 	wg.Wait()
 
@@ -136,11 +132,7 @@ func TestUnspecifiedUDPMux(t *testing.T) {
 		testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag2", udp4)
 	}()
 
-	// Skip IPv6 test on i386
-	const ptrSize = 32 << (^uintptr(0) >> 63)
-	if ptrSize != 32 {
-		testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag3", udp6)
-	}
+	testMultiUDPMuxConnections(t, udpMuxMulti, "ufrag3", udp6)
 
 	wg.Wait()
 

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -107,10 +107,8 @@ func TestUDPMux(t *testing.T) { //nolint:cyclop
 					defer wg.Done()
 					testMuxConnection(t, udpMux, "ufrag2", udp4)
 				}()
-				// Skip IPv6 test on i386
-				if ptrSize != 32 {
-					testMuxConnection(t, udpMux, "ufrag3", udp6)
-				}
+
+				testMuxConnection(t, udpMux, "ufrag3", udp6)
 			} else if ptrSize != 32 || network != udp6 {
 				testMuxConnection(t, udpMux, "ufrag2", network)
 			}


### PR DESCRIPTION
#### Description
Re-enables the ipv6 UDP mux tests for i386. Please let me know what I can improve since I'd love to know what I can do better. I'm open to all feedback!

This change is made possible thanks to https://github.com/pion/.goassets/pull/224. Note that https://github.com/pion/mdns/pull/223 was a similar effort that re-enabled ipv6 tests in i386.

#### Reference issue
Fixes #560 