### PR TITLE
Example of broken relay candidate priority

### DIFF
--- a/candidate_test.go
+++ b/candidate_test.go
@@ -172,6 +172,17 @@ func TestCandidatePriority(t *testing.T) {
 					candidateType: CandidateTypeRelay,
 					component:     ComponentRTP,
 				},
+				relayProtocol: "udp",
+			},
+			WantPriority: 16777215,
+		},
+		{
+			Candidate: &CandidateRelay{
+				candidateBase: candidateBase{
+					candidateType: CandidateTypeRelay,
+					component:     ComponentRTP,
+				},
+				relayProtocol: "tcp",
 			},
 			WantPriority: 16777215,
 		},


### PR DESCRIPTION
The [CandidateRelay](https://github.com/pion/ice/blob/4da5bc14ec421ae1e075a087ef95af78eecbd98b/candidate_relay.go#L12C6-L12C20) implementation of [LocalPreference](https://github.com/pion/ice/blob/4da5bc14ec421ae1e075a087ef95af78eecbd98b/candidate_relay.go#L79) is currently broken due to two interacting issues.

1. **Ignoring relay preference**
CandidateRelay embeds [candidateBase](https://github.com/pion/ice/blob/4da5bc14ec421ae1e075a087ef95af78eecbd98b/candidate_base.go#L22). The [Priority()](https://github.com/pion/ice/blob/4da5bc14ec421ae1e075a087ef95af78eecbd98b/candidate_base.go#L425) method is defined on candidateBase and calls [c.LocalPreference()](https://github.com/pion/ice/blob/4da5bc14ec421ae1e075a087ef95af78eecbd98b/candidate_base.go#L143). Because Go embedding does not support true polymorphism like in C++ for receiver methods, CandidateBase.Priority() always calls CandidateBase.LocalPreference(), completely ignoring the overridden LocalPreference() method defined on CandidateRelay. As a result, the relay-specific preference logic is never executed. The preference for two relays using `transport=tcp` and `transport=udp` remains the same.
2. **Integer overflow**
Even if the dispatch issue were fixed, the current logic in CandidateRelay.LocalPreference() is: `return c.candidateBase.LocalPreference() + relayPreference`. For a relay candidate, c.candidateBase.LocalPreference() always returns 65535. Adding any positive 
relayPreference causes a uint16 overflow.

I've added a test case demonstrating that the relay protocol currently has no effect on local candidate priority. Also, the current logic’s attempt to increase priority for TCP/TLS TURN connections is unexpected.

I think in WebRTC UDP is almost always preferred due to lower overhead and better bandwidth performance. I would expect UDP to have the highest priority and TCP/TLS the least. Maybe there should be an option to prioritize UDP over TCP?

I am open to contributing a fix and would appreciate your suggestions on the preferred implementation path.