### PR TITLE
Fix STUN busy loop in controlled agent's HandleBindingRequest

### DIFF
--- a/selection.go
+++ b/selection.go
@@ -461,7 +461,15 @@ func (s *controlledSelector) HandleBindingRequest(message *stun.Message, local, 
 	}
 
 	s.agent.sendBindingSuccess(message, local, remote)
-	s.PingCandidate(local, remote)
+
+	// Only send a triggered check during ICE checking phase (RFC 8445 §7.3.1.4).
+	// Once the pair is established (succeeded + selected), sending a triggered check
+	// on every inbound request creates a ping-pong busy loop: the remote side responds
+	// and sends its own request, which triggers another check here, repeating at 1/RTT.
+	// After connection, consent freshness is maintained by checkKeepalive() on a timer.
+	if pair.state != CandidatePairStateSucceeded || s.agent.getSelectedPair() == nil {
+		s.PingCandidate(local, remote)
+	}
 
 	if s.agent.userBindingRequestHandler != nil {
 		if shouldSwitch := s.agent.userBindingRequestHandler(message, local, remote, pair); shouldSwitch {

--- a/selection_test.go
+++ b/selection_test.go
@@ -367,6 +367,103 @@ func TestControlledSelector_HandleSuccessResponse_UnknownTxID(t *testing.T) {
 	require.True(t, logger.warned, "expected Warnf to be called for unknown TransactionID (hitting !ok branch)")
 }
 
+// TestControlledSelector_NoTriggeredCheckAfterConnected verifies that once a pair
+// is in Succeeded state with a selected pair, HandleBindingRequest does NOT send
+// a triggered check (PingCandidate). Before the fix, every inbound Binding Request
+// unconditionally called PingCandidate, creating a ping-pong busy loop at 1/RTT.
+func TestControlledSelector_NoTriggeredCheckAfterConnected(t *testing.T) {
+	agent := bareAgentForPing()
+	agent.log = logging.NewDefaultLoggerFactory().NewLogger("test")
+	agent.remoteUfrag = selectionTestRemoteUfrag
+	agent.localUfrag = selectionTestLocalUfrag
+	agent.remotePwd = selectionTestPassword
+	agent.localPwd = selectionTestPassword
+	agent.tieBreaker = 1
+	agent.isControlling.Store(false)
+	agent.onConnected = make(chan struct{})
+	agent.setSelector()
+
+	selector, ok := agent.getSelector().(*controlledSelector)
+	require.True(t, ok, "expected controlledSelector")
+
+	local := newPingNoIOCand()
+	local.candidateBase.networkType = NetworkTypeUDP4
+	local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+
+	remote := newPingNoIOCand()
+	remote.candidateBase.networkType = NetworkTypeUDP4
+	remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+
+	pair := agent.addPair(local, remote)
+	pair.state = CandidatePairStateSucceeded
+	agent.setSelectedPair(pair)
+
+	// Record requests sent before calling HandleBindingRequest.
+	sentBefore := pair.RequestsSent()
+
+	// Build a STUN Binding Request (no USE-CANDIDATE).
+	msg, err := stun.Build(stun.BindingRequest,
+		stun.TransactionID,
+		stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
+		stun.NewShortTermIntegrity(agent.localPwd),
+		stun.Fingerprint,
+	)
+	require.NoError(t, err)
+
+	// Call HandleBindingRequest multiple times — simulates repeated inbound requests.
+	for range 10 {
+		selector.HandleBindingRequest(msg, local, remote)
+	}
+
+	// No triggered checks should have been sent since the pair is already connected.
+	assert.Equal(t, sentBefore, pair.RequestsSent(),
+		"triggered check should not be sent for a succeeded+selected pair")
+}
+
+// TestControlledSelector_TriggeredCheckDuringChecking verifies that a triggered
+// check IS sent when the pair is not yet in Succeeded state (normal ICE checking).
+func TestControlledSelector_TriggeredCheckDuringChecking(t *testing.T) {
+	agent := bareAgentForPing()
+	agent.log = logging.NewDefaultLoggerFactory().NewLogger("test")
+	agent.remoteUfrag = selectionTestRemoteUfrag
+	agent.localUfrag = selectionTestLocalUfrag
+	agent.remotePwd = selectionTestPassword
+	agent.localPwd = selectionTestPassword
+	agent.tieBreaker = 1
+	agent.isControlling.Store(false)
+	agent.onConnected = make(chan struct{})
+	agent.setSelector()
+
+	selector, ok := agent.getSelector().(*controlledSelector)
+	require.True(t, ok, "expected controlledSelector")
+
+	local := newPingNoIOCand()
+	local.candidateBase.networkType = NetworkTypeUDP4
+	local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+
+	remote := newPingNoIOCand()
+	remote.candidateBase.networkType = NetworkTypeUDP4
+	remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+
+	pair := agent.addPair(local, remote)
+	// Pair is in Waiting state (not Succeeded), no selected pair — normal ICE checking.
+
+	sentBefore := pair.RequestsSent()
+
+	msg, err := stun.Build(stun.BindingRequest,
+		stun.TransactionID,
+		stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
+		stun.NewShortTermIntegrity(agent.localPwd),
+		stun.Fingerprint,
+	)
+	require.NoError(t, err)
+
+	selector.HandleBindingRequest(msg, local, remote)
+
+	assert.Greater(t, pair.RequestsSent(), sentBefore,
+		"triggered check should be sent during ICE checking phase")
+}
+
 func TestAutomaticRenomination(t *testing.T) { //nolint:maintidx
 	report := test.CheckRoutines(t)
 	defer report()


### PR DESCRIPTION
## Summary

The controlled selector's `HandleBindingRequest` unconditionally calls `PingCandidate` (triggered check) for every inbound Binding Request, even after ICE connectivity is fully established. This creates a STUN ping-pong busy loop between the controlled and controlling agents that repeats at 1/RTT speed.

### The Problem

When the controlling agent sends keepalive Binding Requests to the controlled agent:

1. Controlled agent receives the Request
2. Controlled agent sends a **Success Response** (correct)
3. Controlled agent sends its own **Binding Request** back via `PingCandidate` (unnecessary after connection)
4. Controlling agent receives the Request, responds, and sends its next Request
5. Repeat from step 1

This loop runs continuously at network RTT speed:

| RTT | Requests/sec per session |
|-----|------------------------|
| 1.5ms (same DC) | ~643 |
| 13ms (cross DC) | ~76 |

With 200 concurrent WebRTC sessions, total STUN traffic reaches **~57,600 req/s** instead of the expected ~100 req/s, causing kernel softirq CPU spikes (up to 70%) on the media server.

### The Fix

Skip the triggered check when the candidate pair has already succeeded and a selected pair exists. During ICE checking phase, triggered checks are still sent per [RFC 8445 §7.3.1.4](https://datatracker.ietf.org/doc/html/rfc8445#section-7.3.1.4). After connection, consent freshness is handled by `checkKeepalive()` on a timer.

```go
// Before: unconditional triggered check
s.PingCandidate(local, remote)

// After: only during ICE checking phase
if !(pair.state == CandidatePairStateSucceeded && s.agent.getSelectedPair() != nil) {
    s.PingCandidate(local, remote)
}
```

### Observed Impact

| Metric | Before | After |
|--------|--------|-------|
| STUN req/s per session | 76–643 | ~0.5 (keepalive only) |
| 200-session total | ~57,600 req/s | ~100 req/s |
| Reduction | — | **99.8%** |

### How to Reproduce

1. Set up a controlling agent (e.g., OvenMediaEngine) and a controlled agent using pion/ice
2. Establish 100+ concurrent WebRTC sessions between them
3. Monitor STUN `RequestsSent` from `GetCandidatePairsStats()` — the rate scales with 1/RTT instead of staying at the keepalive interval

### Notes

- This bug exists since commit `165d04e` (May 2019) when STUN Binding Indications were replaced with Binding Requests for RFC 7675 consent freshness
- Single-session impact is small (~76–643 req/s), but it compounds linearly with concurrent session count
- The controlling selector's `HandleBindingRequest` does **not** have this issue — it does not call `PingCandidate`