### PR TITLE
Reject oversized DTLS-in-STUN ACK lists

### DIFF
--- a/sped.go
+++ b/sped.go
@@ -35,8 +35,11 @@ func (d *DtlsInStunAttribute) GetFrom(m *stun.Message) error {
 // of DTLS packets (embedded in STUN or without embedding).
 type DtlsInStunAckAttribute []uint32
 
-// Acks are 32 bit values, the attribute can carry up to four of these.
-const ackSizeBytes, ackSizeValues = 32, 4
+// ACKs are 32-bit values, and the attribute can carry up to four of them.
+const (
+	ackSizeValues = 4
+	ackSizeBytes  = ackSizeValues * 4
+)
 
 // AddTo adds DTLS-in-STUN-ACK attribute to message.
 func (a DtlsInStunAckAttribute) AddTo(m *stun.Message) error {

--- a/sped_test.go
+++ b/sped_test.go
@@ -50,6 +50,14 @@ func TestDtlsInStunAckAttribute_GetFrom(t *testing.T) {
 	require.NoError(t, dtlsInStunAck1.GetFrom(m))
 	require.Equal(t, expectedValue, []uint32(dtlsInStunAck1))
 
+	// Test with the maximum valid size.
+	m4 := new(stun.Message)
+	maxValue := make([]byte, ackSizeBytes)
+	m4.Add(stun.AttrDtlsInStunAck, maxValue)
+	var dtlsInStunAck4 DtlsInStunAckAttribute
+	require.NoError(t, dtlsInStunAck4.GetFrom(m4))
+	require.Len(t, dtlsInStunAck4, ackSizeValues)
+
 	// Test with invalid size (not multiple of 4)
 	m2 := new(stun.Message)
 	m2.Add(stun.AttrDtlsInStunAck, []byte{0x01, 0x02, 0x03})


### PR DESCRIPTION
## Summary

- cap `DTLS-IN-STUN-ACK` decoding at the same four ACK values accepted by encoding
- derive the byte limit from the value count so the two limits stay in sync
- add a regression case for the maximum valid ACK attribute size

## Why

`DtlsInStunAckAttribute.AddTo` rejects more than four `uint32` ACK values, but `GetFrom` currently allows up to 32 bytes. Since each ACK is four bytes, that accepts eight ACK values on receive. This makes the inbound parser more permissive than the outbound writer and allows oversized ACK lists through.

## Testing

- `go test -run TestDtlsInStunAckAttribute -count=1 -timeout 30s .`
