### PR TITLE
Reduce read and write allocations

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1167,8 +1167,8 @@ func replacePairRemote(pair *CandidatePair, remote Candidate) *CandidatePair {
 	atomic.StoreUint64(&replacement.responsesReceived, atomic.LoadUint64(&pair.responsesReceived))
 	atomic.StoreUint64(&replacement.responsesSent, atomic.LoadUint64(&pair.responsesSent))
 
-	copyAtomicValue(&replacement.lastPacketSentAt, &pair.lastPacketSentAt)
-	copyAtomicValue(&replacement.lastPacketReceivedAt, &pair.lastPacketReceivedAt)
+	replacement.lastPacketSentAt.Store(pair.lastPacketSentAt.Load())
+	replacement.lastPacketReceivedAt.Store(pair.lastPacketReceivedAt.Load())
 	copyAtomicValue(&replacement.firstRequestSentAt, &pair.firstRequestSentAt)
 	copyAtomicValue(&replacement.lastRequestSentAt, &pair.lastRequestSentAt)
 	copyAtomicValue(&replacement.firstResponseReceivedAt, &pair.firstResponseReceivedAt)

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -41,8 +41,8 @@ type CandidatePair struct {
 	packetsReceived      uint32
 	bytesSent            uint64
 	bytesReceived        uint64
-	lastPacketSentAt     atomic.Value // time.Time
-	lastPacketReceivedAt atomic.Value // time.Time
+	lastPacketSentAt     atomic.Int64 // monotonic nanos since timeRef, see getMonoNanos
+	lastPacketReceivedAt atomic.Int64 // monotonic nanos since timeRef, see getMonoNanos
 
 	requestsReceived  uint64
 	requestsSent      uint64
@@ -221,8 +221,8 @@ func (p *CandidatePair) BytesReceived() uint64 {
 
 // LastPacketSentAt returns the timestamp of the last application packet sent.
 func (p *CandidatePair) LastPacketSentAt() time.Time {
-	if v, ok := p.lastPacketSentAt.Load().(time.Time); ok {
-		return v
+	if nanos := p.lastPacketSentAt.Load(); nanos != 0 {
+		return getMonoTime(nanos)
 	}
 
 	return time.Time{}
@@ -230,8 +230,8 @@ func (p *CandidatePair) LastPacketSentAt() time.Time {
 
 // LastPacketReceivedAt returns the timestamp of the last application packet received.
 func (p *CandidatePair) LastPacketReceivedAt() time.Time {
-	if v, ok := p.lastPacketReceivedAt.Load().(time.Time); ok {
-		return v
+	if nanos := p.lastPacketReceivedAt.Load(); nanos != 0 {
+		return getMonoTime(nanos)
 	}
 
 	return time.Time{}
@@ -245,7 +245,7 @@ func (p *CandidatePair) UpdatePacketSent(n int) {
 
 	atomic.AddUint32(&p.packetsSent, 1)
 	atomic.AddUint64(&p.bytesSent, uint64(n)) // #nosec G115 -- n > 0 validated above
-	p.lastPacketSentAt.Store(time.Now())
+	p.lastPacketSentAt.Store(getMonoNanos(time.Now()))
 }
 
 // UpdatePacketReceived increments packet/byte counters and updates timestamp for a received application packet.
@@ -256,7 +256,7 @@ func (p *CandidatePair) UpdatePacketReceived(n int) {
 
 	atomic.AddUint32(&p.packetsReceived, 1)
 	atomic.AddUint64(&p.bytesReceived, uint64(n)) // #nosec G115 -- n > 0 validated above
-	p.lastPacketReceivedAt.Store(time.Now())
+	p.lastPacketReceivedAt.Store(getMonoNanos(time.Now()))
 }
 
 // FirstRequestSentAt returns the timestamp of the first connectivity check sent.

--- a/candidatepair_test.go
+++ b/candidatepair_test.go
@@ -5,6 +5,7 @@ package ice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -186,4 +187,18 @@ func TestCandidatePair_ID(t *testing.T) {
 	// Set ID
 	pair.id = 42
 	require.Equal(t, uint64(42), pair.ID())
+}
+
+func TestCandidatePairPacketTimestamps(t *testing.T) {
+	pair := newCandidatePair(hostCandidate(), hostCandidate(), false)
+
+	require.Zero(t, pair.LastPacketSentAt())
+	require.Zero(t, pair.LastPacketReceivedAt())
+
+	now := time.Now()
+	pair.UpdatePacketSent(1)
+	pair.UpdatePacketReceived(1)
+
+	require.WithinDuration(t, now, pair.LastPacketSentAt(), 10*time.Millisecond)
+	require.WithinDuration(t, now, pair.LastPacketReceivedAt(), 10*time.Millisecond)
 }

--- a/transport.go
+++ b/transport.go
@@ -134,11 +134,21 @@ func (c *Conn) Write(packet []byte) (int, error) {
 
 	pair := c.agent.getSelectedPair()
 	if pair == nil {
+		// Note: the closure must capture p and not pair. Whether a variable
+		// is heap-allocated is a static decision across all code paths, and
+		// the allocation happens where the variable is declared. If we were
+		// to capture pair directly in this closure, then pair would be heap
+		// allocated on every single packet write, even when there is already
+		// a selected pair. By declaring a new variable inside the fallback,
+		// we avoid allocating on most writes and only allocate when no pair
+		// is currently selected.
+		var p *CandidatePair
 		if err = c.agent.loop.Run(c.agent.loop, func(_ context.Context) {
-			pair = c.agent.getBestValidCandidatePair()
+			p = c.agent.getBestValidCandidatePair()
 		}); err != nil {
 			return 0, err
 		}
+		pair = p
 
 		if pair == nil {
 			return 0, ErrNoCandidatePairs

--- a/transport_test.go
+++ b/transport_test.go
@@ -191,52 +191,52 @@ func stressDuplex(t *testing.T) {
 	require.NoError(t, test.StressDuplex(ca, cb, opt))
 }
 
-func gatherAndExchangeCandidates(t *testing.T, aAgent, bAgent *Agent) {
-	t.Helper()
+func gatherAndExchangeCandidates(tb testing.TB, aAgent, bAgent *Agent) {
+	tb.Helper()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	require.NoError(t, aAgent.OnCandidate(func(candidate Candidate) {
+	require.NoError(tb, aAgent.OnCandidate(func(candidate Candidate) {
 		if candidate == nil {
 			wg.Done()
 		}
 	}))
-	require.NoError(t, aAgent.GatherCandidates())
+	require.NoError(tb, aAgent.GatherCandidates())
 
-	require.NoError(t, bAgent.OnCandidate(func(candidate Candidate) {
+	require.NoError(tb, bAgent.OnCandidate(func(candidate Candidate) {
 		if candidate == nil {
 			wg.Done()
 		}
 	}))
-	require.NoError(t, bAgent.GatherCandidates())
+	require.NoError(tb, bAgent.GatherCandidates())
 
 	wg.Wait()
 
 	candidates, err := aAgent.GetLocalCandidates()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	for _, c := range candidates {
 		if addr, parseErr := netip.ParseAddr(c.Address()); parseErr == nil {
-			require.False(t, shouldFilterLocationTrackedIP(addr))
+			require.False(tb, shouldFilterLocationTrackedIP(addr))
 		}
 		candidateCopy, copyErr := c.copy()
-		require.NoError(t, copyErr)
-		require.NoError(t, bAgent.AddRemoteCandidate(candidateCopy))
+		require.NoError(tb, copyErr)
+		require.NoError(tb, bAgent.AddRemoteCandidate(candidateCopy))
 	}
 
 	candidates, err = bAgent.GetLocalCandidates()
 
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	for _, c := range candidates {
 		candidateCopy, copyErr := c.copy()
-		require.NoError(t, copyErr)
-		require.NoError(t, aAgent.AddRemoteCandidate(candidateCopy))
+		require.NoError(tb, copyErr)
+		require.NoError(tb, aAgent.AddRemoteCandidate(candidateCopy))
 	}
 }
 
-func connect(t *testing.T, aAgent, bAgent *Agent) (*Conn, *Conn) {
-	t.Helper()
-	gatherAndExchangeCandidates(t, aAgent, bAgent)
+func connect(tb testing.TB, aAgent, bAgent *Agent) (*Conn, *Conn) {
+	tb.Helper()
+	gatherAndExchangeCandidates(tb, aAgent, bAgent)
 
 	accepted := make(chan struct{})
 	var aConn *Conn
@@ -244,15 +244,15 @@ func connect(t *testing.T, aAgent, bAgent *Agent) (*Conn, *Conn) {
 	go func() {
 		var acceptErr error
 		bUfrag, bPwd, acceptErr := bAgent.GetLocalUserCredentials()
-		require.NoError(t, acceptErr)
+		require.NoError(tb, acceptErr)
 		aConn, acceptErr = aAgent.Accept(context.TODO(), bUfrag, bPwd)
-		require.NoError(t, acceptErr)
+		require.NoError(tb, acceptErr)
 		close(accepted)
 	}()
 	aUfrag, aPwd, err := aAgent.GetLocalUserCredentials()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	bConn, err := bAgent.Dial(context.TODO(), aUfrag, aPwd)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	// Ensure accepted
 	<-accepted
@@ -260,8 +260,8 @@ func connect(t *testing.T, aAgent, bAgent *Agent) (*Conn, *Conn) {
 	return aConn, bConn
 }
 
-func pipe(t *testing.T, defaultConfig *AgentConfig) (*Conn, *Conn) {
-	t.Helper()
+func pipe(tb testing.TB, defaultConfig *AgentConfig) (*Conn, *Conn) {
+	tb.Helper()
 	var urls []*stun.URI
 
 	aNotifier, aConnected := onConnected()
@@ -276,21 +276,21 @@ func pipe(t *testing.T, defaultConfig *AgentConfig) (*Conn, *Conn) {
 	cfg.NetworkTypes = supportedNetworkTypes()
 
 	aAgent, err := NewAgent(cfg)
-	require.NoError(t, err)
-	require.NoError(t, aAgent.OnConnectionStateChange(aNotifier))
-	t.Cleanup(func() {
-		require.NoError(t, aAgent.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, aAgent.OnConnectionStateChange(aNotifier))
+	tb.Cleanup(func() {
+		require.NoError(tb, aAgent.Close())
 	})
 
 	bAgent, err := NewAgent(cfg)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
-	t.Cleanup(func() {
-		require.NoError(t, bAgent.Close())
+	require.NoError(tb, bAgent.OnConnectionStateChange(bNotifier))
+	tb.Cleanup(func() {
+		require.NoError(tb, bAgent.Close())
 	})
 
-	aConn, bConn := connect(t, aAgent, bAgent)
+	aConn, bConn := connect(tb, aAgent, bAgent)
 
 	// Ensure pair selected
 	// Note: this assumes ConnectionStateConnected is thrown after selecting the final pair
@@ -664,4 +664,72 @@ func TestConn_WriteToPair_Success(t *testing.T) {
 	n, err = cb.Read(buf)
 	require.NoError(t, err)
 	require.Equal(t, testData, buf[:n])
+}
+
+type discardPacketConn struct {
+	deadlinePacketConn
+}
+
+func (*discardPacketConn) WriteTo(b []byte, _ net.Addr) (int, error) {
+	return len(b), nil
+}
+
+// TestConnWriteDoesNotAllocateAbovePacketConn pins Write's fast path at zero
+// heap allocations per packet, from the selected pair down to the candidate's
+// net.PacketConn. The discarding conn excludes the socket write itself.
+func TestConnWriteDoesNotAllocateAbovePacketConn(t *testing.T) {
+	agent, err := NewAgent(&AgentConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, agent.Close())
+	})
+
+	newCandidate := func(port int) *CandidateHost {
+		candidate, err := NewCandidateHost(&CandidateHostConfig{
+			Network:   "udp",
+			Address:   "192.0.2.1",
+			Port:      port,
+			Component: ComponentRTP,
+		})
+		require.NoError(t, err)
+
+		return candidate
+	}
+	local, remote := newCandidate(19000), newCandidate(19001)
+	local.conn = &discardPacketConn{}
+
+	agent.selectedPair.Store(newCandidatePair(local, remote, false))
+
+	conn := &Conn{agent: agent}
+	packet := make([]byte, 1200)
+
+	var writeErr error
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := conn.Write(packet); err != nil {
+			writeErr = err
+		}
+	})
+
+	require.NoError(t, writeErr)
+	require.Zero(t, allocs)
+	require.Positive(t, conn.BytesSent())
+}
+
+func BenchmarkConnWriteRead(b *testing.B) {
+	ca, cb := pipe(b, nil)
+
+	// Note: this loop needs to keep the writes and reads synchronous to keep
+	// the allocation benchmark deterministic. Otherwise, if reads fall behind
+	// writes and packets get dropped, the allocations could get underreported.
+	packet := make([]byte, 1200)
+	readBuf := make([]byte, 2000)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := ca.Write(packet); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := cb.Read(readBuf); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
Remove two per-packet write allocations and one per-packet read allocation:
 - Avoid boxing `time.Time` for last packet sent/received
 - Avoid heap allocating `pair` for a closure declared inside a fallback path

The pattern established by #851 is used to maintain monotonic time while avoiding boxing `time.Time`. See also #690, #697, and #699 for more history on this pattern.

A test is added to pin allocations to zero for the write path, at least outside of `net.PacketConn`. The full write path still does allocate inside of `(net.PacketConn).WriteTo`. `net.UDPConn` has `WriteToUDPAddrPort` which doesn't allocate, but supporting that is a larger change that I plan on chipping away at later. In the meantime, the test uses a mock `PacketConn` so that it can verify that everything else is zero alloc.

The closure-related heap allocation took me a while to hunt down and (to me) is very non-obvious, so I put an overly-large comment explaining the oddity. That plus the test verifying zero allocations is hopefully enough to prevent future developers altering that code from introducing an allocation regression.

The benchmark tests the full end-to-end path with a real connection, and demonstrates a reduction from 5 allocs/op to 2 allocs/op for the write and paired read. The remaining 2 allocs are both in PacketConn, and the fix for both would be to use the `netip.AddrPort` variant.

|  | wall time | bytes | allocs |
|---|---|---|---|
| main | 15694 ns/op | 108 B/op | 5 allocs/op |
| this PR | 15798 ns/op | 52 B/op | 2 allocs/op |
