### PR TITLE
Wire up the remaining agent options

### DIFF
--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -4,15 +4,19 @@
 package ice
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
 )
 
 // testBooleanOption is a helper function to test boolean agent options.
@@ -74,6 +78,206 @@ func TestDefaultNominationValueGenerator(t *testing.T) {
 		assert.Equal(t, uint32(2), gen1())
 		assert.Equal(t, uint32(2), gen2())
 	})
+}
+
+func TestWithLite(t *testing.T) {
+	t.Run("enables lite with host candidates", func(t *testing.T) {
+		agent, err := NewAgentWithOptions(
+			WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+			WithICELite(true),
+		)
+		require.NoError(t, err)
+		defer agent.Close() //nolint:errcheck
+
+		assert.True(t, agent.lite)
+	})
+
+	t.Run("default is not lite", func(t *testing.T) {
+		agent, err := NewAgentWithOptions()
+		require.NoError(t, err)
+		defer agent.Close() //nolint:errcheck
+
+		assert.False(t, agent.lite)
+	})
+
+	t.Run("config sets lite", func(t *testing.T) {
+		config := &AgentConfig{
+			Lite:           true,
+			CandidateTypes: []CandidateType{CandidateTypeHost},
+			NetworkTypes:   []NetworkType{NetworkTypeUDP4},
+		}
+
+		agent, err := NewAgent(config)
+		require.NoError(t, err)
+		defer agent.Close() //nolint:errcheck
+
+		assert.True(t, agent.lite)
+	})
+
+	t.Run("errors when candidate types include non-host", func(t *testing.T) {
+		_, err := NewAgentWithOptions(WithICELite(true))
+		assert.ErrorIs(t, err, ErrLiteUsingNonHostCandidates)
+	})
+}
+
+func TestWithUrls(t *testing.T) {
+	stunURL, err := stun.ParseURI("stun:example.com:3478")
+	require.NoError(t, err)
+
+	input := []*stun.URI{stunURL}
+	agent, err := NewAgentWithOptions(WithUrls(input))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	require.Len(t, agent.urls, 1)
+	assert.Equal(t, stunURL.String(), agent.urls[0].String())
+
+	input[0] = nil
+	require.Len(t, agent.urls, 1)
+	assert.NotNil(t, agent.urls[0])
+}
+
+func TestWithPortRange(t *testing.T) {
+	agent, err := NewAgentWithOptions(WithPortRange(1000, 2000))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, uint16(1000), agent.portMin)
+	assert.Equal(t, uint16(2000), agent.portMax)
+
+	_, err = NewAgentWithOptions(WithPortRange(2000, 1000))
+	assert.ErrorIs(t, err, ErrPort)
+}
+
+func TestWithTimeoutOptions(t *testing.T) {
+	agent, err := NewAgentWithOptions(
+		WithDisconnectedTimeout(10*time.Second),
+		WithFailedTimeout(20*time.Second),
+		WithKeepaliveInterval(3*time.Second),
+		WithCheckInterval(150*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, 10*time.Second, agent.disconnectedTimeout)
+	assert.Equal(t, 20*time.Second, agent.failedTimeout)
+	assert.Equal(t, 3*time.Second, agent.keepaliveInterval)
+	assert.Equal(t, 150*time.Millisecond, agent.checkInterval)
+}
+
+func TestWithAcceptanceWaitOptions(t *testing.T) {
+	agent, err := NewAgentWithOptions(
+		WithHostAcceptanceMinWait(1*time.Second),
+		WithSrflxAcceptanceMinWait(2*time.Second),
+		WithPrflxAcceptanceMinWait(3*time.Second),
+		WithRelayAcceptanceMinWait(4*time.Second),
+	)
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, 1*time.Second, agent.hostAcceptanceMinWait)
+	assert.Equal(t, 2*time.Second, agent.srflxAcceptanceMinWait)
+	assert.Equal(t, 3*time.Second, agent.prflxAcceptanceMinWait)
+	assert.Equal(t, 4*time.Second, agent.relayAcceptanceMinWait)
+}
+
+func TestWithSTUNGatherTimeout(t *testing.T) {
+	agent, err := NewAgentWithOptions(WithSTUNGatherTimeout(7 * time.Second))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, 7*time.Second, agent.stunGatherTimeout)
+}
+
+func TestWithIPFilterOption(t *testing.T) {
+	filter := func(ip net.IP) bool {
+		return ip.IsLoopback()
+	}
+
+	agent, err := NewAgentWithOptions(WithIPFilter(filter))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	require.NotNil(t, agent.ipFilter)
+	assert.True(t, agent.ipFilter(net.IPv4(127, 0, 0, 1)))
+	assert.False(t, agent.ipFilter(net.IPv4(192, 0, 2, 1)))
+}
+
+func TestWithNetOption(t *testing.T) {
+	stub := newStubNet(t)
+
+	agent, err := NewAgentWithOptions(WithNet(stub))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, agent.Close()) }()
+
+	assert.Equal(t, stub, agent.net)
+}
+
+func TestWithMulticastDNSOptions(t *testing.T) {
+	agent, err := NewAgentWithOptions(
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+		WithMulticastDNSHostName("pion-test.local"),
+	)
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, MulticastDNSModeDisabled, agent.mDNSMode)
+	assert.Equal(t, "pion-test.local", agent.mDNSName)
+
+	_, err = NewAgentWithOptions(WithMulticastDNSHostName("invalid-host"))
+	assert.ErrorIs(t, err, ErrInvalidMulticastDNSHostName)
+}
+
+func TestWithLocalCredentials(t *testing.T) {
+	password := strings.Repeat("p", 16)
+
+	agent, err := NewAgentWithOptions(WithLocalCredentials("abcd", password))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, "abcd", agent.localUfrag)
+	assert.Equal(t, password, agent.localPwd)
+
+	_, err = NewAgentWithOptions(WithLocalCredentials("ab", password))
+	assert.ErrorIs(t, err, ErrLocalUfragInsufficientBits)
+
+	shortPassword := strings.Repeat("p", 10)
+	_, err = NewAgentWithOptions(WithLocalCredentials("abcd", shortPassword))
+	assert.ErrorIs(t, err, ErrLocalPwdInsufficientBits)
+}
+
+func TestWithMuxOptions(t *testing.T) {
+	tcpMux := &stubTCPMux{}
+	udpMux := &stubUDPMux{}
+	udpMuxSrflx := &stubUniversalUDPMux{}
+
+	agent, err := NewAgentWithOptions(
+		WithTCPMux(tcpMux),
+		WithUDPMux(udpMux),
+		WithUDPMuxSrflx(udpMuxSrflx),
+	)
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, tcpMux, agent.tcpMux)
+	assert.Equal(t, udpMux, agent.udpMux)
+	assert.Equal(t, udpMuxSrflx, agent.udpMuxSrflx)
+}
+
+func TestWithProxyDialer(t *testing.T) {
+	agent, err := NewAgentWithOptions(WithProxyDialer(proxy.Direct))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, proxy.Direct, agent.proxyDialer)
+}
+
+func TestWithMaxBindingRequests(t *testing.T) {
+	agent, err := NewAgentWithOptions(WithMaxBindingRequests(3))
+	require.NoError(t, err)
+	defer agent.Close() //nolint:errcheck
+
+	assert.Equal(t, uint16(3), agent.maxBindingRequests)
 }
 
 func TestWithRenomination(t *testing.T) {
@@ -441,6 +645,52 @@ func TestWithCandidateTypesNAT1To1Validation(t *testing.T) {
 		}, WithCandidateTypes([]CandidateType{CandidateTypeHost}))
 		require.ErrorIs(t, err, ErrIneffectiveNAT1To1IPMappingSrflx)
 	})
