### PR TITLE
Store lastSent and lastReceived as int64

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -32,8 +32,8 @@ type candidateBase struct {
 
 	resolvedAddr net.Addr
 
-	lastSent     atomic.Value
-	lastReceived atomic.Value
+	lastSent     atomic.Int64
+	lastReceived atomic.Int64
 	conn         net.PacketConn
 
 	currAgent *Agent
@@ -454,29 +454,29 @@ func (c *candidateBase) String() string {
 // LastReceived returns a time.Time indicating the last time
 // this candidate was received.
 func (c *candidateBase) LastReceived() time.Time {
-	if lastReceived, ok := c.lastReceived.Load().(time.Time); ok {
-		return lastReceived
+	if lastReceived := c.lastReceived.Load(); lastReceived != 0 {
+		return time.Unix(0, lastReceived)
 	}
 
 	return time.Time{}
 }
 
 func (c *candidateBase) setLastReceived(t time.Time) {
-	c.lastReceived.Store(t)
+	c.lastReceived.Store(t.UnixNano())
 }
 
 // LastSent returns a time.Time indicating the last time
 // this candidate was sent.
 func (c *candidateBase) LastSent() time.Time {
-	if lastSent, ok := c.lastSent.Load().(time.Time); ok {
-		return lastSent
+	if lastSent := c.lastSent.Load(); lastSent != 0 {
+		return time.Unix(0, lastSent)
 	}
 
 	return time.Time{}
 }
 
 func (c *candidateBase) setLastSent(t time.Time) {
-	c.lastSent.Store(t)
+	c.lastSent.Store(t.UnixNano())
 }
 
 func (c *candidateBase) seen(outbound bool) {

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -48,15 +48,16 @@ type candidateBase struct {
 	extensions            []CandidateExtension
 }
 
-// Save a time reference to calculate monotonic time for candidate last sent/received
+// Save a time reference to calculate monotonic time for candidate last sent/received.
+// nolint: gochecknoglobals
 var timeRef = time.Now()
 
-// getMonoNanos returns the monotonic nanoseconds of a time t since timeRef
+// getMonoNanos returns the monotonic nanoseconds of a time t since timeRef.
 func getMonoNanos(t time.Time) int64 {
 	return t.Sub(timeRef).Nanoseconds()
 }
 
-// getMonoTime returns a time.Time based on monotonic nanos since timeRef
+// getMonoTime returns a time.Time based on monotonic nanos since timeRef.
 func getMonoTime(nanos int64) time.Time {
 	return timeRef.Add(time.Duration(nanos))
 }

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -185,7 +185,7 @@ func TestCandidateLastSent(t *testing.T) {
 	require.Equal(t, candidate.LastSent(), time.Time{})
 	now := time.Now()
 	candidate.setLastSent(now)
-	require.Equal(t, candidate.LastSent(), now)
+	require.True(t, candidate.LastSent().Equal(now))
 }
 
 func TestCandidateLastReceived(t *testing.T) {
@@ -193,7 +193,7 @@ func TestCandidateLastReceived(t *testing.T) {
 	require.Equal(t, candidate.LastReceived(), time.Time{})
 	now := time.Now()
 	candidate.setLastReceived(now)
-	require.Equal(t, candidate.LastReceived(), now)
+	require.True(t, candidate.LastReceived().Equal(now))
 }
 
 func TestCandidateFoundation(t *testing.T) {

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -185,7 +185,7 @@ func TestCandidateLastSent(t *testing.T) {
 	require.Equal(t, candidate.LastSent(), time.Time{})
 	now := time.Now()
 	candidate.setLastSent(now)
-	require.Equal(t, candidate.LastSent(), now)
+	require.WithinDuration(t, candidate.LastSent(), now, 1*time.Microsecond)
 }
 
 func TestCandidateLastReceived(t *testing.T) {
@@ -193,7 +193,7 @@ func TestCandidateLastReceived(t *testing.T) {
 	require.Equal(t, candidate.LastReceived(), time.Time{})
 	now := time.Now()
 	candidate.setLastReceived(now)
-	require.Equal(t, candidate.LastReceived(), now)
+	require.WithinDuration(t, candidate.LastReceived(), now, 1*time.Microsecond)
 }
 
 func TestCandidateFoundation(t *testing.T) {

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -185,7 +185,7 @@ func TestCandidateLastSent(t *testing.T) {
 	require.Equal(t, candidate.LastSent(), time.Time{})
 	now := time.Now()
 	candidate.setLastSent(now)
-	require.True(t, candidate.LastSent().Equal(now))
+	require.Equal(t, candidate.LastSent(), now)
 }
 
 func TestCandidateLastReceived(t *testing.T) {
@@ -193,7 +193,7 @@ func TestCandidateLastReceived(t *testing.T) {
 	require.Equal(t, candidate.LastReceived(), time.Time{})
 	now := time.Now()
 	candidate.setLastReceived(now)
-	require.True(t, candidate.LastReceived().Equal(now))
+	require.Equal(t, candidate.LastReceived(), now)
 }
 
 func TestCandidateFoundation(t *testing.T) {


### PR DESCRIPTION
#### Description

This patch will store candidate `lastSent` and `lastReceived` in `int64` in place of `time`. The interface will not be changed, since we just convert to `time` when a reading is requested.
In order to preserve monotonic clock, we save a referenceTime and use it:
- to store nanoseconds since the ref time when writing
- build a monotonic clock from nanoseconds when reading

#### Reference issue
While memory profiling our video SFU, we noticed that on high loads the memory allocations performed by `setLastSent` start to impact. This patch aims at reducing allocations in ice.
<img width="1850" height="464" alt="pion-ice-allocs" src="https://github.com/user-attachments/assets/63909a60-89fc-4123-a629-10c91bd85cf9" />

#### Benchmark

```
                                 │  master.txt  │          with-ref-nanos.txt          │
                                 │    sec/op    │   sec/op     vs base                 │
CandidateLastSent/setLastSent-24   17.640n ± 5%   4.996n ± 1%   -71.68% (p=0.000 n=10)
CandidateLastSent/LastSent-24       1.169n ± 1%   3.557n ± 4%  +204.45% (p=0.000 n=10)
geomean                             4.540n        4.216n         -7.14%

                                 │  master.txt  │           with-ref-nanos.txt            │
                                 │     B/op     │    B/op     vs base                     │
CandidateLastSent/setLastSent-24   24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
CandidateLastSent/LastSent-24      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                       ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                 │  master.txt  │           with-ref-nanos.txt            │
                                 │  allocs/op   │ allocs/op   vs base                     │
CandidateLastSent/setLastSent-24   1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
CandidateLastSent/LastSent-24      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                       ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

