### PR TITLE
Add API to write to specific candidate pair

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -105,7 +105,9 @@ type Agent struct {
 	remotePwd        string
 	remoteCandidates map[NetworkType][]Candidate
 
-	checklist []*CandidatePair
+	checklist  []*CandidatePair
+	nextPairID uint64
+	pairsByID  map[uint64]*CandidatePair
 
 	selectorLock sync.RWMutex
 	selector     pairCandidateSelector
@@ -336,6 +338,7 @@ func createAgentBase(config *AgentConfig) (*Agent, error) {
 		connectionState:                 ConnectionStateNew,
 		localCandidates:                 make(map[NetworkType][]Candidate),
 		remoteCandidates:                make(map[NetworkType][]Candidate),
+		pairsByID:                       make(map[uint64]*CandidatePair),
 		urls:                            config.Urls,
 		networkTypes:                    config.NetworkTypes,
 		onConnected:                     make(chan struct{}),
@@ -661,6 +664,7 @@ func (a *Agent) updateConnectionState(newState ConnectionState) {
 		if newState == ConnectionStateFailed {
 			a.removeUfragFromMux()
 			a.checklist = make([]*CandidatePair, 0)
+			a.pairsByID = make(map[uint64]*CandidatePair)
 			a.pendingBindingRequests = make([]bindingRequest, 0)
 			a.setSelectedPair(nil)
 			a.deleteAllCandidates()
@@ -784,8 +788,11 @@ func (a *Agent) getBestValidCandidatePair() *CandidatePair {
 }
 
 func (a *Agent) addPair(local, remote Candidate) *CandidatePair {
+	a.nextPairID++
 	p := newCandidatePair(local, remote, a.isControlling.Load())
+	p.id = a.nextPairID
 	a.checklist = append(a.checklist, p)
+	a.pairsByID[p.id] = p
 
 	return p
 }
@@ -1611,6 +1618,7 @@ func (a *Agent) Restart(ufrag, pwd string) error { //nolint:cyclop
 		a.remotePwd = ""
 		a.gatheringState = GatheringStateNew
 		a.checklist = make([]*CandidatePair, 0)
+		a.pairsByID = make(map[uint64]*CandidatePair)
 		a.pendingBindingRequests = make([]bindingRequest, 0)
 		a.setSelectedPair(nil)
 		a.deleteAllCandidates()

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -22,6 +22,7 @@ func newCandidatePair(local, remote Candidate, controlling bool) *CandidatePair 
 
 // CandidatePair is a combination of a local and remote candidate.
 type CandidatePair struct {
+	id                       uint64
 	iceRoleControlling       bool
 	Remote                   Candidate
 	Local                    Candidate
@@ -326,4 +327,9 @@ func (p *CandidatePair) UpdateRequestReceived() {
 	now := time.Now()
 	p.firstRequestReceivedAt.CompareAndSwap(nil, now)
 	p.lastRequestReceivedAt.Store(now)
+}
+
+// ID returns the unique identifier for this candidate pair.
+func (p *CandidatePair) ID() uint64 {
+	return p.id
 }

--- a/candidatepair_test.go
+++ b/candidatepair_test.go
@@ -175,3 +175,14 @@ func TestCandidatePair_TimeGetters_DefaultZero(t *testing.T) {
 	require.True(t, p.FirstRequestReceivedAt().IsZero(), "FirstRequestReceivedAt should be zero by default")
 	require.True(t, p.LastRequestReceivedAt().IsZero(), "LastRequestReceivedAt should be zero by default")
 }
+
+func TestCandidatePair_ID(t *testing.T) {
+	pair := newCandidatePair(hostCandidate(), srflxCandidate(), true)
+
+	// Default ID should be 0
+	require.Equal(t, uint64(0), pair.ID())
+
+	// Set ID
+	pair.id = 42
+	require.Equal(t, uint64(42), pair.ID())
+}

--- a/errors.go
+++ b/errors.go
@@ -157,6 +157,9 @@ var (
 	// ErrCandidatePairNotFound indicates that candidate pair was not found.
 	ErrCandidatePairNotFound = errors.New("candidate pair not found")
 
+	// ErrCandidatePairNotSucceeded indicates that candidate pair is not in succeeded state.
+	ErrCandidatePairNotSucceeded = errors.New("candidate pair not in succeeded state")
+
 	// ErrInvalidNominationAttribute indicates an invalid nomination attribute type was provided.
 	ErrInvalidNominationAttribute = errors.New("invalid nomination attribute type")
 

--- a/selection_test.go
+++ b/selection_test.go
@@ -260,6 +260,7 @@ func bareAgentForPing() *Agent {
 		relayAcceptanceMinWait: time.Hour,
 
 		checklist:         []*CandidatePair{},
+		pairsByID:         make(map[uint64]*CandidatePair),
 		keepaliveInterval: time.Second,
 		checkInterval:     time.Second,
 

--- a/stats.go
+++ b/stats.go
@@ -140,6 +140,33 @@ type CandidatePairStats struct {
 	ConsentExpiredTimestamp time.Time
 }
 
+// CandidatePairInfo is a snapshot of a candidate pair's state.
+// Use the ID with Conn.WriteToPair() to write to this specific pair.
+type CandidatePairInfo struct {
+	// ID is the unique identifier for this candidate pair.
+	// Use this with Conn.WriteToPair() to write to this pair.
+	ID uint64
+
+	// LocalCandidateType is the type of the local candidate (host, srflx, prflx, relay).
+	LocalCandidateType CandidateType
+
+	// RemoteCandidateType is the type of the remote candidate (host, srflx, prflx, relay).
+	RemoteCandidateType CandidateType
+
+	// State is the current state of the candidate pair.
+	State CandidatePairState
+
+	// Nominated indicates whether this pair has been nominated.
+	Nominated bool
+
+	// CurrentRoundTripTime is the latest RTT measurement.
+	CurrentRoundTripTime time.Duration
+
+	// RenominationQuality is a score indicating the pair's quality (higher is better).
+	// Considers candidate types (host > srflx > relay), measured RTT, and stability.
+	RenominationQuality float64
+}
+
 // CandidateStats contains ICE candidate statistics related to the ICETransport objects.
 type CandidateStats struct {
 	// Timestamp is the timestamp associated with this object.

--- a/transport.go
+++ b/transport.go
@@ -113,6 +113,75 @@ func (c *Conn) Write(packet []byte) (int, error) {
 	return n, err
 }
 
+// GetCandidatePairsInfo returns snapshot information for all candidate pairs.
+// Use the returned ID with WriteToPair() to write to a specific pair.
+func (c *Conn) GetCandidatePairsInfo() []CandidatePairInfo {
+	var pairs []CandidatePairInfo
+
+	err := c.agent.loop.Run(c.agent.loop, func(_ context.Context) {
+		pairs = make([]CandidatePairInfo, 0, len(c.agent.checklist))
+		for _, cp := range c.agent.checklist {
+			pairs = append(pairs, CandidatePairInfo{
+				ID:                   cp.id,
+				LocalCandidateType:   cp.Local.Type(),
+				RemoteCandidateType:  cp.Remote.Type(),
+				State:                cp.state,
+				Nominated:            cp.nominated,
+				CurrentRoundTripTime: time.Duration(atomic.LoadInt64(&cp.currentRoundTripTime)),
+				RenominationQuality:  c.agent.evaluateCandidatePairQuality(cp),
+			})
+		}
+	})
+	if err != nil {
+		return nil
+	}
+
+	return pairs
+}
+
+// WriteToPair writes packet to a specific candidate pair identified by its ID.
+// Returns ErrCandidatePairNotFound if the pair ID is not found.
+// Returns ErrCandidatePairNotSucceeded if the pair is not in Succeeded state.
+// This is useful for sending packets over alternate paths
+// even if they are not nominated.
+func (c *Conn) WriteToPair(pairID uint64, packet []byte) (int, error) {
+	if err := c.agent.loop.Err(); err != nil {
+		return 0, err
+	}
+
+	if stun.IsMessage(packet) {
+		return 0, errWriteSTUNMessageToIceConn
+	}
+
+	var pair *CandidatePair
+	var lookupErr error
+
+	if err := c.agent.loop.Run(c.agent.loop, func(_ context.Context) {
+		pair = c.agent.pairsByID[pairID]
+		if pair == nil {
+			lookupErr = ErrCandidatePairNotFound
+
+			return
+		}
+		if pair.state != CandidatePairStateSucceeded {
+			lookupErr = ErrCandidatePairNotSucceeded
+		}
+	}); err != nil {
+		return 0, err
+	}
+
+	if lookupErr != nil {
+		return 0, lookupErr
+	}
+
+	n, err := pair.Write(packet)
+	if n > 0 {
+		pair.UpdatePacketSent(n)
+	}
+
+	return n, err
+}
+
 // Close implements the Conn Close method. It is used to close
 // the connection. Any calls to Read and Write will be unblocked and return an error.
 func (c *Conn) Close() error {


### PR DESCRIPTION
#### Description

Adds a `WriteToPair()` API to write to a specific candidate pair, which is useful for utilizing paths that are not the ICE-nominated path.

This change itself has no effect on any existing functionality, it only exposes a useful API. I will be utilizing the API
to send FEC packets over a secondary path so we utilize multiple links at the same time without jitter buffer pressure.

#### Reference issue
Fixes #...
