### PR TITLE
Support append rewrite rule for UDP/TCP mux

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -344,7 +344,7 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 			}
 		}
 
-		for mappedIdx, mappedIP := range mappedAddrs {
+		for _, mappedIP := range mappedAddrs {
 			address := mappedIP.String()
 			var isLocationTracked bool
 			if a.mDNSMode == MulticastDNSModeQueryAndGather {
@@ -357,12 +357,6 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 			}
 
 			for network := range networks {
-				// TCPMux maintains a single listener per interface. Avoid duplicating passive TCP candidates
-				// for additional mapped IPs until connection sharing is supported.
-				if network == tcp && mappedIdx > 0 {
-					continue
-				}
-
 				type connAndPort struct {
 					conn net.PacketConn
 					port int
@@ -418,7 +412,12 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 						if tcpConn, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 							conns = append(conns, connAndPort{conn, tcpConn.Port})
 						} else {
-							a.log.Warnf("Failed to get port of connection from TCPMux: %s %s %s", network, addr, a.localUfrag)
+							closeConnAndLog(
+								conn,
+								a.log,
+								"Failed to get port of connection from TCPMux: %s %s %s",
+								network, addr, a.localUfrag,
+							)
 						}
 					}
 					if len(conns) == 0 {
@@ -484,7 +483,12 @@ func (a *Agent) gatherCandidatesLocal(ctx context.Context, networkTypes []Networ
 						if closeErr := candidateHost.close(); closeErr != nil {
 							a.log.Warnf("Failed to close candidate: %v", closeErr)
 						}
-						a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
+						closeConnAndLog(
+							connAndPort.conn,
+							a.log,
+							"Failed to append to localCandidates and run onCandidateHdlr: %v",
+							err,
+						)
 					}
 				}
 			}
@@ -792,7 +796,12 @@ func (a *Agent) gatherCandidatesSrflxUDPMux(ctx context.Context, urls []*stun.UR
 						if closeErr := c.close(); closeErr != nil {
 							a.log.Warnf("Failed to close candidate: %v", closeErr)
 						}
-						a.log.Warnf("Failed to append to localCandidates and run onCandidateHdlr: %v", err)
+						closeConnAndLog(
+							conn,
+							a.log,
+							"Failed to append srflx mux candidate to localCandidates: %v",
+							err,
+						)
 					}
 				}(*urls[i], networkType.String(), udpAddr)
 			}

--- a/gather_test.go
+++ b/gather_test.go
@@ -3498,6 +3498,272 @@ func TestGatherAddressRewriteHostModes(t *testing.T) { //nolint:cyclop
 	})
 }
 
