### PR TITLE
Fix a deadlock in TaskLoop

### DIFF
--- a/internal/taskloop/taskloop.go
+++ b/internal/taskloop/taskloop.go
@@ -85,6 +85,8 @@ func (l *Loop) Run(ctx context.Context, t func(context.Context)) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-l.done:
+		return ErrClosed
 	case l.tasks <- task{t, done}:
 		<-done
 

--- a/internal/taskloop/taskloop_test.go
+++ b/internal/taskloop/taskloop_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package taskloop
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunReturnsErrClosedWhenLoopClosing(t *testing.T) {
+	loop := New(func() {})
+
+	blockStarted := make(chan struct{})
+	releaseBlock := make(chan struct{})
+	go func() {
+		_ = loop.Run(context.Background(), func(context.Context) {
+			close(blockStarted)
+			<-releaseBlock
+		})
+	}()
+	<-blockStarted
+
+	var secondRan atomic.Bool
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- loop.Run(context.Background(), func(context.Context) {
+			secondRan.Store(true)
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		loop.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, ErrClosed)
+	case <-time.After(time.Second):
+		assert.Fail(t, "Run did not return after loop close")
+	}
+
+	close(releaseBlock)
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		assert.Fail(t, "Close did not return")
+	}
+
+	assert.False(t, secondRan.Load(), "second task should not excute after loop is closed")
+}


### PR DESCRIPTION
#### Description
Fixes a rare race condition in taskloop if close fired just while Run was getting called in the tiny window after the err check and just before Run gets called, and because the context is actually set to the loop itself we get a deadlock.

#### Reference issue
I saw it happening this week and I think it Fixes https://github.com/pion/interceptor/issues/384 but not 100% sure
