### PR TITLE
Add generic STUN send hook for outbound message rewriting

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -38,6 +38,22 @@ type bindingRequest struct {
 	nominationValue *uint32 // Tracks nomination value for renomination requests
 }
 
+// STUNSendHandler allows applications to inspect or modify outbound Binding
+// responses before they are sent.
+//
+// The callback receives the outbound message plus the inbound request that
+// triggered it.
+type STUNSendHandler func(
+	outbound, inbound *stun.Message,
+	local, remote Candidate,
+) error
+
+type stunSetterFunc func(*stun.Message) error
+
+func (f stunSetterFunc) AddTo(message *stun.Message) error {
+	return f(message)
+}
+
 // Agent represents the ICE agent.
 type Agent struct {
 	loop *taskloop.Loop
@@ -134,6 +150,8 @@ type Agent struct {
 	// Callback that allows user to implement custom behavior
 	// for STUN Binding Requests
 	userBindingRequestHandler func(m *stun.Message, local, remote Candidate, pair *CandidatePair) bool
+	// Callback that allows user to inspect or modify outbound STUN messages.
+	stunSendHandler STUNSendHandler
 
 	gatherCandidateCancel func()
 	gatherCandidateDone   chan struct{}
@@ -1420,7 +1438,7 @@ func (a *Agent) sendBindingRequest(msg *stun.Message, local, remote Candidate) {
 	a.sendSTUN(msg, local, remote)
 }
 
-func (a *Agent) sendBindingSuccess(m *stun.Message, local, remote Candidate) {
+func (a *Agent) sendBindingSuccess(request *stun.Message, local, remote Candidate) {
 	base := remote
 
 	ip, port, _, err := parseAddr(base.addr())
@@ -1430,21 +1448,39 @@ func (a *Agent) sendBindingSuccess(m *stun.Message, local, remote Candidate) {
 		return
 	}
 
-	if out, err := stun.Build(m, stun.BindingSuccess,
+	if out, err := stun.Build(
+		request,
+		stun.BindingSuccess,
 		&stun.XORMappedAddress{
 			IP:   ip.AsSlice(),
 			Port: port,
 		},
+		stunSetterFunc(func(outbound *stun.Message) error {
+			if a.stunSendHandler == nil {
+				return nil
+			}
+
+			if err := a.stunSendHandler(outbound, request, local, remote); err != nil {
+				a.log.Tracef("Failed to process STUN message before send: %s", err)
+
+				return err
+			}
+
+			return nil
+		}),
 		stun.NewShortTermIntegrity(a.localPwd),
 		stun.Fingerprint,
 	); err != nil {
 		a.log.Warnf("Failed to handle inbound ICE from: %s to: %s error: %s", local, remote, err)
+
+		return
 	} else {
 		if pair := a.findPair(local, remote); pair != nil {
 			pair.UpdateResponseSent()
 		} else {
 			a.log.Warnf("Failed to find pair for add binding response from %s to %s", local, remote)
 		}
+
 		a.sendSTUN(out, local, remote)
 	}
 }

--- a/agent_options.go
+++ b/agent_options.go
@@ -789,6 +789,20 @@ func WithBindingRequestHandler(
 	}
 }
 
+// WithSTUNSendHandler sets a handler that can inspect or modify outbound STUN
+// messages before they are sent.
+func WithSTUNSendHandler(handler STUNSendHandler) AgentOption {
+	return func(a *Agent) error {
+		if a.constructed {
+			return ErrAgentOptionNotUpdatable
+		}
+
+		a.stunSendHandler = handler
+
+		return nil
+	}
+}
+
 // WithEnableUseCandidateCheckPriority enables checking for equal or higher priority when
 // switching selected candidate pair if the peer requests USE-CANDIDATE and agent is a lite agent.
 // This is disabled by default, i.e. when peer requests USE-CANDIDATE, the selected pair will be

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -483,6 +483,36 @@ func TestWithBindingRequestHandler(t *testing.T) {
 	})
 }
 
+func TestWithSTUNSendHandler(t *testing.T) {
+	t.Run("sets STUN send handler", func(t *testing.T) {
+		handlerCalled := false
+		handler := func(_ *stun.Message, _ *stun.Message, _, _ Candidate) error {
+			handlerCalled = true
+
+			return nil
+		}
+
+		agent, err := NewAgentWithOptions(WithSTUNSendHandler(handler))
+		assert.NoError(t, err)
+		defer agent.Close() //nolint:errcheck
+
+		assert.NotNil(t, agent.stunSendHandler)
+
+		if agent.stunSendHandler != nil {
+			assert.NoError(t, agent.stunSendHandler(nil, nil, nil, nil))
+			assert.True(t, handlerCalled)
+		}
+	})
+
+	t.Run("default is nil", func(t *testing.T) {
+		agent, err := NewAgentWithOptions()
+		assert.NoError(t, err)
+		defer agent.Close() //nolint:errcheck
+
+		assert.Nil(t, agent.stunSendHandler)
+	})
+}
+
 func TestWithEnableUseCandidateCheckPriority(t *testing.T) {
 	testBooleanOption(t, booleanOptionTest{
 		optionFunc:   WithEnableUseCandidateCheckPriority,
@@ -506,6 +536,9 @@ func TestMultipleConfigOptions(t *testing.T) {
 			WithTCPPriorityOffset(customOffset),
 			WithDisableActiveTCP(),
 			WithBindingRequestHandler(handler),
+			WithSTUNSendHandler(func(_ *stun.Message, _ *stun.Message, _, _ Candidate) error {
+				return nil
+			}),
 			WithEnableUseCandidateCheckPriority(),
 		)
 		assert.NoError(t, err)
@@ -515,6 +548,7 @@ func TestMultipleConfigOptions(t *testing.T) {
 		assert.Equal(t, customOffset, agent.tcpPriorityOffset)
 		assert.True(t, agent.disableActiveTCP)
 		assert.NotNil(t, agent.userBindingRequestHandler)
+		assert.NotNil(t, agent.stunSendHandler)
 		assert.True(t, agent.enableUseCandidateCheckPriority)
 
 		if agent.userBindingRequestHandler != nil {

--- a/selection_test.go
+++ b/selection_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -251,6 +252,23 @@ func newPingNoIOCand() *pingNoIOCand {
 }
 func (d *pingNoIOCand) writeTo(b []byte, _ Candidate) (int, error) { return len(b), nil }
 
+type capturePingNoIOCand struct {
+	pingNoIOCand
+	lastWrite []byte
+}
+
+func newCapturePingNoIOCand() *capturePingNoIOCand {
+	return &capturePingNoIOCand{
+		pingNoIOCand: *newPingNoIOCand(),
+	}
+}
+
+func (d *capturePingNoIOCand) writeTo(b []byte, _ Candidate) (int, error) {
+	d.lastWrite = append(d.lastWrite[:0], b...)
+
+	return len(b), nil
+}
+
 func bareAgentForPing() *Agent {
 	return &Agent{
 		hostAcceptanceMinWait:  time.Hour,
@@ -319,6 +337,61 @@ func TestControlledSelector_PingCandidate_BuildError(t *testing.T) {
 	sel.PingCandidate(local, remote)
 
 	require.NotEmpty(t, testLogger.lastErrorMessage, "expected error to be logged from stun.Build")
+}
+
+func TestSTUNSendHandlerOverridesBindingSuccessResponseAddress(t *testing.T) {
+	agent := bareAgentForPing()
+	agent.localPwd = selectionTestPassword
+	agent.log = logging.NewDefaultLoggerFactory().NewLogger("test")
+
+	overrideAddr := netip.MustParseAddrPort("203.0.113.10:45678")
+	handlerCalled := false
+	agent.stunSendHandler = func(
+		outbound, inbound *stun.Message,
+		_, _ Candidate,
+	) error {
+		handlerCalled = true
+		require.NotNil(t, outbound)
+		require.NotNil(t, inbound)
+
+		return outbound.Build(
+			inbound,
+			stun.BindingSuccess,
+			&stun.XORMappedAddress{
+				IP:   overrideAddr.Addr().AsSlice(),
+				Port: int(overrideAddr.Port()),
+			},
+		)
+	}
+
+	local := newCapturePingNoIOCand()
+	local.candidateBase.networkType = NetworkTypeUDP4
+	local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+	remote := newPingNoIOCand()
+	remote.candidateBase.networkType = NetworkTypeUDP4
+	remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+	agent.addPair(local, remote)
+
+	req, err := stun.Build(
+		stun.BindingRequest,
+		stun.TransactionID,
+		stun.NewShortTermIntegrity(agent.localPwd),
+		stun.Fingerprint,
+	)
+	require.NoError(t, err)
+
+	agent.sendBindingSuccess(req, local, remote)
+	require.True(t, handlerCalled)
+	require.NotEmpty(t, local.lastWrite)
+
+	resp := new(stun.Message)
+	resp.Raw = append([]byte(nil), local.lastWrite...)
+	require.NoError(t, resp.Decode())
+
+	var xorMapped stun.XORMappedAddress
+	require.NoError(t, xorMapped.GetFrom(resp))
+	require.True(t, xorMapped.IP.Equal(overrideAddr.Addr().AsSlice()))
+	require.Equal(t, int(overrideAddr.Port()), xorMapped.Port)
 }
 
 type warnTestLogger struct {


### PR DESCRIPTION
## Background
RFC 8489 Section [14.2](https://www.rfc-editor.org/rfc/rfc8489.html#section-14.2) expects a STUN Binding Success response to report the client's transport address in `XOR-MAPPED-ADDRESS`. That becomes incorrect when the ICE server is behind a proxy or relay hop and only sees the proxy-facing tuple.

This PR reframes the original request from a narrow address-override callback into a broader outbound STUN extension point. The immediate use case is allowing upstream integrations such as `pion/webrtc` to rewrite Binding Success responses based on proxy metadata, but the hook is generic enough for other STUN response/request customization.

## Summary
- replace the narrow `WithBindingSuccessXORMappedAddressHandler(...)` hook with a generic `WithSTUNSendHandler(...)`
- call the handler for outbound STUN sends, including Binding Success responses
- run the handler for Binding Success before `MESSAGE-INTEGRITY` and `FINGERPRINT` are added, so callers can safely modify attributes like `XOR-MAPPED-ADDRESS`
- keep the existing `WithBindingRequestHandler(...)` behavior unchanged
- add focused tests for option wiring and Binding Success rewriting via the new hook

## Testing
- `go test ./... -run 'TestWithSTUNSendHandler|TestSTUNSendHandlerOverridesBindingSuccessResponseAddress' -count=1`
- `go test ./...`
- `golangci-lint run`