+func TestGatherAddressRewriteAppendHostTCPMux(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	listenerAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	tcpMux := NewTCPMuxDefault(TCPMuxParams{
+		Listener:       listener,
+		Logger:         loggerFactory.NewLogger("ice"),
+		ReadBufferSize: 20,
+	})
+	defer func() {
+		_ = tcpMux.Close()
+	}()
+
+	agent, err := NewAgentWithOptions(
+		WithNet(newHostGatherNet(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})),
+		WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+		WithNetworkTypes([]NetworkType{NetworkTypeTCP4}),
+		WithTCPMux(tcpMux),
+		WithIncludeLoopback(),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+		WithAddressRewriteRules(AddressRewriteRule{
+			External:        []string{"198.51.100.1"},
+			Local:           "127.0.0.1",
+			AsCandidateType: CandidateTypeHost,
+			Mode:            AddressRewriteAppend,
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = agent.Close()
+	}()
+
+	done := make(chan struct{})
+	require.NoError(t, agent.OnCandidate(func(c Candidate) {
+		if c == nil {
+			close(done)
+		}
+	}))
+	require.NoError(t, agent.GatherCandidates())
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "gather did not complete")
+	}
+
+	cands, err := agent.GetLocalCandidates()
+	require.NoError(t, err)
+	require.Len(t, cands, 2, "expected both alias TCP host candidates")
+	assert.ElementsMatch(t,
+		[]string{"127.0.0.1", "198.51.100.1"},
+		[]string{cands[0].Address(), cands[1].Address()},
+	)
+	for _, c := range cands {
+		assert.Equal(t, CandidateTypeHost, c.Type())
+		assert.Equal(t, NetworkTypeTCP4, c.NetworkType())
+		assert.Equal(t, TCPTypePassive, c.TCPType())
+		assert.Equal(t, listenerAddr.Port, c.Port())
+	}
+
+	// Each alias holds its own wrapper around one underlying tcpPacketConn.
+	hostA, ok := cands[0].(*CandidateHost)
+	require.True(t, ok)
+	hostB, ok := cands[1].(*CandidateHost)
+	require.True(t, ok)
+	wrapA, ok := hostA.conn.(*sharedPacketConn)
+	require.True(t, ok, "candidate conn must be a *sharedPacketConn")
+	wrapB, ok := hostB.conn.(*sharedPacketConn)
+	require.True(t, ok)
+	require.NotSame(t, wrapA, wrapB, "aliases must hold distinct wrappers")
+	require.Same(t, wrapA.underlying, wrapB.underlying,
+		"alias wrappers must share one underlying tcpPacketConn")
+	underlying, ok := wrapA.underlying.(*tcpPacketConn)
+	require.True(t, ok)
+	require.Equal(t, int32(2), underlying.refs.Load(),
+		"refcount must reflect both alias candidates")
+
+	// Closing the agent must drain every refcount the mux handed out so
+	// gather doesn't leak wrappers — particularly important since alias
+	// gather acquires multiple wrappers from one underlying conn.
+	require.NoError(t, agent.Close())
+	require.Equal(t, int32(0), underlying.refs.Load(),
+		"agent.Close must release every alias wrapper's reference")
+}
+
+func TestGatherAddressRewriteAppendHostMultiTCPMux(t *testing.T) { //nolint:cyclop
+	defer test.CheckRoutines(t)()
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	const numMuxes = 2
+	muxes := make([]TCPMux, 0, numMuxes)
+	expectedPorts := make([]int, 0, numMuxes)
+	for range numMuxes {
+		l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+		require.NoError(t, err)
+		lAddr, ok := l.Addr().(*net.TCPAddr)
+		require.True(t, ok)
+		expectedPorts = append(expectedPorts, lAddr.Port)
+		muxes = append(muxes, NewTCPMuxDefault(TCPMuxParams{
+			Listener:       l,
+			Logger:         loggerFactory.NewLogger("ice"),
+			ReadBufferSize: 20,
+		}))
+	}
+	multi := NewMultiTCPMuxDefault(muxes...)
+	defer func() { _ = multi.Close() }()
+
+	agent, err := NewAgentWithOptions(
+		WithNet(newHostGatherNet(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})),
+		WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+		WithNetworkTypes([]NetworkType{NetworkTypeTCP4}),
+		WithTCPMux(multi),
+		WithIncludeLoopback(),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+		WithAddressRewriteRules(AddressRewriteRule{
+			External:        []string{"198.51.100.1"},
+			Local:           "127.0.0.1",
+			AsCandidateType: CandidateTypeHost,
+			Mode:            AddressRewriteAppend,
+		}),
+	)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	require.NoError(t, agent.OnCandidate(func(c Candidate) {
+		if c == nil {
+			close(done)
+		}
+	}))
+	require.NoError(t, agent.GatherCandidates())
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "gather did not complete")
+	}
+
+	cands, err := agent.GetLocalCandidates()
+	require.NoError(t, err)
+	require.Len(t, cands, 2*numMuxes, "expected M*N alias TCP candidates")
+
+	byPort := map[int][]*CandidateHost{}
+	for _, c := range cands {
+		h, ok := c.(*CandidateHost)
+		require.True(t, ok)
+		require.Equal(t, NetworkTypeTCP4, h.NetworkType())
+		require.Equal(t, TCPTypePassive, h.TCPType())
+		byPort[h.Port()] = append(byPort[h.Port()], h)
+	}
+	require.Len(t, byPort, numMuxes, "expected one port per child mux")
+	underlyings := make([]*tcpPacketConn, 0, numMuxes)
+	for _, port := range expectedPorts {
+		group := byPort[port]
+		require.Len(t, group, 2, "expected 2 alias candidates for port %d", port)
+		wrapA, ok := group[0].conn.(*sharedPacketConn)
+		require.True(t, ok)
+		wrapB, ok := group[1].conn.(*sharedPacketConn)
+		require.True(t, ok)
+		require.Same(t, wrapA.underlying, wrapB.underlying,
+			"aliases on the same mux port must share one tcpPacketConn")
+		muxedConn, ok := wrapA.underlying.(*tcpPacketConn)
+		require.True(t, ok)
+		require.Equal(t, int32(2), muxedConn.refs.Load())
+		underlyings = append(underlyings, muxedConn)
+		addrs := []string{group[0].Address(), group[1].Address()}
+		assert.ElementsMatch(t, []string{"127.0.0.1", "198.51.100.1"}, addrs)
+	}
+	require.NotSame(t, underlyings[0], underlyings[1],
+		"conns from different child muxes must be distinct")
+
+	require.NoError(t, agent.Close())
+	for _, u := range underlyings {
+		require.Equal(t, int32(0), u.refs.Load(),
+			"agent.Close must release every alias wrapper's reference")
+	}
+}
+
+func TestGatherAddressRewriteAppendHostMultiUDPMux(t *testing.T) { //nolint:cyclop
+	defer test.CheckRoutines(t)()
+
+	const numMuxes = 2
+	muxes := make([]UDPMux, 0, numMuxes)
+	expectedPorts := make([]int, 0, numMuxes)
+	for range numMuxes {
+		udpConn, err := net.ListenUDP(udp, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		require.NoError(t, err)
+		uAddr, ok := udpConn.LocalAddr().(*net.UDPAddr)
+		require.True(t, ok)
+		expectedPorts = append(expectedPorts, uAddr.Port)
+		muxes = append(muxes, NewUDPMuxDefault(UDPMuxParams{UDPConn: udpConn}))
+	}
+	multi := NewMultiUDPMuxDefault(muxes...)
+	defer func() { _ = multi.Close() }()
+
+	agent, err := NewAgentWithOptions(
+		WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+		WithNetworkTypes([]NetworkType{NetworkTypeUDP4}),
+		WithUDPMux(multi),
+		WithIncludeLoopback(),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+		WithAddressRewriteRules(AddressRewriteRule{
+			External:        []string{"198.51.100.1"},
+			Local:           "127.0.0.1",
+			AsCandidateType: CandidateTypeHost,
+			Mode:            AddressRewriteAppend,
+		}),
+	)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	require.NoError(t, agent.OnCandidate(func(c Candidate) {
+		if c == nil {
+			close(done)
+		}
+	}))
+	require.NoError(t, agent.GatherCandidates())
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "gather did not complete")
+	}
+
+	cands, err := agent.GetLocalCandidates()
+	require.NoError(t, err)
+	require.Len(t, cands, 2*numMuxes, "expected M*N alias UDP candidates")
+
+	byPort := map[int][]*CandidateHost{}
+	for _, c := range cands {
+		h, ok := c.(*CandidateHost)
+		require.True(t, ok)
+		require.Equal(t, NetworkTypeUDP4, h.NetworkType())
+		byPort[h.Port()] = append(byPort[h.Port()], h)
+	}
+	require.Len(t, byPort, numMuxes, "expected one port per child mux")
+	underlyings := make([]*udpMuxedConn, 0, numMuxes)
+	for _, port := range expectedPorts {
+		group := byPort[port]
+		require.Len(t, group, 2, "expected 2 alias candidates for port %d", port)
+		wrapA, ok := group[0].conn.(*sharedPacketConn)
+		require.True(t, ok)
+		wrapB, ok := group[1].conn.(*sharedPacketConn)
+		require.True(t, ok)
+		require.Same(t, wrapA.underlying, wrapB.underlying,
+			"aliases on the same mux port must share one udpMuxedConn")
+		muxedConn, ok := wrapA.underlying.(*udpMuxedConn)
+		require.True(t, ok)
+		require.Equal(t, int32(2), muxedConn.refs.Load())
+		underlyings = append(underlyings, muxedConn)
+		addrs := []string{group[0].Address(), group[1].Address()}
+		assert.ElementsMatch(t, []string{"127.0.0.1", "198.51.100.1"}, addrs)
+	}
+	require.NotSame(t, underlyings[0], underlyings[1],
+		"conns from different child muxes must be distinct")
+
+	require.NoError(t, agent.Close())
+	for _, u := range underlyings {
+		require.Equal(t, int32(0), u.refs.Load(),
+			"agent.Close must release every alias wrapper's reference")
+	}
+}
+
 func TestGatherAddressRewriteSrflxModes(t *testing.T) {
 	urls := []*stun.URI{{
 		Scheme: SchemeTypeSTUN,

--- a/shared_packet_conn.go
+++ b/shared_packet_conn.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package ice
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type muxedPacketConn interface {
+	net.PacketConn
+	readFromContext(ctx context.Context, b []byte) (int, net.Addr, error)
+}
+
+// sharedPacketConn is a reference-counted wrapper around an underlying
+// muxedPacketConn owned by a mux. The mux can hand out several wrappers that
+// share one underlying connection (for example, alias host candidates
+// produced by an AddressRewrite append rule).
+//
+// Each wrapper owns its own context. Close() cancels that context, which
+// unblocks any in-flight ReadFrom on this wrapper — without affecting
+// siblings that still hold their own references. The underlying connection
+// itself is closed only when the last wrapper is released.
+type sharedPacketConn struct {
+	underlying muxedPacketConn
+	refs       *atomic.Int32
+
+	ctx       context.Context //nolint:containedctx
+	cancel    context.CancelFunc
+	closeOnce sync.Once
+
+	readDeadline atomic.Pointer[time.Time]
+}
+
+// newSharedPacketConn increments the shared refcount and returns a wrapper.
+// Each returned wrapper must have Close called exactly once.
+func newSharedPacketConn(u muxedPacketConn, refs *atomic.Int32) *sharedPacketConn {
+	refs.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &sharedPacketConn{
+		underlying: u,
+		refs:       refs,
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+func (s *sharedPacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	ctx := s.ctx
+	if ctx.Err() != nil {
+		return 0, nil, io.ErrClosedPipe
+	}
+
+	if p := s.readDeadline.Load(); p != nil && !p.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(s.ctx, *p)
+		defer cancel()
+	}
+
+	n, addr, err := s.underlying.readFromContext(ctx, b)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return n, addr, os.ErrDeadlineExceeded
+	}
+	if errors.Is(err, context.Canceled) {
+		return n, addr, io.ErrClosedPipe
+	}
+
+	return n, addr, err
+}
+
+func (s *sharedPacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	if s.ctx.Err() != nil {
+		return 0, io.ErrClosedPipe
+	}
+
+	return s.underlying.WriteTo(b, addr)
+}
+
+func (s *sharedPacketConn) LocalAddr() net.Addr {
+	return s.underlying.LocalAddr()
+}
+
+func (s *sharedPacketConn) SetReadDeadline(t time.Time) error {
+	if s.ctx.Err() != nil {
+		return io.ErrClosedPipe
+	}
+
+	s.readDeadline.Store(&t)
+
+	return nil
+}
+
+func (s *sharedPacketConn) SetWriteDeadline(t time.Time) error {
+	if s.ctx.Err() != nil {
+		return io.ErrClosedPipe
+	}
+
+	return s.underlying.SetWriteDeadline(t)
+}
+
+func (s *sharedPacketConn) SetDeadline(t time.Time) error {
+	if err := s.SetReadDeadline(t); err != nil {
+		return err
+	}
+
+	return s.SetWriteDeadline(t)
+}
+
+func (s *sharedPacketConn) Close() error {
+	var err error
+	fired := false
+	s.closeOnce.Do(func() {
+		fired = true
+		s.cancel()
+		if s.refs.Add(-1) <= 0 {
+			err = s.underlying.Close()
+		}
+	})
+	if !fired {
+		return nil
+	}
+
+	return err
+}

--- a/shared_packet_conn_test.go
+++ b/shared_packet_conn_test.go
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package ice
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// countingPacketConn records whether Close was invoked and how many times,
+// and exposes the latest write deadline applied to it so tests can confirm
+// SetWriteDeadline delegation. All other net.PacketConn methods return zero
+// values. It satisfies the internal muxedPacketConn interface so
+// sharedPacketConn can wrap it.
+type countingPacketConn struct {
+	closeCount    atomic.Int32
+	writeDeadline atomic.Pointer[time.Time]
+}
+
+func (c *countingPacketConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, nil }
+func (c *countingPacketConn) readFromContext(ctx context.Context, _ []byte) (int, net.Addr, error) {
+	<-ctx.Done()
+
+	return 0, nil, ctx.Err()
+}
+func (c *countingPacketConn) WriteTo([]byte, net.Addr) (int, error) { return 0, nil }
+func (c *countingPacketConn) LocalAddr() net.Addr                   { return nil }
+func (c *countingPacketConn) SetDeadline(time.Time) error           { return nil }
+func (c *countingPacketConn) SetReadDeadline(time.Time) error       { return nil }
+
+func (c *countingPacketConn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline.Store(&t)
+
+	return nil
+}
+
+func (c *countingPacketConn) Close() error {
+	c.closeCount.Add(1)
+
+	return nil
+}
+
+func TestSharedPacketConn_RefcountClose(t *testing.T) {
+	underlying := &countingPacketConn{}
+	var refs atomic.Int32
+
+	a := newSharedPacketConn(underlying, &refs)
+	b := newSharedPacketConn(underlying, &refs)
+	c := newSharedPacketConn(underlying, &refs)
+	require.Equal(t, int32(3), refs.Load())
+
+	require.NoError(t, a.Close())
+	require.Equal(t, int32(2), refs.Load())
+	require.Zero(t, underlying.closeCount.Load(), "underlying must stay open while refs > 0")
+
+	require.NoError(t, b.Close())
+	require.Equal(t, int32(1), refs.Load())
+	require.Zero(t, underlying.closeCount.Load(), "underlying must stay open while refs > 0")
+
+	require.NoError(t, c.Close())
+	require.Equal(t, int32(0), refs.Load())
+	require.Equal(t, int32(1), underlying.closeCount.Load(), "underlying must close exactly once at refs==0")
+}
+
+func TestSharedPacketConn_DoubleCloseIdempotent(t *testing.T) {
+	underlying := &countingPacketConn{}
+	var refs atomic.Int32
+
+	a := newSharedPacketConn(underlying, &refs)
+	b := newSharedPacketConn(underlying, &refs)
+
+	require.NoError(t, a.Close())
+	require.NoError(t, a.Close(), "second Close on same wrapper must be a no-op")
+	require.NoError(t, a.Close())
+
+	// b is still alive — its ref must not have been consumed by a's repeat Close calls.
+	require.Equal(t, int32(1), refs.Load())
+	require.Zero(t, underlying.closeCount.Load())
+
+	require.NoError(t, b.Close())
+	require.Equal(t, int32(1), underlying.closeCount.Load())
+}
+
+// blockingReadPacketConn parks readFromContext until release is closed or ctx
+// is done, simulating a network conn that has no incoming packets. Close/
+// WriteTo are normal.
+type blockingReadPacketConn struct {
+	countingPacketConn
+	release chan struct{}
+}
+
+func newBlockingReadPacketConn() *blockingReadPacketConn {
+	return &blockingReadPacketConn{release: make(chan struct{})}
+}
+
+func (b *blockingReadPacketConn) ReadFrom(_ []byte) (int, net.Addr, error) {
+	<-b.release
+
+	return 0, nil, io.EOF
+}
+
+func (b *blockingReadPacketConn) readFromContext(ctx context.Context, _ []byte) (int, net.Addr, error) {
+	select {
+	case <-b.release:
+		return 0, nil, io.EOF
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+	}
+}
+
+// A wrapper's Close must unblock its own in-flight ReadFrom without closing
+// the underlying conn or affecting sibling wrappers — this is the property
+// that lets candidate.close work for a single alias candidate while
+// siblings still hold references.
+func TestSharedPacketConn_CloseUnblocksOwnReadWithoutTouchingSiblings(t *testing.T) {
+	underlying := newBlockingReadPacketConn()
+	var refs atomic.Int32
+
+	wrapperA := newSharedPacketConn(underlying, &refs)
+	wrapperB := newSharedPacketConn(underlying, &refs)
+	require.Equal(t, int32(2), refs.Load())
+	t.Cleanup(func() {
+		close(underlying.release) // let any leftover ReadFrom helpers exit
+	})
+
+	// Start a ReadFrom on wrapperA; it will park inside the underlying.
+	readDone := make(chan struct{})
+	var readErr error
+	go func() {
+		buf := make([]byte, 1500)
+		_, _, readErr = wrapperA.ReadFrom(buf)
+		close(readDone)
+	}()
+
+	// Give the read time to enter the wait.
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-readDone:
+		require.FailNow(t, "ReadFrom returned before Close fired")
+	default:
+	}
+
+	// Closing wrapperA must unblock its own ReadFrom even though wrapperB
+	// still holds the underlying alive.
+	require.NoError(t, wrapperA.Close())
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "ReadFrom did not return after wrapper Close")
+	}
+	require.ErrorIs(t, readErr, io.ErrClosedPipe)
+	require.Equal(t, int32(1), refs.Load(), "sibling wrapperB must still hold a reference")
+	require.Zero(t, underlying.closeCount.Load(), "underlying must stay open while sibling holds a ref")
+
+	// wrapperB is unaffected; closing it releases the underlying.
+	require.NoError(t, wrapperB.Close())
+	require.Equal(t, int32(0), refs.Load())
+	require.Equal(t, int32(1), underlying.closeCount.Load())
+}
+
+func TestSharedPacketConn_ConcurrentLastCloserOnlyClosesUnderlying(t *testing.T) {
+	// Closing many wrappers concurrently must call underlying.Close exactly
+	// once — for the last release. This is the property Agent.deleteAllCandidates
+	// relies on to break the alias-candidate close deadlock.
+	const n = 64
+	underlying := &countingPacketConn{}
+	var refs atomic.Int32
+
+	wrappers := make([]*sharedPacketConn, n)
+	for i := range wrappers {
+		wrappers[i] = newSharedPacketConn(underlying, &refs)
+	}
+	require.Equal(t, int32(n), refs.Load())
+
+	var wg sync.WaitGroup
+	for _, w := range wrappers {
+		wg.Add(1)
+		go func(wrapper *sharedPacketConn) {
+			defer wg.Done()
+			require.NoError(t, wrapper.Close())
+		}(w)
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(0), refs.Load())
+	require.Equal(t, int32(1), underlying.closeCount.Load(),
+		"underlying must close exactly once even under concurrent wrapper close")
+}
+
+// SetReadDeadline on one wrapper must not affect concurrent reads on
+// sibling wrappers sharing the same underlying conn.
+func TestSharedPacketConn_SetReadDeadlineIsolated(t *testing.T) {
+	underlying := newBlockingReadPacketConn()
+	var refs atomic.Int32
+
+	wrapperA := newSharedPacketConn(underlying, &refs)
+	wrapperB := newSharedPacketConn(underlying, &refs)
+	t.Cleanup(func() {
+		close(underlying.release)
+		_ = wrapperA.Close()
+		_ = wrapperB.Close()
+	})
+
+	// Apply a short read deadline only on wrapperA. wrapperB stays deadline-free.
+	require.NoError(t, wrapperA.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+
+	doneA := make(chan error, 1)
+	doneB := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		_, _, err := wrapperA.ReadFrom(buf)
+		doneA <- err
+	}()
+	go func() {
+		buf := make([]byte, 1500)
+		_, _, err := wrapperB.ReadFrom(buf)
+		doneB <- err
+	}()
+
+	select {
+	case err := <-doneA:
+		require.ErrorIs(t, err, os.ErrDeadlineExceeded, "wrapperA must hit its per-wrapper read deadline")
+	case <-time.After(time.Second):
+		require.FailNow(t, "wrapperA's ReadFrom did not respect its SetReadDeadline")
+	}
+
+	// wrapperB must still be parked — no deadline, no release yet.
+	select {
+	case err := <-doneB:
+		require.FailNowf(t, "unexpected return", "wrapperB's ReadFrom returned: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// ReadFrom and WriteTo on a closed wrapper must return io.ErrClosedPipe,
+// even if siblings keep the underlying alive and packets are buffered.
+func TestSharedPacketConn_ReadWriteAfterCloseReturnsClosed(t *testing.T) {
+	underlying := newBlockingReadPacketConn()
+	var refs atomic.Int32
+
+	wrapperA := newSharedPacketConn(underlying, &refs)
+	wrapperB := newSharedPacketConn(underlying, &refs)
+	t.Cleanup(func() {
+		close(underlying.release)
+		_ = wrapperB.Close()
+	})
+
+	require.NoError(t, wrapperA.Close())
+
+	buf := make([]byte, 1500)
+	_, _, rerr := wrapperA.ReadFrom(buf)
+	require.ErrorIs(t, rerr, io.ErrClosedPipe, "ReadFrom after Close must return io.ErrClosedPipe")
+
+	_, werr := wrapperA.WriteTo([]byte("x"), &net.UDPAddr{})
+	require.ErrorIs(t, werr, io.ErrClosedPipe, "WriteTo after Close must return io.ErrClosedPipe")
+
+	// wrapperB is untouched.
+	require.Equal(t, int32(1), refs.Load())
+	require.Zero(t, underlying.closeCount.Load())
+}

--- a/tcp_mux.go
+++ b/tcp_mux.go
@@ -120,7 +120,9 @@ func (m *TCPMuxDefault) LocalAddr() net.Addr {
 	return m.params.Listener.Addr()
 }
 
-// GetConnByUfrag retrieves an existing or creates a new net.PacketConn.
+// GetConnByUfrag retrieves an existing or creates a new net.PacketConn. The returned conn
+// is a refcounted — repeat calls return connection with increased refcount, so
+// the connection's Close method should be called for each GetConn call to avoid leaks.
 func (m *TCPMuxDefault) GetConnByUfrag(ufrag string, isIPv6 bool, local net.IP) (net.PacketConn, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -129,13 +131,18 @@ func (m *TCPMuxDefault) GetConnByUfrag(ufrag string, isIPv6 bool, local net.IP) 
 		return nil, io.ErrClosedPipe
 	}
 
-	if conn, ok := m.getConn(ufrag, isIPv6, local); ok {
+	conn, ok := m.getConn(ufrag, isIPv6, local)
+	if ok {
 		conn.ClearAliveTimer()
-
-		return conn, nil
+	} else {
+		var err error
+		conn, err = m.createConn(ufrag, isIPv6, local, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return m.createConn(ufrag, isIPv6, local, false)
+	return newSharedPacketConn(conn, &conn.refs), nil
 }
 
 func (m *TCPMuxDefault) createConn(ufrag string, isIPv6 bool, local net.IP, fromStun bool) (*tcpPacketConn, error) {

--- a/tcp_mux_test.go
+++ b/tcp_mux_test.go
@@ -264,3 +264,62 @@ func TestTCPMux_NoLeakForConnectionFromStun(t *testing.T) {
 		require.Equal(t, msg.Raw, recv, "received bytes mismatch")
 	})
 }
+
+// Two GetConnByUfrag calls with the same (ufrag, isIPv6, local) must return
+// distinct wrappers backed by one underlying tcpPacketConn. Closing one
+// wrapper leaves the underlying alive (its CloseChannel remains open);
+// closing both releases it.
+func TestTCPMux_GetConnByUfrag_SharedRefcount(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	tcpMux := NewTCPMuxDefault(TCPMuxParams{
+		Listener:       listener,
+		Logger:         logging.NewDefaultLoggerFactory().NewLogger("ice"),
+		ReadBufferSize: 20,
+	})
+	defer func() {
+		_ = tcpMux.Close()
+	}()
+
+	listenerAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	connA, err := tcpMux.GetConnByUfrag("shared-ufrag", false, listenerAddr.IP)
+	require.NoError(t, err)
+	connB, err := tcpMux.GetConnByUfrag("shared-ufrag", false, listenerAddr.IP)
+	require.NoError(t, err)
+
+	wrapperA, ok := connA.(*sharedPacketConn)
+	require.True(t, ok, "GetConnByUfrag must return *sharedPacketConn")
+	wrapperB, ok := connB.(*sharedPacketConn)
+	require.True(t, ok)
+	require.NotSame(t, wrapperA, wrapperB, "each call must produce its own wrapper")
+	require.Same(t, wrapperA.underlying, wrapperB.underlying,
+		"wrappers must share one underlying tcpPacketConn")
+
+	underlying, ok := wrapperA.underlying.(*tcpPacketConn)
+	require.True(t, ok)
+	require.Equal(t, int32(2), underlying.refs.Load())
+
+	require.NoError(t, connA.Close())
+	require.Equal(t, int32(1), underlying.refs.Load())
+	select {
+	case <-underlying.CloseChannel():
+		require.FailNow(t, "underlying must stay open while another wrapper holds a reference")
+	default:
+	}
+
+	require.NoError(t, connB.Close())
+	require.Equal(t, int32(0), underlying.refs.Load())
+	select {
+	case <-underlying.CloseChannel():
+	case <-time.After(time.Second):
+		require.FailNow(t, "underlying must close when the last wrapper is released")
+	}
+}

--- a/tcp_packet_conn.go
+++ b/tcp_packet_conn.go
@@ -4,6 +4,7 @@
 package ice
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -91,6 +92,9 @@ type tcpPacketConn struct {
 	closedChan chan struct{}
 	closeOnce  sync.Once
 	aliveTimer *time.Timer
+
+	// refs counts outstanding sharedPacketConn wrappers handed out by the mux.
+	refs atomic.Int32
 }
 
 type streamingPacket struct {
@@ -229,12 +233,21 @@ func (t *tcpPacketConn) isClosed() bool {
 	}
 }
 
-// WriteTo is for passive and s-o candidates.
-func (t *tcpPacketConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
-	pkt, ok := <-t.recvChan
+// ReadFrom is for passive and s-o candidates.
+func (t *tcpPacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	return t.readFromContext(context.Background(), b)
+}
 
-	if !ok {
-		return 0, nil, io.ErrClosedPipe
+func (t *tcpPacketConn) readFromContext(ctx context.Context, b []byte) (int, net.Addr, error) {
+	var pkt streamingPacket
+	var ok bool
+	select {
+	case pkt, ok = <-t.recvChan:
+		if !ok {
+			return 0, nil, io.ErrClosedPipe
+		}
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
 	}
 
 	if pkt.Err != nil {
@@ -245,10 +258,10 @@ func (t *tcpPacketConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
 		return 0, pkt.RAddr, io.ErrShortBuffer
 	}
 
-	n = len(pkt.Data)
+	n := len(pkt.Data)
 	copy(b, pkt.Data[:n])
 
-	return n, pkt.RAddr, err
+	return n, pkt.RAddr, nil
 }
 
 // WriteTo is for active and s-o candidates.

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -145,7 +145,9 @@ func (m *UDPMuxDefault) GetListenAddresses() []net.Addr {
 }
 
 // GetConn returns a PacketConn given the connection's ufrag and network address.
-// creates the connection if an existing one can't be found.
+// creates the connection if an existing one can't be found. The returned conn
+// is a refcounted — repeat calls return connection with increased refcount, so
+// the connection's Close method should be called for each GetConn call to avoid leaks.
 func (m *UDPMuxDefault) GetConn(ufrag string, addr net.Addr) (net.PacketConn, error) {
 	// don't check addr for mux using unspecified address
 	if len(m.localAddrsForUnspecified) == 0 && m.params.UDPConnString != addr.String() {
@@ -163,23 +165,22 @@ func (m *UDPMuxDefault) GetConn(ufrag string, addr net.Addr) (net.PacketConn, er
 		return nil, io.ErrClosedPipe
 	}
 
-	if conn, ok := m.getConn(ufrag, isIPv6); ok {
-		return conn, nil
+	muxedConn, ok := m.getConn(ufrag, isIPv6)
+	if !ok {
+		muxedConn = m.createMuxedConn(ufrag)
+		go func() {
+			<-muxedConn.CloseChannel()
+			m.RemoveConnByUfrag(ufrag)
+		}()
+
+		if isIPv6 {
+			m.connsIPv6[ufrag] = muxedConn
+		} else {
+			m.connsIPv4[ufrag] = muxedConn
+		}
 	}
 
-	c := m.createMuxedConn(ufrag)
-	go func() {
-		<-c.CloseChannel()
-		m.RemoveConnByUfrag(ufrag)
-	}()
-
-	if isIPv6 {
-		m.connsIPv6[ufrag] = c
-	} else {
-		m.connsIPv4[ufrag] = c
-	}
-
-	return c, nil
+	return newSharedPacketConn(muxedConn, &muxedConn.refs), nil
 }
 
 // RemoveConnByUfrag stops and removes the muxed packet connection.

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -366,6 +366,53 @@ func TestUDPMuxedConn_ReadFrom_WaitingThenClosedEOF(t *testing.T) {
 	}
 }
 
+func TestUDPMuxedConn_TwoReadersWokenByTwoWrites(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(time.Second * 10).Stop()
+
+	conn := secondTestMuxedConn(t, 1500)
+	remote := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5678}
+
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	results := make(chan readResult, 2)
+	read := func() {
+		buf := make([]byte, 1500)
+		n, _, err := conn.ReadFrom(buf)
+		results <- readResult{data: append([]byte(nil), buf[:n]...), err: err}
+	}
+	go read()
+	go read()
+
+	// Both readers must be parked before we write.
+	require.Eventually(t, func() bool {
+		return conn.readWaiting.Load() == 2
+	}, 2*time.Second, time.Millisecond, "both readers must block on the empty queue")
+
+	// First write wakes exactly one reader, which drains the single packet.
+	require.NoError(t, conn.writePacket([]byte("p1"), remote))
+	first := <-results
+	require.NoError(t, first.err)
+	require.Equal(t, []byte("p1"), first.data)
+
+	// The other reader is still parked; the first has decremented on unpark.
+	require.Eventually(t, func() bool {
+		return conn.readWaiting.Load() == 1
+	}, 2*time.Second, time.Millisecond, "the second reader must still be parked")
+
+	// Second write wakes the remaining reader.
+	require.NoError(t, conn.writePacket([]byte("p2"), remote))
+	second := <-results
+	require.NoError(t, second.err)
+	require.Equal(t, []byte("p2"), second.data)
+
+	// Both readers returned and the counter is balanced.
+	require.Equal(t, int32(0), conn.readWaiting.Load(),
+		"readWaiting must be 0 after both readers are woken")
+}
+
 func TestUDPMuxedConn_WriteTo_ClosedPipe(t *testing.T) {
 	conn := secondTestMuxedConn(t, 64)
 	require.NoError(t, conn.Close())
@@ -493,7 +540,7 @@ func TestUDPMuxedConn_writePacket_ClosedState(t *testing.T) {
 
 	// closed state before write
 	conn.mu.Lock()
-	conn.state = udpMuxedConnClosed
+	conn.closed = true
 	conn.mu.Unlock()
 
 	err := conn.writePacket([]byte{1, 2, 3}, addr) // fits in cap
@@ -511,10 +558,8 @@ func TestUDPMuxedConn_writePacket_NotifyDefaultBranch(t *testing.T) {
 	// fill notify channel so send would block
 	conn.notify <- struct{}{}
 
-	// set pre-state to waiting so the post-unlock select triggers
-	conn.mu.Lock()
-	conn.state = udpMuxedConnWaiting
-	conn.mu.Unlock()
+	// mark a reader as parked so writePacket attempts the (now blocked) notify
+	conn.readWaiting.Store(1)
 
 	// write should take default branch
 	err := conn.writePacket([]byte("hello"), addr)

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -810,9 +810,55 @@ func TestUDPMux_connWorker_WritePacketError(t *testing.T) {
 	ipport, err := newIPPort(remote.IP, remote.Zone, 5555)
 	require.NoError(t, err)
 
-	cInner, ok := c.(*udpMuxedConn)
-	require.True(t, ok, "expected *udpMuxedConn from UDPMuxDefault.GetConn")
-	mux.registerConnForAddress(cInner, ipport)
+	cInner, ok := c.(*sharedPacketConn)
+	require.True(t, ok, "expected *sharedPacketConn from UDPMuxDefault.GetConn")
+	muxedConn, ok := cInner.underlying.(*udpMuxedConn)
+	require.True(t, ok, "expected sharedPacketConn to wrap *udpMuxedConn")
+	mux.registerConnForAddress(muxedConn, ipport)
+}
+
+// Two GetConn calls with the same ufrag/network must return distinct wrappers
+// backed by one underlying udpMuxedConn. Closing one wrapper leaves the
+// underlying alive; closing both releases it.
+func TestUDPMux_GetConn_SharedRefcount(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	udpConn, err := net.ListenUDP(udp, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer func() { _ = udpConn.Close() }()
+
+	mux := NewUDPMuxDefault(UDPMuxParams{UDPConn: udpConn})
+	defer func() { _ = mux.Close() }()
+
+	addr := mux.LocalAddr()
+	connA, err := mux.GetConn("shared-ufrag", addr)
+	require.NoError(t, err)
+	connB, err := mux.GetConn("shared-ufrag", addr)
+	require.NoError(t, err)
+
+	wrapperA, ok := connA.(*sharedPacketConn)
+	require.True(t, ok, "GetConn must return *sharedPacketConn")
+	wrapperB, ok := connB.(*sharedPacketConn)
+	require.True(t, ok)
+	require.NotSame(t, wrapperA, wrapperB, "each call must produce its own wrapper")
+	require.Same(t, wrapperA.underlying, wrapperB.underlying,
+		"wrappers must share one underlying udpMuxedConn")
+
+	underlying, ok := wrapperA.underlying.(*udpMuxedConn)
+	require.True(t, ok)
+	require.Equal(t, int32(2), underlying.refs.Load())
+
+	require.NoError(t, connA.Close())
+	require.Equal(t, int32(1), underlying.refs.Load())
+	require.False(t, underlying.isClosed(), "underlying must stay open while a wrapper holds a reference")
+
+	require.NoError(t, connB.Close())
+	require.Equal(t, int32(0), underlying.refs.Load())
+	select {
+	case <-underlying.CloseChannel():
+	case <-time.After(time.Second):
+		require.FailNow(t, "underlying must close when the last wrapper is released")
+	}
 }
 
 func TestNewUDPMuxDefault_UnspecifiedAddr_AutoInitNet(t *testing.T) {

--- a/udp_mux_universal_test.go
+++ b/udp_mux_universal_test.go
@@ -163,11 +163,17 @@ func TestUniversalUDPMux_GetConnForURL_UniquePerURL(t *testing.T) {
 		_ = pc2.Close()
 	}()
 
-	c1, ok := pc1.(*udpMuxedConn)
-	require.True(t, ok, "pc1 is not *udpMuxedConn")
-	c2, ok := pc2.(*udpMuxedConn)
-	require.True(t, ok, "pc2 is not *udpMuxedConn")
-	require.NotEqual(t, c1, c2, "expected distinct muxed conns for different URLs with same ufrag")
+	// GetConnForURL now hands out *sharedPacketConn wrappers around the
+	// per-(ufrag,url) underlying *udpMuxedConn; unwrap to compare identity.
+	w1, ok := pc1.(*sharedPacketConn)
+	require.True(t, ok, "pc1 is not *sharedPacketConn")
+	w2, ok := pc2.(*sharedPacketConn)
+	require.True(t, ok, "pc2 is not *sharedPacketConn")
+	c1, ok := w1.underlying.(*udpMuxedConn)
+	require.True(t, ok, "pc1 underlying is not *udpMuxedConn")
+	c2, ok := w2.underlying.(*udpMuxedConn)
+	require.True(t, ok, "pc2 underlying is not *udpMuxedConn")
+	require.NotSame(t, c1, c2, "expected distinct muxed conns for different URLs with same ufrag")
 
 	pc1b, err := udpMux.GetConnForURL("ufragX", "stun:serverA", lf)
 	require.NoError(t, err)
@@ -175,10 +181,13 @@ func TestUniversalUDPMux_GetConnForURL_UniquePerURL(t *testing.T) {
 		_ = pc1b.Close()
 	}()
 
-	c1b, ok := pc1b.(*udpMuxedConn)
-	require.True(t, ok, "pc1b is not *udpMuxedConn")
+	w1b, ok := pc1b.(*sharedPacketConn)
+	require.True(t, ok, "pc1b is not *sharedPacketConn")
+	c1b, ok := w1b.underlying.(*udpMuxedConn)
+	require.True(t, ok, "pc1b underlying is not *udpMuxedConn")
 
-	require.Equal(t, c1, c1b, "expected same muxed conn when requesting the same (ufrag,url)")
+	require.NotSame(t, w1, w1b, "GetConnForURL must return a fresh wrapper each call")
+	require.Same(t, c1, c1b, "expected same underlying muxed conn when requesting the same (ufrag,url)")
 }
 
 func newLogger() logging.LeveledLogger {

--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -15,14 +15,6 @@ import (
 	"github.com/pion/logging"
 )
 
-type udpMuxedConnState int
-
-const (
-	udpMuxedConnOpen udpMuxedConnState = iota
-	udpMuxedConnWaiting
-	udpMuxedConnClosed
-)
-
 type udpMuxedConnParams struct {
 	Mux       *UDPMuxDefault
 	AddrPool  *sync.Pool
@@ -41,8 +33,10 @@ type udpMuxedConn struct {
 	bufHead, bufTail *bufferHolder
 	notify           chan struct{}
 	closedChan       chan struct{}
-	state            udpMuxedConnState
-	mu               sync.Mutex
+
+	readWaiting atomic.Int32
+	closed      bool
+	mu          sync.Mutex
 
 	// refs counts outstanding sharedPacketConn wrappers handed out by the mux.
 	refs atomic.Int32
@@ -85,21 +79,28 @@ func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (n int, rA
 			return n, rAddr, err
 		}
 
-		if c.state == udpMuxedConnClosed {
+		if c.closed {
 			c.mu.Unlock()
 
 			return 0, nil, io.EOF
 		}
 
-		c.state = udpMuxedConnWaiting
+		c.readWaiting.Add(1)
 		c.mu.Unlock()
 
 		select {
 		case <-c.notify:
 		case <-c.closedChan:
-			return 0, nil, io.EOF
+			err = io.EOF
+
 		case <-ctx.Done():
-			return 0, nil, ctx.Err()
+			err = ctx.Err()
+		}
+
+		c.readWaiting.Add(-1)
+
+		if err != nil {
+			return 0, nil, err
 		}
 	}
 }
@@ -152,7 +153,7 @@ func (c *udpMuxedConn) CloseChannel() <-chan struct{} {
 func (c *udpMuxedConn) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != udpMuxedConnClosed {
+	if !c.closed {
 		for pkt := c.bufTail; pkt != nil; {
 			next := pkt.next
 
@@ -164,7 +165,7 @@ func (c *udpMuxedConn) Close() error {
 		c.bufHead = nil
 		c.bufTail = nil
 
-		c.state = udpMuxedConnClosed
+		c.closed = true
 		close(c.closedChan)
 	}
 
@@ -175,7 +176,7 @@ func (c *udpMuxedConn) isClosed() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	return c.state == udpMuxedConnClosed
+	return c.closed
 }
 
 func (c *udpMuxedConn) getAddresses() []ipPort {
@@ -229,7 +230,7 @@ func (c *udpMuxedConn) writePacket(data []byte, addr *net.UDPAddr) error {
 	pkt.addr = addr
 
 	c.mu.Lock()
-	if c.state == udpMuxedConnClosed {
+	if c.closed {
 		c.mu.Unlock()
 
 		pkt.reset()
@@ -247,11 +248,10 @@ func (c *udpMuxedConn) writePacket(data []byte, addr *net.UDPAddr) error {
 		c.bufTail = pkt
 	}
 
-	state := c.state
-	c.state = udpMuxedConnOpen
+	notify := c.readWaiting.Load() > 0
 	c.mu.Unlock()
 
-	if state == udpMuxedConnWaiting {
+	if notify {
 		select {
 		case c.notify <- struct{}{}:
 		default:

--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -4,10 +4,12 @@
 package ice
 
 import (
+	"context"
 	"io"
 	"net"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/logging"
@@ -41,6 +43,9 @@ type udpMuxedConn struct {
 	closedChan       chan struct{}
 	state            udpMuxedConnState
 	mu               sync.Mutex
+
+	// refs counts outstanding sharedPacketConn wrappers handed out by the mux.
+	refs atomic.Int32
 }
 
 func newUDPMuxedConn(params *udpMuxedConnParams) *udpMuxedConn {
@@ -51,7 +56,11 @@ func newUDPMuxedConn(params *udpMuxedConnParams) *udpMuxedConn {
 	}
 }
 
-func (c *udpMuxedConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
+func (c *udpMuxedConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	return c.readFromContext(context.Background(), b)
+}
+
+func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (n int, rAddr net.Addr, err error) {
 	for {
 		c.mu.Lock()
 		if c.bufTail != nil {
@@ -89,6 +98,8 @@ func (c *udpMuxedConn) ReadFrom(b []byte) (n int, rAddr net.Addr, err error) {
 		case <-c.notify:
 		case <-c.closedChan:
 			return 0, nil, io.EOF
+		case <-ctx.Done():
+			return 0, nil, ctx.Err()
 		}
 	}
 }


### PR DESCRIPTION
Wrap the conn returned by UDP/TCP mux GetConn in a ref-counted sharedPacketConn so AddressRewriteAppend can hand out multiple alias host candidates that share a single underlying mux conn. The underlying conn is closed only when the last wrapper is released. Close mux conn in error paths in gather to avoid leak.

Close #922 