### PR TITLE
Fix ICE Agent gathering notification on Close

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1214,6 +1214,12 @@ func (a *Agent) GracefulClose() error {
 }
 
 func (a *Agent) close(graceful bool) error {
+	// Ensure that we mark gathering as complete
+	err := a.setGatheringState(GatheringStateComplete)
+	if err != nil {
+		a.log.Warnf("Failed to setGatheringState to complete while closing: %v", err)
+	}
+
 	// the loop is safe to wait on no matter what
 	a.loop.Close()
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -2593,3 +2593,24 @@ func TestAgentUpdateOptions(t *testing.T) {
 		}
 	})
 }
+
+// TestGatheringCompleteOnClose tests that when the Agent is Closed
+// the gathering state is marked complete and a `nil` candidate is sent.
+func TestGatheringCompleteOnClose(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	agent, err := NewAgent(&AgentConfig{})
+	require.NoError(t, err)
+
+	nilCandidateBroadcast := false
+	err = agent.OnCandidate(func(c Candidate) {
+		if c == nil {
+			nilCandidateBroadcast = true
+		}
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, agent.Close())
+
+	require.True(t, nilCandidateBroadcast, "Expected to see final empty candidate")
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -200,6 +200,7 @@ func gatherAndExchangeCandidates(t *testing.T, aAgent, bAgent *Agent) {
 	require.NoError(t, aAgent.OnCandidate(func(candidate Candidate) {
 		if candidate == nil {
 			wg.Done()
+			require.NoError(t, aAgent.OnCandidate(func(c Candidate) {}))
 		}
 	}))
 	require.NoError(t, aAgent.GatherCandidates())
@@ -207,6 +208,7 @@ func gatherAndExchangeCandidates(t *testing.T, aAgent, bAgent *Agent) {
 	require.NoError(t, bAgent.OnCandidate(func(candidate Candidate) {
 		if candidate == nil {
 			wg.Done()
+			require.NoError(t, bAgent.OnCandidate(func(c Candidate) {}))
 		}
 	}))
 	require.NoError(t, bAgent.GatherCandidates())


### PR DESCRIPTION
#### Description

Ensure that when an ICE Agent is closed that the complete handlers fire. As highlighted in https://github.com/pion/webrtc/issues/2507 not firing this handler results in hung go routines when following common patterns.

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/2507
