### PR TITLE
[codex] Fix renomination attribute ordering

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -2042,8 +2042,6 @@ func (a *Agent) sendNominationRequest(pair *CandidatePair, nominationValue uint3
 		UseCandidate(),
 		AttrControlling(a.tieBreaker),
 		PriorityAttr(pair.Local.Priority()),
-		stun.NewShortTermIntegrity(a.remotePwd),
-		stun.Fingerprint,
 	}
 
 	// Add nomination attribute if renomination is enabled and value > 0
@@ -2055,6 +2053,11 @@ func (a *Agent) sendNominationRequest(pair *CandidatePair, nominationValue uint3
 		a.log.Tracef("Sending renomination request from %s to %s with nomination value %d",
 			pair.Local, pair.Remote, nominationValue)
 	}
+
+	attributes = append(attributes,
+		stun.NewShortTermIntegrity(a.remotePwd),
+		stun.Fingerprint,
+	)
 
 	msg, err := stun.Build(append([]stun.Setter{stun.BindingRequest}, attributes...)...)
 	if err != nil {

--- a/renomination_test.go
+++ b/renomination_test.go
@@ -385,6 +385,19 @@ func TestSendNominationRequest(t *testing.T) {
 		err = nomination.GetFrom(msg)
 		assert.NoError(t, err)
 		assert.Equal(t, nominationValue, nomination.Value)
+
+		attributeIndexes := make(map[stun.AttrType]int)
+		for i, attr := range msg.Attributes {
+			attributeIndexes[attr.Type] = i
+		}
+		nominationIndex, hasNomination := attributeIndexes[agent.nominationAttribute]
+		integrityIndex, hasIntegrity := attributeIndexes[stun.AttrMessageIntegrity]
+		fingerprintIndex, hasFingerprint := attributeIndexes[stun.AttrFingerprint]
+		assert.True(t, hasNomination)
+		assert.True(t, hasIntegrity)
+		assert.True(t, hasFingerprint)
+		assert.Less(t, nominationIndex, integrityIndex)
+		assert.Less(t, integrityIndex, fingerprintIndex)
 	})
 
 	t.Run("STUN message without nomination when disabled", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- move the optional renomination attribute ahead of `MESSAGE-INTEGRITY` and `FINGERPRINT`
- assert the serialized outbound STUN order in the existing renomination test

## Why

`sendNominationRequest` appended the renomination attribute after `MESSAGE-INTEGRITY` and `FINGERPRINT`, which leaves the attribute outside the integrity-protected portion of the STUN message and violates the expected ordering.

Fixes #915.

## Testing

- `go test ./... -run TestSendNominationRequest -count=1`