+}
+
+var errStubNotImplemented = errors.New("stub not implemented")
+
+type stubTCPMux struct{}
+
+func (m *stubTCPMux) Close() error {
+	return nil
+}
+
+func (m *stubTCPMux) GetConnByUfrag(string, bool, net.IP) (net.PacketConn, error) {
+	return nil, errStubNotImplemented
+}
+
+func (m *stubTCPMux) RemoveConnByUfrag(string) {}
+
+type stubUDPMux struct{}
+
+func (m *stubUDPMux) Close() error {
+	return nil
+}
+
+func (m *stubUDPMux) GetConn(string, net.Addr) (net.PacketConn, error) {
+	return nil, errStubNotImplemented
+}
+
+func (m *stubUDPMux) RemoveConnByUfrag(string) {}
+
+func (m *stubUDPMux) GetListenAddresses() []net.Addr {
+	return nil
+}
+
+type stubUniversalUDPMux struct {
+	stubUDPMux
+}
+
+func (m *stubUniversalUDPMux) GetXORMappedAddr(net.Addr, time.Duration) (*stun.XORMappedAddress, error) {
+	return nil, errStubNotImplemented
+}
+
+func (m *stubUniversalUDPMux) GetRelayedAddr(net.Addr, time.Duration) (*net.Addr, error) {
+	return nil, errStubNotImplemented
+}
+
+func (m *stubUniversalUDPMux) GetConnForURL(string, string, net.Addr) (net.PacketConn, error) {
+	return nil, errStubNotImplemented
 }
 
 type stubNet struct {


### PR DESCRIPTION
#### Description
Everything that webrtc uses right now except for `NAT1To1IPs` because I'm taking this as an opportunity to introduce a new behavior.