### PR TITLE
Add pre-insertion local candidate filter

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -151,10 +151,11 @@ type Agent struct {
 	udpMux      UDPMux
 	udpMuxSrflx UniversalUDPMux
 
-	interfaceFilter func(string) (keep bool)
-	ipFilter        func(net.IP) (keep bool)
-	remoteIPFilter  func(net.IP) (keep bool)
-	includeLoopback bool
+	interfaceFilter      func(string) (keep bool)
+	ipFilter             func(net.IP) (keep bool)
+	remoteIPFilter       func(net.IP) (keep bool)
+	localCandidateFilter func(Candidate) (keep bool)
+	includeLoopback      bool
 
 	insecureSkipVerify bool
 
@@ -379,6 +380,7 @@ func createAgentBase(config *AgentConfig) (*Agent, error) {
 		interfaceFilter:                 config.InterfaceFilter,
 		ipFilter:                        config.IPFilter,
 		remoteIPFilter:                  config.RemoteIPFilter,
+		localCandidateFilter:            config.LocalCandidateFilter,
 		insecureSkipVerify:              config.InsecureSkipVerify,
 		includeLoopback:                 config.IncludeLoopback,
 		disableActiveTCP:                config.DisableActiveTCP,
@@ -1341,6 +1343,18 @@ func (a *Agent) addCandidate(ctx context.Context, cand Candidate, candidateConn 
 
 				return
 			}
+		}
+
+		if a.localCandidateFilter != nil && !a.localCandidateFilter(cand) {
+			a.log.Debugf("Ignore filtered local candidate: %s", cand)
+			if err := cand.close(); err != nil {
+				a.log.Warnf("Failed to close filtered local candidate: %v", err)
+			}
+			if err := candidateConn.Close(); err != nil {
+				a.log.Warnf("Failed to close filtered local candidate connection: %v", err)
+			}
+
+			return
 		}
 
 		a.setCandidateExtensions(cand)

--- a/agent_config.go
+++ b/agent_config.go
@@ -191,6 +191,10 @@ type AgentConfig struct {
 	// remote candidate IP addresses before they are added to the agent.
 	RemoteIPFilter func(net.IP) (keep bool)
 
+	// LocalCandidateFilter is called before a gathered local candidate is added to the agent.
+	// Candidates for which this function returns false are discarded.
+	LocalCandidateFilter func(Candidate) (keep bool)
+
 	// InsecureSkipVerify controls if self-signed certificates are accepted when connecting
 	// to TURN servers via TLS or DTLS
 	InsecureSkipVerify bool

--- a/agent_options.go
+++ b/agent_options.go
@@ -511,6 +511,20 @@ func WithRemoteIPFilter(filter func(net.IP) bool) AgentOption {
 	}
 }
 
+// WithLocalCandidateFilter sets a filter for gathered local candidates.
+// Candidates for which this function returns false are discarded.
+func WithLocalCandidateFilter(filter func(Candidate) bool) AgentOption {
+	return func(a *Agent) error {
+		if a.constructed {
+			return ErrAgentOptionNotUpdatable
+		}
+
+		a.localCandidateFilter = filter
+
+		return nil
+	}
+}
+
 // WithNet sets the underlying network implementation for the agent.
 func WithNet(net transport.Net) AgentOption {
 	return func(a *Agent) error {

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -222,6 +222,23 @@ func TestWithRemoteIPFilterOption(t *testing.T) {
 	assert.False(t, agent.remoteIPFilter(net.IPv4(203, 0, 113, 1)))
 }
 
+func TestWithLocalCandidateFilterOption(t *testing.T) {
+	filter := func(candidate Candidate) bool {
+		return candidate.Type() == CandidateTypeHost
+	}
+
+	agent, err := NewAgentWithOptions(WithLocalCandidateFilter(filter))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, agent.Close()) }()
+
+	require.NotNil(t, agent.localCandidateFilter)
+	candidate, err := NewCandidateHost(&CandidateHostConfig{
+		Network: "udp", Address: "192.0.2.1", Port: 41000, Component: 1,
+	})
+	require.NoError(t, err)
+	require.True(t, agent.localCandidateFilter(candidate))
+}
+
 func TestWithNetOption(t *testing.T) {
 	stub := newStubNet(t)
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -2098,6 +2098,173 @@ func TestGetLocalCandidates(t *testing.T) {
 	require.ElementsMatch(t, expectedCandidates, actualCandidates)
 }
 
+func TestLocalCandidateFilter(t *testing.T) {
+	t.Run("accepts and notifies", func(t *testing.T) {
+		filterCalls := 0
+		notified := make(chan Candidate, 1)
+		agent, err := NewAgent(&AgentConfig{
+			LocalCandidateFilter: func(Candidate) bool {
+				filterCalls++
+
+				return true
+			},
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, agent.Close()) }()
+		require.NoError(t, agent.OnCandidate(func(candidate Candidate) {
+			if candidate != nil {
+				notified <- candidate
+			}
+		}))
+
+		candidate, err := NewCandidateHost(&CandidateHostConfig{
+			Network: "udp", Address: "192.0.2.1", Port: 41000, Component: 1,
+		})
+		require.NoError(t, err)
+		require.NoError(t, agent.addCandidate(t.Context(), candidate, &fakenet.MockPacketConn{}))
+
+		actual, err := agent.GetLocalCandidates()
+		require.NoError(t, err)
+		require.Equal(t, 1, filterCalls)
+		require.Equal(t, []Candidate{candidate}, actual)
+		require.Equal(t, candidate, <-notified)
+	})
+
+	t.Run("rejects candidates before insertion pairs checks and notification", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			candidate func(t *testing.T, onClose func() error) Candidate
+		}{
+			{
+				name: "host",
+				candidate: func(t *testing.T, _ func() error) Candidate {
+					candidate, err := NewCandidateHost(&CandidateHostConfig{
+						Network: "udp", Address: "192.0.2.2", Port: 41001, Component: 1,
+					})
+					require.NoError(t, err)
+
+					return candidate
+				},
+			},
+			{
+				name: "server reflexive",
+				candidate: func(t *testing.T, _ func() error) Candidate {
+					candidate, err := NewCandidateServerReflexive(&CandidateServerReflexiveConfig{
+						Network: "udp", Address: "192.0.2.3", Port: 41002, Component: 1,
+						RelAddr: "10.0.0.1", RelPort: 41002,
+					})
+					require.NoError(t, err)
+
+					return candidate
+				},
+			},
+			{
+				name: "relay",
+				candidate: func(t *testing.T, onClose func() error) Candidate {
+					candidate, err := NewCandidateRelay(&CandidateRelayConfig{
+						Network: "udp", Address: "192.0.2.4", Port: 41003, Component: 1,
+						RelAddr: "10.0.0.1", RelPort: 41003, OnClose: onClose,
+					})
+					require.NoError(t, err)
+
+					return candidate
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				filterCalls := 0
+				relayClosed := false
+				agent, err := NewAgent(&AgentConfig{
+					LocalCandidateFilter: func(Candidate) bool {
+						filterCalls++
+
+						return false
+					},
+				})
+				require.NoError(t, err)
+				defer func() { require.NoError(t, agent.Close()) }()
+				notified := make(chan struct{}, 1)
+				require.NoError(t, agent.OnCandidate(func(Candidate) { notified <- struct{}{} }))
+				remote, err := NewCandidateHost(&CandidateHostConfig{
+					Network: "udp", Address: "198.51.100.1", Port: 42000, Component: 1,
+				})
+				require.NoError(t, err)
+				agent.remoteCandidates[NetworkTypeUDP4] = []Candidate{remote}
+
+				candidate := tt.candidate(t, func() error {
+					relayClosed = true
+
+					return nil
+				})
+				conn := &candidateFilterPacketConn{}
+				require.NoError(t, agent.addCandidate(t.Context(), candidate, conn))
+
+				actual, err := agent.GetLocalCandidates()
+				require.NoError(t, err)
+				require.Empty(t, actual)
+				require.Empty(t, agent.checklist)
+				require.Equal(t, 1, filterCalls)
+				require.True(t, conn.closed)
+				select {
+				case <-notified:
+					t.Fatal("rejected candidate was notified")
+				default:
+				}
+				if tt.name == "relay" {
+					require.True(t, relayClosed)
+				}
+				select {
+				case <-agent.forceCandidateContact:
+					t.Fatal("rejected candidate requested a connectivity check")
+				default:
+				}
+			})
+		}
+	})
+
+	t.Run("duplicate does not invoke filter", func(t *testing.T) {
+		filterCalls := 0
+		agent, err := NewAgent(&AgentConfig{
+			LocalCandidateFilter: func(Candidate) bool {
+				filterCalls++
+
+				return true
+			},
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, agent.Close()) }()
+
+		candidate, err := NewCandidateHost(&CandidateHostConfig{
+			Network: "udp", Address: "192.0.2.5", Port: 41004, Component: 1,
+		})
+		require.NoError(t, err)
+		require.NoError(t, agent.addCandidate(t.Context(), candidate, &fakenet.MockPacketConn{}))
+		require.Equal(t, 1, filterCalls)
+
+		duplicate, err := NewCandidateHost(&CandidateHostConfig{
+			Network: "udp", Address: "192.0.2.5", Port: 41004, Component: 1,
+		})
+		require.NoError(t, err)
+		duplicateConn := &candidateFilterPacketConn{}
+		require.NoError(t, agent.addCandidate(t.Context(), duplicate, duplicateConn))
+		require.Equal(t, 1, filterCalls)
+		require.True(t, duplicateConn.closed)
+	})
+}
+
+type candidateFilterPacketConn struct {
+	fakenet.MockPacketConn
+	closed bool
+}
+
+func (c *candidateFilterPacketConn) Close() error {
+	c.closed = true
+
+	return nil
+}
+
 func TestCloseInConnectionStateCallback(t *testing.T) {
 	defer test.CheckRoutines(t)()
 


### PR DESCRIPTION
Adds a generic LocalCandidateFilter agent option invoked after duplicate detection and before candidate startup, insertion, pair creation, connectivity checks, or notification. Rejected candidates and their connections are closed without surfacing a gather error. Tests cover accepted and rejected host, server-reflexive, and relay candidates, cleanup, notification/pair suppression, and duplicate behavior. Full and focused race suites pass.