### PR TITLE
Fix gosec slice bounds warning

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -831,15 +831,15 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 	network := NetworkTypeUDP4.String()
 	_, ifaces, _ := localInterfaces(a.net, a.interfaceFilter, a.ipFilter, a.networkTypes, a.includeLoopback)
 
-	for i := range urls {
+	for _, url := range urls {
 		switch {
-		case urls[i].Scheme != stun.SchemeTypeTURN && urls[i].Scheme != stun.SchemeTypeTURNS:
+		case url.Scheme != stun.SchemeTypeTURN && url.Scheme != stun.SchemeTypeTURNS:
 			continue
-		case urls[i].Username == "":
+		case url.Username == "":
 			a.log.Errorf("Failed to gather relay candidates: %v", ErrUsernameEmpty)
 
 			return
-		case urls[i].Password == "":
+		case url.Password == "":
 			a.log.Errorf("Failed to gather relay candidates: %v", ErrPasswordEmpty)
 
 			return
@@ -1042,7 +1042,7 @@ func (a *Agent) gatherCandidatesRelay(ctx context.Context, urls []*stun.URI) {
 					}
 				},
 			})
-		}(*urls[i])
+		}(*url)
 	}
 }
 


### PR DESCRIPTION
Replace range loop index access with direct value iteration to address G602 gosec warning in gatherCandidatesRelay.
