### PR TITLE
Add WriteBatch for batch packet sending

### DIFF
--- a/candidate.go
+++ b/candidate.go
@@ -92,4 +92,5 @@ type Candidate interface {
 	seen(outbound bool)
 	start(a *Agent, conn net.PacketConn, initializedCh <-chan struct{})
 	writeTo(raw []byte, dst Candidate) (int, error)
+	writeBatchTo(rawPackets [][]byte, dst Candidate) (int, error)
 }

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -127,8 +127,17 @@ func (p *CandidatePair) priority() uint64 {
 	return (1<<32-1)*localMin(g, d) + 2*localMax(g, d) + cmp(g, d)
 }
 
+// Write sends a single packet on the candidate pair.
+// Returns the number of bytes written.
 func (p *CandidatePair) Write(b []byte) (int, error) {
 	return p.Local.writeTo(b, p.Remote)
+}
+
+// WriteBatch sends multiple packets on the candidate pair.
+// On Linux, this uses sendmmsg for improved performance.
+// Returns the number of packets successfully written.
+func (p *CandidatePair) WriteBatch(packets [][]byte) (int, error) {
+	return p.Local.writeBatchTo(packets, p.Remote)
 }
 
 func (a *Agent) sendSTUN(msg *stun.Message, local, remote Candidate) {


### PR DESCRIPTION
#### Description
This adds a `WriteBatch` function to the candidatepair that uses `WriteBatch` ipv4/ipv6. Under the hood, on linux systems this leverages `sendmmsg` to send multiple packets at ones, reducing CPU cost.

Note: on other platforms, we fall back to looping through the packets as `WriteBatch` will only send a single packet at a time.

#### Reference issue
Closes #128

#### FYI
This is my first public PR to the open Go community. Please do **not** spare me in the review. I'd appreciate thorough feedback and am open to learning!