### PR TITLE
Set linger time for tcp connections

### DIFF
--- a/tcp_packet_conn.go
+++ b/tcp_packet_conn.go
@@ -284,6 +284,11 @@ func (t *tcpPacketConn) removeConn(conn net.Conn) bool {
 
 	t.closeAndLogError(conn)
 
+	// wait for some time to flush pending writes
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	// read deadline as well just in case
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
 	delete(t.conns, conn.RemoteAddr().String())
 
 	return len(t.conns) == 0
@@ -303,6 +308,12 @@ func (t *tcpPacketConn) Close() error {
 
 	for _, conn := range t.conns {
 		t.closeAndLogError(conn)
+
+		// wait for some time to flush pending writes
+		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		// read deadline as well just in case
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
 		delete(t.conns, conn.RemoteAddr().String())
 	}
 


### PR DESCRIPTION
#### Description

It is possible that Close() of a TCP connection to block if there is pending data to be written till it is written out. Set linger to ensure that it does not block.
