### PR TITLE
Reduce allocations by using netip.AddrPort

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -165,6 +165,11 @@ func addrEqual(a, b net.Addr) bool {
 	return aType == bType && aIP.Compare(bIP) == 0 && aPort == bPort
 }
 
+// addrPortEqual compares IP and port using the same normalization as addrEqual.
+func addrPortEqual(a, b netip.AddrPort) bool {
+	return a.IsValid() && b.IsValid() && canonicalAddrPort(a) == canonicalAddrPort(b)
+}
+
 // canonicalAddr maps an address to a single representation for use as a map key
 // or in equality comparisons: IPv4-in-IPv6 is unmapped to IPv4, and a zone is
 // kept only where it identifies an interface (link-local IPv6).
@@ -187,18 +192,16 @@ func canonicalAddrPort(ap netip.AddrPort) netip.AddrPort {
 // AddrPort is  an IP and a port number.
 type AddrPort [18]byte
 
-func toAddrPort(addr net.Addr) AddrPort {
+func toAddrPortKey(addr netip.AddrPort) AddrPort {
 	var ap AddrPort
-	switch addr := addr.(type) {
-	case *net.UDPAddr:
-		copy(ap[:16], addr.IP.To16())
-		ap[16] = uint8(addr.Port >> 8) //nolint:gosec // G115  false positive
-		ap[17] = uint8(addr.Port)      //nolint:gosec // G115  false positive
-	case *net.TCPAddr:
-		copy(ap[:16], addr.IP.To16())
-		ap[16] = uint8(addr.Port >> 8) //nolint:gosec // G115 false positive
-		ap[17] = uint8(addr.Port)      //nolint:gosec // G115 false positive
+	if !addr.IsValid() {
+		return ap
 	}
+
+	addr16 := addr.Addr().As16()
+	copy(ap[:16], addr16[:])
+	ap[16] = uint8(addr.Port() >> 8)
+	ap[17] = uint8(addr.Port() & 0xFF)
 
 	return ap
 }

--- a/addr.go
+++ b/addr.go
@@ -151,6 +151,47 @@ func portFitsInUint16(port int) bool {
 	return port >= 0 && port <= 0xFFFF
 }
 
+// AddrPortReaderWriter is an optional net.PacketConn capability that avoids
+// allocating net.Addr values. Its methods must have the same packet-oriented
+// semantics as net.PacketConn.ReadFrom and net.PacketConn.WriteTo, except that
+// addresses are represented by netip.AddrPort. Custom UDP and framed TCP
+// connections may implement it to opt in to the allocation-free path.
+type AddrPortReaderWriter interface {
+	ReadFromAddrPort(b []byte) (int, netip.AddrPort, error)
+	WriteToAddrPort(b []byte, addr netip.AddrPort) (int, error)
+}
+
+// udpAddrPortReaderWriter adapts the allocation-free methods provided by a
+// raw *net.UDPConn to the transport-neutral AddrPortReaderWriter interface.
+type udpAddrPortReaderWriter struct {
+	conn *net.UDPConn
+}
+
+func (c *udpAddrPortReaderWriter) ReadFromAddrPort(b []byte) (int, netip.AddrPort, error) {
+	return c.conn.ReadFromUDPAddrPort(b)
+}
+
+func (c *udpAddrPortReaderWriter) WriteToAddrPort(b []byte, addr netip.AddrPort) (int, error) {
+	return c.conn.WriteToUDPAddrPort(b, addr)
+}
+
+// asAddrPortReaderWriter checks whether conn implements the
+// AddrPortReaderWriter interface and, if so, returns a reference to
+// the AddrPort-capable connection. *net.UDPConn is automatically adapted
+// to AddrPortReaderWriter. If conn does not support AddrPort
+// reads and writes, nil is returned.
+func asAddrPortReaderWriter(conn net.PacketConn) AddrPortReaderWriter {
+	// Match only the concrete type so wrappers embedding *net.UDPConn do not
+	// accidentally bypass their ReadFrom and WriteTo implementations.
+	if udpConn, ok := conn.(*net.UDPConn); ok {
+		return &udpAddrPortReaderWriter{conn: udpConn}
+	}
+
+	addrPortConn, _ := conn.(AddrPortReaderWriter)
+
+	return addrPortConn
+}
+
 func addrEqual(a, b net.Addr) bool {
 	aIP, aPort, aType, aErr := parseAddr(a)
 	if aErr != nil {

--- a/addr.go
+++ b/addr.go
@@ -9,11 +9,17 @@ import (
 	"net/netip"
 )
 
+// isIPv6LinkLocal reports whether addr needs a zone to identify the interface
+// it belongs to.
+func isIPv6LinkLocal(addr netip.Addr) bool {
+	return addr.Is6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast())
+}
+
 func addrWithOptionalZone(addr netip.Addr, zone string) netip.Addr {
 	if zone == "" {
 		return addr
 	}
-	if addr.Is6() && (addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()) {
+	if isIPv6LinkLocal(addr) {
 		return addr.WithZone(zone)
 	}
 
@@ -110,6 +116,41 @@ func createAddr(network NetworkType, ip netip.Addr, port int) net.Addr {
 	}
 }
 
+// netAddrToAddrPort converts an address to netip.AddrPort. UDP and TCP
+// addresses use their allocation-free conversions; other address types are
+// parsed from their string representation. Invalid addresses and ports return
+// the zero value.
+func netAddrToAddrPort(addr net.Addr) netip.AddrPort {
+	if addr == nil {
+		return netip.AddrPort{}
+	}
+	switch a := addr.(type) {
+	case *net.UDPAddr:
+		if a == nil || !portFitsInUint16(a.Port) {
+			return netip.AddrPort{}
+		}
+
+		return a.AddrPort()
+	case *net.TCPAddr:
+		if a == nil || !portFitsInUint16(a.Port) {
+			return netip.AddrPort{}
+		}
+
+		return a.AddrPort()
+	default:
+		addrPort, err := netip.ParseAddrPort(addr.String())
+		if err != nil {
+			return netip.AddrPort{}
+		}
+
+		return addrPort
+	}
+}
+
+func portFitsInUint16(port int) bool {
+	return port >= 0 && port <= 0xFFFF
+}
+
 func addrEqual(a, b net.Addr) bool {
 	aIP, aPort, aType, aErr := parseAddr(a)
 	if aErr != nil {
@@ -122,6 +163,25 @@ func addrEqual(a, b net.Addr) bool {
 	}
 
 	return aType == bType && aIP.Compare(bIP) == 0 && aPort == bPort
+}
+
+// canonicalAddr maps an address to a single representation for use as a map key
+// or in equality comparisons: IPv4-in-IPv6 is unmapped to IPv4, and a zone is
+// kept only where it identifies an interface (link-local IPv6).
+func canonicalAddr(addr netip.Addr) netip.Addr {
+	addr = addr.Unmap()
+	if isIPv6LinkLocal(addr) {
+		return addr
+	}
+
+	return addr.WithZone("")
+}
+
+// canonicalAddrPort applies canonicalAddr to the address so that the same
+// transport address produces one key regardless of the IPv4/IPv4-in-IPv6 form
+// it arrives in.
+func canonicalAddrPort(ap netip.AddrPort) netip.AddrPort {
+	return netip.AddrPortFrom(canonicalAddr(ap.Addr()), ap.Port())
 }
 
 // AddrPort is  an IP and a port number.

--- a/addr_test.go
+++ b/addr_test.go
@@ -164,3 +164,25 @@ func TestAddrPortEqual(t *testing.T) {
 		})
 	}
 }
+
+type embeddingUDPConnWrapper struct {
+	*net.UDPConn
+}
+
+func (c *embeddingUDPConnWrapper) ReadFrom(b []byte) (int, net.Addr, error) {
+	return c.UDPConn.ReadFrom(b)
+}
+
+func (c *embeddingUDPConnWrapper) WriteTo(b []byte, addr net.Addr) (int, error) {
+	return c.UDPConn.WriteTo(b, addr)
+}
+
+func TestAsAddrPortReaderWriter(t *testing.T) {
+	udpConn := &net.UDPConn{}
+	require.NotNil(t, asAddrPortReaderWriter(udpConn))
+
+	// Embedding *net.UDPConn promotes its UDP-specific AddrPort methods, but
+	// must not implicitly opt the wrapper in to AddrPortReaderWriter.
+	wrapper := &embeddingUDPConnWrapper{UDPConn: udpConn}
+	require.Nil(t, asAddrPortReaderWriter(wrapper))
+}

--- a/addr_test.go
+++ b/addr_test.go
@@ -130,3 +130,37 @@ func TestAddrEqual_SameTypeIPPort(t *testing.T) {
 
 	require.True(t, addrEqual(a, b))
 }
+
+func TestAddrPortEqual(t *testing.T) {
+	mk := func(addr string, port uint16) netip.AddrPort {
+		return netip.AddrPortFrom(netip.MustParseAddr(addr), port)
+	}
+
+	tests := []struct {
+		name  string
+		a, b  netip.AddrPort
+		equal bool
+	}{
+		// Two zero values must NOT compare equal: a bare `a == b` would report
+		// true here and silently treat unset addresses as matching.
+		{name: "both zero values", a: netip.AddrPort{}, b: netip.AddrPort{}, equal: false},
+		{name: "valid vs zero value", a: mk("1.2.3.4", 5), b: netip.AddrPort{}, equal: false},
+		{name: "identical IPv4", a: mk("1.2.3.4", 5), b: mk("1.2.3.4", 5), equal: true},
+		// IPv4 and its IPv4-in-IPv6 form are the same transport address.
+		{name: "IPv4 vs IPv4-in-IPv6", a: mk("1.2.3.4", 5), b: mk("::ffff:1.2.3.4", 5), equal: true},
+		{name: "different address", a: mk("1.2.3.4", 5), b: mk("1.2.3.5", 5), equal: false},
+		{name: "different port", a: mk("1.2.3.4", 5), b: mk("1.2.3.4", 6), equal: false},
+		{name: "identical IPv6", a: mk("2001:db8::1", 5), b: mk("2001:db8::1", 5), equal: true},
+		// Zones only identify an interface for link-local addresses.
+		{name: "link-local zone is significant", a: mk("fe80::1%eth0", 5), b: mk("fe80::1%eth1", 5), equal: false},
+		{name: "matching link-local zone", a: mk("fe80::1%eth0", 5), b: mk("fe80::1%eth0", 5), equal: true},
+		{name: "non-link-local zone is ignored", a: mk("2001:db8::1%eth0", 5), b: mk("2001:db8::1", 5), equal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.equal, addrPortEqual(tt.a, tt.b))
+			require.Equal(t, tt.equal, addrPortEqual(tt.b, tt.a), "addrPortEqual must be symmetric")
+		})
+	}
+}

--- a/agent.go
+++ b/agent.go
@@ -1554,16 +1554,9 @@ func (a *Agent) deleteAllCandidates() {
 }
 
 func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) Candidate {
-	ip, port, _, err := parseAddr(addr)
-	if err != nil {
-		a.log.Warnf("Failed to parse address: %s; error: %s", addr, err)
-
-		return nil
-	}
-
 	set := a.remoteCandidates[networkType]
 	for _, c := range set {
-		if c.Address() == ip.String() && c.Port() == port {
+		if addrEqual(c.addr(), addr) {
 			return c
 		}
 	}

--- a/agent.go
+++ b/agent.go
@@ -33,7 +33,8 @@ import (
 type bindingRequest struct {
 	timestamp       time.Time
 	transactionID   [stun.TransactionIDSize]byte
-	destination     net.Addr
+	destination     netip.AddrPort
+	networkType     NetworkType // Transport the request was sent over; destination alone omits it.
 	isUseCandidate  bool
 	nominationValue *uint32 // Tracks nomination value for renomination requests
 }
@@ -1553,10 +1554,10 @@ func (a *Agent) deleteAllCandidates() {
 	}
 }
 
-func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) Candidate {
+func (a *Agent) findRemoteCandidate(networkType NetworkType, addr netip.AddrPort) Candidate {
 	set := a.remoteCandidates[networkType]
 	for _, c := range set {
-		if addrEqual(c.addr(), addr) {
+		if addrPortEqual(c.addrPort(), addr) {
 			return c
 		}
 	}
@@ -1578,7 +1579,8 @@ func (a *Agent) sendBindingRequest(msg *stun.Message, local, remote Candidate) {
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
 		timestamp:       time.Now(),
 		transactionID:   msg.TransactionID,
-		destination:     remote.addr(),
+		destination:     remote.addrPort(),
+		networkType:     remote.NetworkType(),
 		isUseCandidate:  msg.Contains(stun.AttrUseCandidate),
 		nominationValue: nominationValue,
 	})
@@ -1694,7 +1696,7 @@ func (a *Agent) handleRoleConflict(msg *stun.Message, local, remote Candidate, r
 }
 
 // handleInbound processes STUN traffic from a remote candidate.
-func (a *Agent) handleInbound(msg *stun.Message, local Candidate, remote net.Addr) {
+func (a *Agent) handleInbound(msg *stun.Message, local Candidate, remote netip.AddrPort) {
 	if msg == nil || local == nil {
 		return
 	}
@@ -1733,7 +1735,7 @@ func canHandleInbound(msg *stun.Message) bool {
 }
 
 func (a *Agent) handleInboundResponse(
-	remoteCandidate, local Candidate, remote net.Addr, msg *stun.Message,
+	remoteCandidate, local Candidate, remote netip.AddrPort, msg *stun.Message,
 ) bool {
 	if err := stun.MessageIntegrity([]byte(a.remotePwd)).Check(msg); err != nil {
 		a.log.Warnf("Discard success response with broken integrity from (%s), %v", remote, err)
@@ -1753,7 +1755,7 @@ func (a *Agent) handleInboundResponse(
 }
 
 func (a *Agent) handleInboundRequest(
-	remoteCandidate, local Candidate, remote net.Addr, msg *stun.Message,
+	remoteCandidate, local Candidate, remote netip.AddrPort, msg *stun.Message,
 ) (remoteCand Candidate, ok bool) {
 	a.log.Tracef(
 		"Inbound STUN (Request) from %s to %s, useCandidate: %v",
@@ -1773,17 +1775,20 @@ func (a *Agent) handleInboundRequest(
 	}
 
 	if remoteCandidate == nil {
-		ip, port, networkType, err := parseAddr(remote)
+		// Use the local candidate's transport to determine the network
+		// type. Peer-reflexive candidates by definition are reached
+		// over the same transport as the local candidate.
+		networkType, err := determineNetworkType(local.NetworkType().NetworkShort(), remote.Addr())
 		if err != nil {
-			a.log.Errorf("Failed to create parse remote net.Addr when creating remote prflx candidate: %s", err)
+			a.log.Errorf("Failed to determine network type for remote prflx candidate: %s", err)
 
 			return nil, false
 		}
 
 		prflxCandidateConfig := CandidatePeerReflexiveConfig{
 			Network:   networkType.String(),
-			Address:   ip.String(),
-			Port:      port,
+			Address:   canonicalAddr(remote.Addr()).String(),
+			Port:      int(remote.Port()),
 			Component: local.Component(),
 			RelAddr:   "",
 			RelPort:   0,
@@ -1827,7 +1832,7 @@ func (a *Agent) handleInboundRequest(
 
 // validateNonSTUNTraffic processes non STUN traffic from a remote candidate,
 // and returns true if it is an actual remote candidate.
-func (a *Agent) validateNonSTUNTraffic(local Candidate, remote net.Addr) (Candidate, bool) {
+func (a *Agent) validateNonSTUNTraffic(local Candidate, remote netip.AddrPort) (Candidate, bool) {
 	var remoteCandidate Candidate
 	if err := a.loop.Run(local.context(), func(context.Context) {
 		remoteCandidate = a.findRemoteCandidate(local.NetworkType(), remote)

--- a/agent_test.go
+++ b/agent_test.go
@@ -25,16 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type BadAddr struct{}
-
-func (ba *BadAddr) Network() string {
-	return "xxx"
-}
-
-func (ba *BadAddr) String() string {
-	return "yyy"
-}
-
 type recordingSelector struct {
 	handledBindingRequest bool
 	handledSuccess        bool
@@ -46,7 +36,7 @@ func (r *recordingSelector) ContactCandidates() {}
 
 func (r *recordingSelector) PingCandidate(Candidate, Candidate) {}
 
-func (r *recordingSelector) HandleSuccessResponse(*stun.Message, Candidate, Candidate, net.Addr) {
+func (r *recordingSelector) HandleSuccessResponse(*stun.Message, Candidate, Candidate, netip.AddrPort) {
 	r.handledSuccess = true
 }
 
@@ -675,7 +665,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			require.NoError(t, err)
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
@@ -750,7 +740,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			require.NoError(t, err)
 
 			// nolint: contextcheck
-			agent.handleInbound(msg, local, &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999})
+			agent.handleInbound(msg, local, netip.MustParseAddrPort("172.17.0.3:999"))
 
 			// The inbound traffic must match the resolved mDNS candidate by
 			// transport address rather than surfacing a duplicate prflx
@@ -786,7 +776,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			require.NoError(t, err)
 			local.conn = &fakenet.MockPacketConn{}
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 			remotePriority := uint32(123456)
 
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
@@ -832,7 +822,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			agent.localCandidates[local.NetworkType()] = []Candidate{local}
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
 				UseCandidate(),
@@ -889,7 +879,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			require.Equal(t, prflx, pair.Remote)
 			require.Same(t, updatedPair, agent.getSelectedPair())
 			require.Same(t, updatedPair, sel.nominatedPair)
-			cached, ok := local.remoteCandidateCaches.Load(toAddrPort(remote))
+			cached, ok := local.remoteCandidateCaches.Load(toAddrPortKey(remote))
 			require.True(t, ok)
 			require.Equal(t, host, cached)
 		}))
@@ -915,7 +905,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			agent.localCandidates[local.NetworkType()] = []Candidate{local}
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
 				UseCandidate(),
@@ -962,7 +952,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			require.Equal(t, srflx, updatedPair.Remote)
 			require.Equal(t, oldPriority, updatedPair.priority())
 			require.Equal(t, prflx, pair.Remote)
-			cached, ok := local.remoteCandidateCaches.Load(toAddrPort(remote))
+			cached, ok := local.remoteCandidateCaches.Load(toAddrPortKey(remote))
 			require.True(t, ok)
 			require.Equal(t, srflx, cached)
 		}))
@@ -988,7 +978,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			agent.localCandidates[local.NetworkType()] = []Candidate{local}
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
 				UseCandidate(),
@@ -1035,7 +1025,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			require.Equal(t, relay, updatedPair.Remote)
 			require.Equal(t, oldPriority, updatedPair.priority())
 			require.Equal(t, prflx, pair.Remote)
-			cached, ok := local.remoteCandidateCaches.Load(toAddrPort(remote))
+			cached, ok := local.remoteCandidateCaches.Load(toAddrPortKey(remote))
 			require.True(t, ok)
 			require.Equal(t, relay, cached)
 		}))
@@ -1134,10 +1124,8 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local, err := NewCandidateHost(&hostConfig)
 			require.NoError(t, err)
 
-			remote := &BadAddr{}
-
 			// nolint: contextcheck
-			agent.handleInbound(nil, local, remote)
+			agent.handleInbound(nil, local, netip.AddrPort{})
 			require.Len(t, agent.remoteCandidates, 0)
 		}))
 	})
@@ -1164,7 +1152,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			require.NoError(t, err)
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 
 			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
 				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
@@ -1195,7 +1183,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			tID := [stun.TransactionIDSize]byte{}
 			copy(tID[:], "ABC")
 			agent.pendingBindingRequests = []bindingRequest{
-				{time.Now(), tID, &net.UDPAddr{}, false, nil},
+				{timestamp: time.Now(), transactionID: tID, destination: netip.AddrPort{}},
 			}
 
 			hostConfig := CandidateHostConfig{
@@ -1208,7 +1196,7 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 			local.conn = &fakenet.MockPacketConn{}
 			require.NoError(t, err)
 
-			remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+			remote := netip.MustParseAddrPort("172.17.0.3:999")
 			msg, err := stun.Build(stun.BindingSuccess, stun.NewTransactionIDSetter(tID),
 				stun.NewShortTermIntegrity(agent.remotePwd),
 				stun.Fingerprint,
@@ -1455,7 +1443,7 @@ func TestInboundValidity(t *testing.T) { //nolint:cyclop
 		return msg
 	}
 
-	remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+	remote := netip.MustParseAddrPort("172.17.0.3:999")
 	hostConfig := CandidateHostConfig{
 		Network:   "udp",
 		Address:   "192.168.0.2",
@@ -1557,7 +1545,7 @@ func TestInboundValidity(t *testing.T) { //nolint:cyclop
 		local.conn = &fakenet.MockPacketConn{}
 		require.NoError(t, err)
 
-		remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+		remote := netip.MustParseAddrPort("172.17.0.3:999")
 		tID := [stun.TransactionIDSize]byte{}
 		copy(tID[:], "ABC")
 		msg, err := stun.Build(stun.BindingSuccess, stun.NewTransactionIDSetter(tID),
@@ -1602,7 +1590,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		}
 		remoteCandidate, err := NewCandidateHost(remoteConfig)
 		require.NoError(t, err)
-		remoteAddr := &net.UDPAddr{IP: net.ParseIP(remoteCandidate.Address()), Port: remoteCandidate.Port()}
+		remoteAddr := remoteCandidate.addrPort()
 
 		require.NoError(t, agent.loop.Run(agent.loop, func(_ context.Context) {
 			agent.addRemoteCandidate(remoteCandidate) //nolint:contextcheck
@@ -1625,7 +1613,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 
 		local := newHostLocal(t)
 		local.conn = &fakenet.MockPacketConn{}
-		remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+		remote := netip.MustParseAddrPort("172.17.0.3:999")
 		selector := &recordingSelector{}
 		agent.selector = selector
 		agent.isControlling.Store(true)
@@ -1658,7 +1646,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		agent.handleInbound(msg, local, &BadAddr{})
+		agent.handleInbound(msg, local, netip.AddrPort{})
 		require.Len(t, agent.remoteCandidates, 0)
 	})
 
@@ -1675,7 +1663,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		remote := &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999}
+		remote := netip.MustParseAddrPort("172.17.0.3:999")
 		agent.handleInbound(msg, nil, remote)
 		require.Len(t, agent.remoteCandidates, 0)
 	})
@@ -1695,7 +1683,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		}
 		remoteCandidate, err := NewCandidateHost(remoteConfig)
 		require.NoError(t, err)
-		remoteAddr := &net.UDPAddr{IP: net.ParseIP(remoteCandidate.Address()), Port: remoteCandidate.Port()}
+		remoteAddr := remoteCandidate.addrPort()
 		transactionID := stun.NewTransactionID()
 		remotePwd := "remotekey"
 
@@ -1708,6 +1696,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 				timestamp:     time.Now(),
 				transactionID: transactionID,
 				destination:   remoteAddr,
+				networkType:   remoteCandidate.NetworkType(),
 			}}
 			agent.remotePwd = remotePwd
 		}))
@@ -1751,7 +1740,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		remote := &net.UDPAddr{IP: net.IPv4(172, 17, 0, 44), Port: 9999}
+		remote := netip.AddrPortFrom(netip.AddrFrom4([4]byte{172, 17, 0, 44}), 9999)
 		agent.handleInbound(msg, local, remote)
 
 		require.False(t, selector.handledBindingRequest)
@@ -1787,7 +1776,7 @@ func TestHandleInboundAdditionalCases(t *testing.T) {
 		require.NoError(t, err)
 
 		remote := &net.UDPAddr{IP: net.IPv4(172, 17, 0, 45), Port: 9999}
-		agent.handleInbound(msg, local, remote)
+		agent.handleInbound(msg, local, remote.AddrPort())
 
 		require.Equal(t, 1, filterCalls)
 		require.False(t, selector.handledBindingRequest)

--- a/agent_test.go
+++ b/agent_test.go
@@ -705,6 +705,67 @@ func TestHandlePeerReflexive(t *testing.T) { //nolint:cyclop,maintidx
 		}))
 	})
 
+	t.Run("Resolved mDNS candidate is matched instead of creating prflx", func(t *testing.T) {
+		agent, err := NewAgent(&AgentConfig{})
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, agent.Close())
+		}()
+
+		require.NoError(t, agent.loop.Run(agent.loop, func(_ context.Context) {
+			sel := &controllingSelector{agent: agent, log: agent.log}
+			agent.selector = sel
+
+			local, err := NewCandidateHost(&CandidateHostConfig{
+				Network:   "udp",
+				Address:   "192.168.0.2",
+				Port:      777,
+				Component: 1,
+			})
+			require.NoError(t, err)
+			local.conn = &fakenet.MockPacketConn{}
+
+			remoteMDNS, err := NewCandidateHost(&CandidateHostConfig{
+				Network:   "udp",
+				Address:   "1f4712db-ea17-4bcf-a596-105139dfd8bf.local",
+				Port:      999,
+				Component: 1,
+			})
+			require.NoError(t, err)
+			// Resolve and register the candidate with the same calls
+			// resolveAndAddMulticastCandidate makes after its mDNS query
+			// returns; only the query itself is skipped here.
+			require.NoError(t, remoteMDNS.setIPAddr(netip.MustParseAddr("172.17.0.3")))
+			// nolint: contextcheck
+			require.True(t, agent.addRemoteCandidate(remoteMDNS))
+
+			msg, err := stun.Build(stun.BindingRequest, stun.TransactionID,
+				stun.NewUsername(agent.localUfrag+":"+agent.remoteUfrag),
+				UseCandidate(),
+				AttrControlling(agent.tieBreaker),
+				PriorityAttr(local.Priority()),
+				stun.NewShortTermIntegrity(agent.localPwd),
+				stun.Fingerprint,
+			)
+			require.NoError(t, err)
+
+			// nolint: contextcheck
+			agent.handleInbound(msg, local, &net.UDPAddr{IP: net.ParseIP("172.17.0.3"), Port: 999})
+
+			// The inbound traffic must match the resolved mDNS candidate by
+			// transport address rather than surfacing a duplicate prflx
+			// candidate for the same remote.
+			// See:
+			//  - https://datatracker.ietf.org/doc/html/rfc8445#section-7.3.1.3
+			//  - https://datatracker.ietf.org/doc/html/rfc8445#section-4
+			//  - (expired draft) https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-mdns-ice-candidates-03#section-3.2.1
+			set := agent.remoteCandidates[local.NetworkType()]
+			require.Len(t, set, 1)
+			require.Same(t, Candidate(remoteMDNS), set[0])
+			require.Equal(t, "1f4712db-ea17-4bcf-a596-105139dfd8bf.local", set[0].Address())
+		}))
+	})
+
 	t.Run("prflx candidate priority comes from inbound PRIORITY", func(t *testing.T) {
 		agent, err := NewAgent(&AgentConfig{})
 		require.NoError(t, err)

--- a/candidate.go
+++ b/candidate.go
@@ -6,6 +6,7 @@ package ice
 import (
 	"context"
 	"net"
+	"net/netip"
 	"time"
 )
 
@@ -87,6 +88,7 @@ type Candidate interface {
 	transportAddressEqual(other Candidate) bool
 
 	addr() net.Addr
+	addrPort() netip.AddrPort
 	filterForLocationTracking() bool
 	agent() *Agent
 	context() context.Context

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -38,6 +38,9 @@ type candidateBase struct {
 	lastReceived atomic.Int64
 	conn         net.PacketConn
 
+	// addrPortConn is non-nil when conn opts in to AddrPortReaderWriter.
+	addrPortConn AddrPortReaderWriter
+
 	currAgent *Agent
 	closeCh   chan struct{}
 	closedCh  chan struct{}
@@ -248,6 +251,7 @@ func (c *candidateBase) start(a *Agent, conn net.PacketConn, initializedCh <-cha
 	}
 	c.currAgent = a
 	c.conn = conn
+	c.addrPortConn = asAddrPortReaderWriter(conn)
 	c.closeCh = make(chan struct{})
 	c.closedCh = make(chan struct{})
 	a.registerStartedCandidate(c)
@@ -282,7 +286,18 @@ func (c *candidateBase) recvLoop(initializedCh <-chan struct{}) {
 	buf := *bufPtr
 
 	for {
-		n, netAddr, err := c.conn.ReadFrom(buf)
+		var n int
+		var srcAddr netip.AddrPort
+		var err error
+		if c.addrPortConn != nil {
+			n, srcAddr, err = c.addrPortConn.ReadFromAddrPort(buf)
+		} else {
+			var netAddr net.Addr
+			n, netAddr, err = c.conn.ReadFrom(buf)
+			if err == nil {
+				srcAddr = netAddrToAddrPort(netAddr)
+			}
+		}
 		if err != nil {
 			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
 				agent.log.Warnf("Failed to read from candidate %s: %v", c, err)
@@ -290,7 +305,6 @@ func (c *candidateBase) recvLoop(initializedCh <-chan struct{}) {
 
 			return
 		}
-		srcAddr := netAddrToAddrPort(netAddr)
 
 		c.handleInboundPacket(buf[:n], srcAddr)
 	}
@@ -333,25 +347,7 @@ func (c *candidateBase) handleInboundPacket(buf []byte, srcAddr netip.AddrPort) 
 	agent := c.agent()
 
 	if stun.IsMessage(buf) {
-		msg := &stun.Message{
-			Raw: make([]byte, len(buf)),
-		}
-
-		// Explicitly copy raw buffer so Message can own the memory.
-		copy(msg.Raw, buf)
-
-		if err := msg.Decode(); err != nil {
-			agent.log.Warnf("Failed to handle decode ICE from %s to %s: %v", c.addr(), srcAddr, err)
-
-			return
-		}
-
-		if err := agent.loop.Run(c, func(_ context.Context) {
-			// nolint: contextcheck
-			agent.handleInbound(msg, c, srcAddr)
-		}); err != nil {
-			agent.log.Warnf("Failed to handle message: %v", err)
-		}
+		c.handleInboundSTUNMessage(buf, srcAddr)
 
 		return
 	}
@@ -379,6 +375,34 @@ func (c *candidateBase) handleInboundPacket(buf []byte, srcAddr netip.AddrPort) 
 		if sp := agent.getSelectedPair(); sp != nil {
 			sp.UpdatePacketReceived(n)
 		}
+	}
+}
+
+// handleInboundSTUNMessage decodes buf and hands it to the agent loop.
+// Note: keep this out of handleInboundPacket. The closure captures srcAddr,
+// which would otherwise be heap-allocated on every inbound packet instead of
+// only for STUN messages.
+func (c *candidateBase) handleInboundSTUNMessage(buf []byte, srcAddr netip.AddrPort) {
+	agent := c.agent()
+
+	msg := &stun.Message{
+		Raw: make([]byte, len(buf)),
+	}
+
+	// Explicitly copy raw buffer so Message can own the memory.
+	copy(msg.Raw, buf)
+
+	if err := msg.Decode(); err != nil {
+		agent.log.Warnf("Failed to handle decode ICE from %s to %s: %v", c.addr(), srcAddr, err)
+
+		return
+	}
+
+	if err := agent.loop.Run(c, func(_ context.Context) {
+		// nolint: contextcheck
+		agent.handleInbound(msg, c, srcAddr)
+	}); err != nil {
+		agent.log.Warnf("Failed to handle message: %v", err)
 	}
 }
 
@@ -432,7 +456,13 @@ func (c *candidateBase) abortIO() error {
 }
 
 func (c *candidateBase) writeTo(raw []byte, dst Candidate) (int, error) {
-	n, err := c.conn.WriteTo(raw, dst.addr())
+	var n int
+	var err error
+	if ap := dst.addrPort(); c.addrPortConn != nil && ap.IsValid() {
+		n, err = c.addrPortConn.WriteToAddrPort(raw, ap)
+	} else {
+		n, err = c.conn.WriteTo(raw, dst.addr())
+	}
 	if err != nil {
 		// If the connection is closed, we should return the error
 		if errors.Is(err, io.ErrClosedPipe) {

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"io"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,7 +31,8 @@ type candidateBase struct {
 	relatedAddress *CandidateRelatedAddress
 	tcpType        TCPType
 
-	resolvedAddr net.Addr
+	resolvedAddr     net.Addr
+	resolvedAddrPort netip.AddrPort
 
 	lastSent     atomic.Int64
 	lastReceived atomic.Int64
@@ -280,7 +282,7 @@ func (c *candidateBase) recvLoop(initializedCh <-chan struct{}) {
 	buf := *bufPtr
 
 	for {
-		n, srcAddr, err := c.conn.ReadFrom(buf)
+		n, netAddr, err := c.conn.ReadFrom(buf)
 		if err != nil {
 			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
 				agent.log.Warnf("Failed to read from candidate %s: %v", c, err)
@@ -288,13 +290,14 @@ func (c *candidateBase) recvLoop(initializedCh <-chan struct{}) {
 
 			return
 		}
+		srcAddr := netAddrToAddrPort(netAddr)
 
 		c.handleInboundPacket(buf[:n], srcAddr)
 	}
 }
 
-func (c *candidateBase) validateSTUNTrafficCache(addr net.Addr) bool {
-	if candidate, ok := c.remoteCandidateCaches.Load(toAddrPort(addr)); ok {
+func (c *candidateBase) validateSTUNTrafficCache(addr netip.AddrPort) bool {
+	if candidate, ok := c.remoteCandidateCaches.Load(toAddrPortKey(addr)); ok {
 		remoteCandidate, ok := candidate.(Candidate)
 		if !ok {
 			return false
@@ -308,11 +311,11 @@ func (c *candidateBase) validateSTUNTrafficCache(addr net.Addr) bool {
 	return false
 }
 
-func (c *candidateBase) addRemoteCandidateCache(candidate Candidate, srcAddr net.Addr) {
+func (c *candidateBase) addRemoteCandidateCache(candidate Candidate, srcAddr netip.AddrPort) {
 	if c.validateSTUNTrafficCache(srcAddr) {
 		return
 	}
-	c.remoteCandidateCaches.Store(toAddrPort(srcAddr), candidate)
+	c.remoteCandidateCaches.Store(toAddrPortKey(srcAddr), candidate)
 }
 
 func (c *candidateBase) replaceRemoteCandidateCacheValues(oldRemote, newRemote Candidate) {
@@ -326,7 +329,7 @@ func (c *candidateBase) replaceRemoteCandidateCacheValues(oldRemote, newRemote C
 	})
 }
 
-func (c *candidateBase) handleInboundPacket(buf []byte, srcAddr net.Addr) {
+func (c *candidateBase) handleInboundPacket(buf []byte, srcAddr netip.AddrPort) {
 	agent := c.agent()
 
 	if stun.IsMessage(buf) {
@@ -562,6 +565,15 @@ func (c *candidateBase) seen(outbound bool) {
 
 func (c *candidateBase) addr() net.Addr {
 	return c.resolvedAddr
+}
+
+func (c *candidateBase) addrPort() netip.AddrPort {
+	return c.resolvedAddrPort
+}
+
+func (c *candidateBase) setResolvedAddr(addr net.Addr) {
+	c.resolvedAddr = addr
+	c.resolvedAddrPort = netAddrToAddrPort(addr)
 }
 
 func (c *candidateBase) filterForLocationTracking() bool {

--- a/candidate_host.go
+++ b/candidate_host.go
@@ -75,7 +75,7 @@ func (c *CandidateHost) setIPAddr(addr netip.Addr) error {
 	}
 
 	c.candidateBase.networkType = networkType
-	c.candidateBase.resolvedAddr = createAddr(networkType, addr, c.port)
+	c.candidateBase.setResolvedAddr(createAddr(networkType, addr, c.port))
 
 	return nil
 }

--- a/candidate_peer_reflexive.go
+++ b/candidate_peer_reflexive.go
@@ -45,14 +45,13 @@ func NewCandidatePeerReflexive(config *CandidatePeerReflexiveConfig) (*Candidate
 		candidateID = globalCandidateIDGenerator.Generate()
 	}
 
-	return &CandidatePeerReflexive{
+	candidate := &CandidatePeerReflexive{
 		candidateBase: candidateBase{
 			id:                 candidateID,
 			networkType:        networkType,
 			candidateType:      CandidateTypePeerReflexive,
 			address:            config.Address,
 			port:               config.Port,
-			resolvedAddr:       createAddr(networkType, ipAddr, config.Port),
 			component:          config.Component,
 			foundationOverride: config.Foundation,
 			priorityOverride:   config.Priority,
@@ -61,5 +60,8 @@ func NewCandidatePeerReflexive(config *CandidatePeerReflexiveConfig) (*Candidate
 				Port:    config.RelPort,
 			},
 		},
-	}, nil
+	}
+	candidate.setResolvedAddr(createAddr(networkType, ipAddr, config.Port))
+
+	return candidate, nil
 }

--- a/candidate_relay.go
+++ b/candidate_relay.go
@@ -59,18 +59,13 @@ func NewCandidateRelay(config *CandidateRelayConfig) (*CandidateRelay, error) {
 		return nil, err
 	}
 
-	return &CandidateRelay{
+	candidate := &CandidateRelay{
 		candidateBase: candidateBase{
-			id:            candidateID,
-			networkType:   networkType,
-			candidateType: CandidateTypeRelay,
-			address:       config.Address,
-			port:          config.Port,
-			resolvedAddr: &net.UDPAddr{
-				IP:   ipAddr.AsSlice(),
-				Port: config.Port,
-				Zone: ipAddr.Zone(),
-			},
+			id:                 candidateID,
+			networkType:        networkType,
+			candidateType:      CandidateTypeRelay,
+			address:            config.Address,
+			port:               config.Port,
 			component:          config.Component,
 			foundationOverride: config.Foundation,
 			priorityOverride:   config.Priority,
@@ -82,7 +77,14 @@ func NewCandidateRelay(config *CandidateRelayConfig) (*CandidateRelay, error) {
 		},
 		relayProtocol: config.RelayProtocol,
 		onClose:       config.OnClose,
-	}, nil
+	}
+	candidate.setResolvedAddr(&net.UDPAddr{
+		IP:   ipAddr.AsSlice(),
+		Port: config.Port,
+		Zone: ipAddr.Zone(),
+	})
+
+	return candidate, nil
 }
 
 // RelayProtocol returns the protocol used between the endpoint and the relay server.

--- a/candidate_server_reflexive.go
+++ b/candidate_server_reflexive.go
@@ -43,18 +43,13 @@ func NewCandidateServerReflexive(config *CandidateServerReflexiveConfig) (*Candi
 		candidateID = globalCandidateIDGenerator.Generate()
 	}
 
-	return &CandidateServerReflexive{
+	candidate := &CandidateServerReflexive{
 		candidateBase: candidateBase{
-			id:            candidateID,
-			networkType:   networkType,
-			candidateType: CandidateTypeServerReflexive,
-			address:       config.Address,
-			port:          config.Port,
-			resolvedAddr: &net.UDPAddr{
-				IP:   ipAddr.AsSlice(),
-				Port: config.Port,
-				Zone: ipAddr.Zone(),
-			},
+			id:                 candidateID,
+			networkType:        networkType,
+			candidateType:      CandidateTypeServerReflexive,
+			address:            config.Address,
+			port:               config.Port,
 			component:          config.Component,
 			foundationOverride: config.Foundation,
 			priorityOverride:   config.Priority,
@@ -63,5 +58,12 @@ func NewCandidateServerReflexive(config *CandidateServerReflexiveConfig) (*Candi
 				Port:    config.RelPort,
 			},
 		},
-	}, nil
+	}
+	candidate.setResolvedAddr(&net.UDPAddr{
+		IP:   ipAddr.AsSlice(),
+		Port: config.Port,
+		Zone: ipAddr.Zone(),
+	})
+
+	return candidate, nil
 }

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -625,9 +625,8 @@ func TestCandidateWriteTo(t *testing.T) {
 		},
 	}
 
-	c2 := &candidateBase{
-		resolvedAddr: listener.Addr(),
-	}
+	c2 := &candidateBase{}
+	c2.setResolvedAddr(listener.Addr())
 
 	_, err = c1.writeTo([]byte("test"), c2)
 	require.NoError(t, err, "writing to open conn")

--- a/connectivity_vnet_test.go
+++ b/connectivity_vnet_test.go
@@ -319,11 +319,11 @@ func pipeWithVNetUsingOptions(t *testing.T, opts0, opts1 []AgentOption) (*Conn, 
 	return aConn, bConn
 }
 
-func closePipe(t *testing.T, ca *Conn, cb *Conn) {
-	t.Helper()
+func closePipe(tb testing.TB, ca *Conn, cb *Conn) {
+	tb.Helper()
 
-	require.NoError(t, ca.Close())
-	require.NoError(t, cb.Close())
+	require.NoError(tb, ca.Close())
+	require.NoError(tb, cb.Close())
 }
 
 func TestConnectivityVNet(t *testing.T) {

--- a/gather_test.go
+++ b/gather_test.go
@@ -3763,9 +3763,9 @@ func TestGatherAddressRewriteAppendHostMultiUDPMux(t *testing.T) { //nolint:cycl
 	for _, port := range expectedPorts {
 		group := byPort[port]
 		require.Len(t, group, 2, "expected 2 alias candidates for port %d", port)
-		wrapA, ok := group[0].conn.(*sharedPacketConn)
+		wrapA, ok := group[0].conn.(*sharedAddrPortConn)
 		require.True(t, ok)
-		wrapB, ok := group[1].conn.(*sharedPacketConn)
+		wrapB, ok := group[1].conn.(*sharedAddrPortConn)
 		require.True(t, ok)
 		require.Same(t, wrapA.underlying, wrapB.underlying,
 			"aliases on the same mux port must share one udpMuxedConn")

--- a/selection.go
+++ b/selection.go
@@ -4,7 +4,7 @@
 package ice
 
 import (
-	"net"
+	"net/netip"
 	"time"
 
 	"github.com/pion/logging"
@@ -15,8 +15,14 @@ type pairCandidateSelector interface {
 	Start()
 	ContactCandidates()
 	PingCandidate(local, remote Candidate)
-	HandleSuccessResponse(m *stun.Message, local, remote Candidate, remoteAddr net.Addr)
+	HandleSuccessResponse(m *stun.Message, local, remote Candidate, remoteAddr netip.AddrPort)
 	HandleBindingRequest(m *stun.Message, local, remote Candidate)
+}
+
+// responseSymmetric implements the transport-address check in RFC 8445 §7.2.5.2.1.
+func responseSymmetric(pendingRequest *bindingRequest, local Candidate, remoteAddr netip.AddrPort) bool {
+	return pendingRequest.networkType == local.NetworkType() &&
+		addrPortEqual(pendingRequest.destination, remoteAddr)
 }
 
 type controllingSelector struct {
@@ -156,7 +162,9 @@ func (a *Agent) handleBindingRequestWithCustomHandler(
 	}
 }
 
-func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remote Candidate, remoteAddr net.Addr) {
+func (s *controllingSelector) HandleSuccessResponse(
+	m *stun.Message, local, remote Candidate, remoteAddr netip.AddrPort,
+) {
 	ok, pendingRequest, rtt := s.agent.handleInboundBindingSuccess(m.TransactionID)
 	if !ok {
 		s.log.Warnf("Discard success response from (%s), unknown TransactionID 0x%x", remote, m.TransactionID)
@@ -164,14 +172,12 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 		return
 	}
 
-	transactionAddr := pendingRequest.destination
-
 	// Assert that NAT is not symmetric
 	// https://tools.ietf.org/html/rfc8445#section-7.2.5.2.1
-	if !addrEqual(transactionAddr, remoteAddr) {
+	if !responseSymmetric(pendingRequest, local, remoteAddr) {
 		s.log.Debugf(
 			"Discard message: transaction source and destination does not match expected(%s), actual(%s)",
-			transactionAddr,
+			pendingRequest.destination,
 			remote,
 		)
 
@@ -383,7 +389,9 @@ func (s *controlledSelector) PingCandidate(local, remote Candidate) {
 	s.agent.sendBindingRequest(msg, local, remote)
 }
 
-func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remote Candidate, remoteAddr net.Addr) {
+func (s *controlledSelector) HandleSuccessResponse(
+	m *stun.Message, local, remote Candidate, remoteAddr netip.AddrPort,
+) {
 	//nolint:godox
 	// TODO according to the standard we should specifically answer a failed nomination:
 	// https://tools.ietf.org/html/rfc8445#section-7.3.1.5
@@ -399,14 +407,12 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 		return
 	}
 
-	transactionAddr := pendingRequest.destination
-
 	// Assert that NAT is not symmetric
 	// https://tools.ietf.org/html/rfc8445#section-7.2.5.2.1
-	if !addrEqual(transactionAddr, remoteAddr) {
+	if !responseSymmetric(pendingRequest, local, remoteAddr) {
 		s.log.Debugf(
 			"Discard message: transaction source and destination does not match expected(%s), actual(%s)",
-			transactionAddr,
+			pendingRequest.destination,
 			remote,
 		)
 

--- a/selection_test.go
+++ b/selection_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -371,9 +372,172 @@ func TestControlledSelector_HandleSuccessResponse_UnknownTxID(t *testing.T) {
 	var m stun.Message
 	copy(m.TransactionID[:], []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
 
-	sel.HandleSuccessResponse(&m, local, remote, nil)
+	sel.HandleSuccessResponse(&m, local, remote, netip.AddrPort{})
 
 	require.True(t, logger.warned, "expected Warnf to be called for unknown TransactionID (hitting !ok branch)")
+}
+
+// TestResponseSymmetric covers the RFC 8445 §7.2.5.2.1 transport-address check.
+// A success response is symmetric only when it arrives on the same transport the
+// request was sent over (networkType) and from the same address it was sent to.
+func TestResponseSymmetric(t *testing.T) {
+	local := func(nt NetworkType) Candidate {
+		c := newPingNoIOCand()
+		c.candidateBase.networkType = nt
+
+		return c
+	}
+	mk := func(addr string, port uint16) netip.AddrPort {
+		return netip.AddrPortFrom(netip.MustParseAddr(addr), port)
+	}
+
+	tests := []struct {
+		name       string
+		reqNetwork NetworkType
+		localNT    NetworkType
+		dest       netip.AddrPort
+		remoteAddr netip.AddrPort
+		want       bool
+	}{
+		{
+			name:       "matching transport and address",
+			reqNetwork: NetworkTypeUDP4, localNT: NetworkTypeUDP4,
+			dest: mk("192.168.1.2", 20000), remoteAddr: mk("192.168.1.2", 20000),
+			want: true,
+		},
+		{
+			// netip.AddrPort carries no transport, so the network-type check is
+			// what rejects a response that arrived on a different transport.
+			name:       "network type mismatch",
+			reqNetwork: NetworkTypeUDP6, localNT: NetworkTypeUDP4,
+			dest: mk("2001:db8::2", 20000), remoteAddr: mk("2001:db8::2", 20000),
+			want: false,
+		},
+		{
+			name:       "source address mismatch",
+			reqNetwork: NetworkTypeUDP4, localNT: NetworkTypeUDP4,
+			dest: mk("192.168.1.2", 20000), remoteAddr: mk("192.168.1.9", 20000),
+			want: false,
+		},
+		{
+			name:       "source port mismatch",
+			reqNetwork: NetworkTypeUDP4, localNT: NetworkTypeUDP4,
+			dest: mk("192.168.1.2", 20000), remoteAddr: mk("192.168.1.2", 20001),
+			want: false,
+		},
+		{
+			name:       "IPv4-in-IPv6 source form still matches",
+			reqNetwork: NetworkTypeUDP4, localNT: NetworkTypeUDP4,
+			dest: mk("192.168.1.2", 20000), remoteAddr: mk("::ffff:192.168.1.2", 20000),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &bindingRequest{destination: tt.dest, networkType: tt.reqNetwork}
+			require.Equal(t, tt.want, responseSymmetric(req, local(tt.localNT), tt.remoteAddr))
+		})
+	}
+}
+
+// TestHandleSuccessResponse_AsymmetricDiscarded verifies that HandleSuccessResponse
+// honors the symmetry check: a success response with a known TransactionID but a
+// mismatched transport (different network type or source address) is discarded and
+// does not mark the pair succeeded.
+func TestHandleSuccessResponse_AsymmetricDiscarded(t *testing.T) {
+	newAgent := func(t *testing.T) (*Agent, *controllingSelector) {
+		t.Helper()
+		agent := bareAgentForPing()
+		agent.log = logging.NewDefaultLoggerFactory().NewLogger("test")
+		agent.remoteUfrag = selectionTestRemoteUfrag
+		agent.localUfrag = selectionTestLocalUfrag
+		agent.remotePwd = selectionTestPassword
+		agent.tieBreaker = 1
+		agent.isControlling.Store(true)
+		agent.onConnected = make(chan struct{})
+		agent.setSelector()
+
+		selector, ok := agent.getSelector().(*controllingSelector)
+		require.True(t, ok, "expected controllingSelector")
+
+		return agent, selector
+	}
+	newCand := func(nt NetworkType, ip string, port int) *pingNoIOCand {
+		c := newPingNoIOCand()
+		c.candidateBase.networkType = nt
+		c.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP(ip), Port: port})
+
+		return c
+	}
+	// sendRequest registers a pending binding request for (local, remote) and
+	// returns the matching success response.
+	sendRequest := func(t *testing.T, agent *Agent, local, remote Candidate) *stun.Message {
+		t.Helper()
+		req, err := stun.Build(stun.BindingRequest,
+			stun.TransactionID,
+			stun.NewUsername(agent.remoteUfrag+":"+agent.localUfrag),
+			AttrControlling(agent.tieBreaker),
+			PriorityAttr(local.Priority()),
+			stun.NewShortTermIntegrity(agent.remotePwd),
+			stun.Fingerprint,
+		)
+		require.NoError(t, err)
+		agent.sendBindingRequest(req, local, remote)
+
+		resp, err := stun.Build(req, stun.BindingSuccess,
+			stun.NewShortTermIntegrity(agent.remotePwd),
+			stun.Fingerprint,
+		)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	t.Run("network type mismatch is discarded", func(t *testing.T) {
+		agent, selector := newAgent(t)
+		local := newCand(NetworkTypeUDP4, "192.168.1.1", 10000)
+		remote := newCand(NetworkTypeUDP6, "2001:db8::2", 20000)
+		pair := agent.addPair(local, remote)
+		pair.state = CandidatePairStateInProgress
+
+		resp := sendRequest(t, agent, local, remote)
+		selector.HandleSuccessResponse(resp, local, remote, remote.addrPort())
+
+		require.Equal(t, CandidatePairStateInProgress, pair.state,
+			"pair must not be marked succeeded when the response transport does not match")
+		require.Nil(t, agent.getSelectedPair())
+	})
+
+	t.Run("source address mismatch is discarded", func(t *testing.T) {
+		agent, selector := newAgent(t)
+		local := newCand(NetworkTypeUDP4, "192.168.1.1", 10000)
+		remote := newCand(NetworkTypeUDP4, "192.168.1.2", 20000)
+		pair := agent.addPair(local, remote)
+		pair.state = CandidatePairStateInProgress
+
+		resp := sendRequest(t, agent, local, remote)
+		wrongSrc := netip.AddrPortFrom(netip.MustParseAddr("192.168.1.9"), 20000)
+		selector.HandleSuccessResponse(resp, local, remote, wrongSrc)
+
+		require.Equal(t, CandidatePairStateInProgress, pair.state,
+			"pair must not be marked succeeded when the response source does not match")
+		require.Nil(t, agent.getSelectedPair())
+	})
+
+	t.Run("matching transport is accepted", func(t *testing.T) {
+		agent, selector := newAgent(t)
+		local := newCand(NetworkTypeUDP4, "192.168.1.1", 10000)
+		remote := newCand(NetworkTypeUDP4, "192.168.1.2", 20000)
+		pair := agent.addPair(local, remote)
+		pair.state = CandidatePairStateInProgress
+
+		resp := sendRequest(t, agent, local, remote)
+		selector.HandleSuccessResponse(resp, local, remote, remote.addrPort())
+
+		require.Equal(t, CandidatePairStateSucceeded, pair.state,
+			"pair must be marked succeeded when the response transport matches")
+	})
 }
 
 // TestControlledSelector_NoTriggeredCheckAfterConnected verifies that once a pair
@@ -397,11 +561,11 @@ func TestControlledSelector_NoTriggeredCheckAfterConnected(t *testing.T) {
 
 	local := newPingNoIOCand()
 	local.candidateBase.networkType = NetworkTypeUDP4
-	local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+	local.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 	remote := newPingNoIOCand()
 	remote.candidateBase.networkType = NetworkTypeUDP4
-	remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+	remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 	pair := agent.addPair(local, remote)
 	pair.state = CandidatePairStateSucceeded
@@ -448,11 +612,11 @@ func TestControlledSelector_TriggeredCheckDuringChecking(t *testing.T) {
 
 	local := newPingNoIOCand()
 	local.candidateBase.networkType = NetworkTypeUDP4
-	local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+	local.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 	remote := newPingNoIOCand()
 	remote.candidateBase.networkType = NetworkTypeUDP4
-	remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+	remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 	pair := agent.addPair(local, remote)
 	// Pair is in Waiting state (not Succeeded), no selected pair — normal ICE checking.
@@ -896,15 +1060,15 @@ func TestKeepAliveCandidatesForRenomination(t *testing.T) {
 	createTestCandidates := func() (Candidate, Candidate, Candidate) {
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		return local1, local2, remote
 	}
@@ -1082,15 +1246,15 @@ func TestRenominationAcceptance(t *testing.T) { //nolint:maintidx
 
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		pair1 := agent.addPair(local1, remote)
 		pair1.state = CandidatePairStateSucceeded
@@ -1137,15 +1301,15 @@ func TestRenominationAcceptance(t *testing.T) { //nolint:maintidx
 		// Create two host candidates with same priority
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		// Create two pairs with the same priority (both host candidates)
 		pair1 := agent.addPair(local1, remote)
@@ -1203,17 +1367,17 @@ func TestRenominationAcceptance(t *testing.T) { //nolint:maintidx
 		// Create candidates - we'll simulate lower priority by using different types
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 		local1.candidateBase.candidateType = CandidateTypeHost // Higher priority
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 		local2.candidateBase.candidateType = CandidateTypeHost // Same priority
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 		remote.candidateBase.candidateType = CandidateTypeHost
 
 		pair1 := agent.addPair(local1, remote)
@@ -1263,19 +1427,19 @@ func TestRenominationAcceptance(t *testing.T) { //nolint:maintidx
 
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		local3 := newPingNoIOCand()
 		local3.candidateBase.networkType = NetworkTypeUDP4
-		local3.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.4"), Port: 10002}
+		local3.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.4"), Port: 10002})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		pair1 := agent.addPair(local1, remote)
 		pair1.state = CandidatePairStateSucceeded
@@ -1351,15 +1515,15 @@ func TestControllingSideRenomination(t *testing.T) {
 		// Create two host candidates
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		// Create two pairs
 		pair1 := agent.addPair(local1, remote)
@@ -1412,7 +1576,7 @@ func TestControllingSideRenomination(t *testing.T) {
 		require.NoError(t, err)
 
 		// Handle the success response - this should switch to pair2
-		selector.HandleSuccessResponse(successMsg, local2, remote, remote.addr())
+		selector.HandleSuccessResponse(successMsg, local2, remote, remote.addrPort())
 
 		// The controlling agent should have switched to pair2
 		selectedPair := agent.getSelectedPair()
@@ -1439,15 +1603,15 @@ func TestControllingSideRenomination(t *testing.T) {
 		// Create two host candidates
 		local1 := newPingNoIOCand()
 		local1.candidateBase.networkType = NetworkTypeUDP4
-		local1.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local1.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		local2 := newPingNoIOCand()
 		local2.candidateBase.networkType = NetworkTypeUDP4
-		local2.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001}
+		local2.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.3"), Port: 10001})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		// Create two pairs
 		pair1 := agent.addPair(local1, remote)
@@ -1492,7 +1656,7 @@ func TestControllingSideRenomination(t *testing.T) {
 
 		// Handle the success response - this should NOT switch since it's standard nomination
 		// and a pair is already selected
-		selector.HandleSuccessResponse(successMsg, local2, remote, remote.addr())
+		selector.HandleSuccessResponse(successMsg, local2, remote, remote.addrPort())
 
 		// The controlling agent should remain with pair1
 		selectedPair := agent.getSelectedPair()
@@ -1566,11 +1730,11 @@ func TestLiteControlledSelector_NoPingCandidate(t *testing.T) {
 
 		local := newPingNoIOCand()
 		local.candidateBase.networkType = NetworkTypeUDP4
-		local.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000}
+		local.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 10000})
 
 		remote := newPingNoIOCand()
 		remote.candidateBase.networkType = NetworkTypeUDP4
-		remote.candidateBase.resolvedAddr = &net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000}
+		remote.candidateBase.setResolvedAddr(&net.UDPAddr{IP: net.ParseIP("192.168.1.2"), Port: 20000})
 
 		pair := liteAgent.addPair(local, remote)
 

--- a/shared_packet_conn.go
+++ b/shared_packet_conn.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,13 @@ import (
 type muxedPacketConn interface {
 	net.PacketConn
 	readFromContext(ctx context.Context, b []byte) (int, net.Addr, error)
+}
+
+// muxedAddrPortConn adds netip.AddrPort I/O to muxedPacketConn.
+type muxedAddrPortConn interface {
+	muxedPacketConn
+	AddrPortReaderWriter
+	readFromAddrPortContext(ctx context.Context, b []byte) (int, netip.AddrPort, error)
 }
 
 // sharedPacketConn is a reference-counted wrapper around an underlying
@@ -53,27 +61,47 @@ func newSharedPacketConn(u muxedPacketConn, refs *atomic.Int32) *sharedPacketCon
 	}
 }
 
-func (s *sharedPacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
-	ctx := s.ctx
+// readContext returns the context to use for a single read, arming the
+// configured read deadline if one is set. cancel is non-nil when the caller
+// must cancel after the read completes.
+func (s *sharedPacketConn) readContext() (ctx context.Context, cancel context.CancelFunc, err error) {
+	ctx = s.ctx
 	if ctx.Err() != nil {
-		return 0, nil, io.ErrClosedPipe
+		return nil, nil, io.ErrClosedPipe
 	}
 
 	if p := s.readDeadline.Load(); p != nil && !p.IsZero() {
-		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(s.ctx, *p)
+	}
+
+	return ctx, cancel, nil
+}
+
+// mapContextError converts context termination errors to the net.Conn
+// equivalents callers expect.
+func mapContextError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return os.ErrDeadlineExceeded
+	}
+	if errors.Is(err, context.Canceled) {
+		return io.ErrClosedPipe
+	}
+
+	return err
+}
+
+func (s *sharedPacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	ctx, cancel, err := s.readContext()
+	if err != nil {
+		return 0, nil, err
+	}
+	if cancel != nil {
 		defer cancel()
 	}
 
 	n, addr, err := s.underlying.readFromContext(ctx, b)
-	if errors.Is(err, context.DeadlineExceeded) {
-		return n, addr, os.ErrDeadlineExceeded
-	}
-	if errors.Is(err, context.Canceled) {
-		return n, addr, io.ErrClosedPipe
-	}
 
-	return n, addr, err
+	return n, addr, mapContextError(err)
 }
 
 func (s *sharedPacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
@@ -138,4 +166,39 @@ func (s *sharedPacketConn) Close() error {
 	}
 
 	return err
+}
+
+// sharedAddrPortConn adds netip.AddrPort I/O to sharedPacketConn.
+type sharedAddrPortConn struct {
+	*sharedPacketConn
+	underlyingAddrPort muxedAddrPortConn
+}
+
+func newSharedAddrPortConn(u muxedAddrPortConn, refs *atomic.Int32) *sharedAddrPortConn {
+	return &sharedAddrPortConn{
+		sharedPacketConn:   newSharedPacketConn(u, refs),
+		underlyingAddrPort: u,
+	}
+}
+
+func (s *sharedAddrPortConn) ReadFromAddrPort(b []byte) (int, netip.AddrPort, error) {
+	ctx, cancel, err := s.readContext()
+	if err != nil {
+		return 0, netip.AddrPort{}, err
+	}
+	if cancel != nil {
+		defer cancel()
+	}
+
+	n, addr, err := s.underlyingAddrPort.readFromAddrPortContext(ctx, b)
+
+	return n, addr, mapContextError(err)
+}
+
+func (s *sharedAddrPortConn) WriteToAddrPort(b []byte, addr netip.AddrPort) (int, error) {
+	if s.ctx.Err() != nil {
+		return 0, io.ErrClosedPipe
+	}
+
+	return s.underlyingAddrPort.WriteToAddrPort(b, addr)
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -7,6 +7,7 @@ package ice
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/netip"
 	"sync"
@@ -273,7 +274,9 @@ func pipe(tb testing.TB, defaultConfig *AgentConfig) (*Conn, *Conn) {
 	}
 
 	cfg.Urls = urls
-	cfg.NetworkTypes = supportedNetworkTypes()
+	if cfg.NetworkTypes == nil {
+		cfg.NetworkTypes = supportedNetworkTypes()
+	}
 
 	aAgent, err := NewAgent(cfg)
 	require.NoError(tb, err)
@@ -666,6 +669,47 @@ func TestConn_WriteToPair_Success(t *testing.T) {
 	require.Equal(t, testData, buf[:n])
 }
 
+// TestUDPConnReadWriteDoesNotAllocate pins the data path at zero heap
+// allocations per packet in both directions: Conn.Write on one agent through
+// real UDP sockets to Conn.Read on the other.
+func TestUDPConnReadWriteDoesNotAllocate(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(30 * time.Second).Stop()
+
+	ca, cb := pipe(t, &AgentConfig{NetworkTypes: []NetworkType{NetworkTypeUDP4}})
+	defer closePipe(t, ca, cb)
+
+	packet := make([]byte, 1200)
+	readBuf := make([]byte, receiveMTU)
+
+	// Note: the read must stay synchronous with the write so the receive path
+	// runs exactly once per iteration; AllocsPerRun counts process-wide.
+	var failure error
+	roundTrip := func() {
+		if _, err := ca.Write(packet); err != nil && failure == nil {
+			failure = err
+		}
+		if _, err := cb.Read(readBuf); err != nil && failure == nil {
+			failure = err
+		}
+	}
+
+	// The first packets take slow paths that allocate (source validation and
+	// address registration); warm up so the measured loop runs steady state.
+	for range 100 {
+		roundTrip()
+	}
+	require.NoError(t, failure)
+
+	allocs := testing.AllocsPerRun(1000, roundTrip)
+	require.NoError(t, failure)
+	require.Zero(t, allocs)
+	require.Positive(t, ca.BytesSent())
+	require.Positive(t, cb.BytesReceived())
+}
+
+// discardPacketConn exercises the net.Addr fallback by implementing
+// a simple black-hole writer that only supports WriteTo.
 type discardPacketConn struct {
 	deadlinePacketConn
 }
@@ -674,10 +718,53 @@ func (*discardPacketConn) WriteTo(b []byte, _ net.Addr) (int, error) {
 	return len(b), nil
 }
 
-// TestConnWriteDoesNotAllocateAbovePacketConn pins Write's fast path at zero
-// heap allocations per packet, from the selected pair down to the candidate's
-// net.PacketConn. The discarding conn excludes the socket write itself.
-func TestConnWriteDoesNotAllocateAbovePacketConn(t *testing.T) {
+// addrPortCapablePacketConn is a black-hole writer that implements
+// support for the netip.AddrPort read/write variants.
+type addrPortCapablePacketConn struct {
+	deadlinePacketConn
+	writeToCalled         bool
+	writeToAddrPortCalled bool
+}
+
+func (c *addrPortCapablePacketConn) WriteTo(b []byte, _ net.Addr) (int, error) {
+	c.writeToCalled = true
+
+	return len(b), nil
+}
+
+func (*addrPortCapablePacketConn) ReadFromAddrPort([]byte) (int, netip.AddrPort, error) {
+	return 0, netip.AddrPort{}, io.EOF
+}
+
+func (c *addrPortCapablePacketConn) WriteToAddrPort(b []byte, _ netip.AddrPort) (int, error) {
+	c.writeToAddrPortCalled = true
+
+	return len(b), nil
+}
+
+// addrPortTCPMux simulates a custom TCPMux that returns PacketConns supporting
+// AddrPortReaderWriter.
+type addrPortTCPMux struct {
+	conn net.PacketConn
+}
+
+func (*addrPortTCPMux) Close() error             { return nil }
+func (*addrPortTCPMux) RemoveConnByUfrag(string) {}
+func (m *addrPortTCPMux) GetConnByUfrag(string, bool, net.IP) (net.PacketConn, error) {
+	return m.conn, nil
+}
+
+// TestConnWriteDoesNotAllocateOverStandardPacketConn pins Conn.Write at zero
+// heap allocations per packet, at least in this package, when the candidate's
+// PacketConn does not support netip.AddrPort writes. The write must reuse the
+// candidate's cached net.Addr rather than synthesizing a *net.UDPAddr from a
+// netip.AddrPort on every write.
+// Note that the *net.UDPConn implementation of WriteTo does allocate internally,
+// so a mock connection is used to isolate allocations to this package.
+func TestConnWriteDoesNotAllocateOverStandardPacketConn(t *testing.T) {
+	_, supportsAddrPort := any(&discardPacketConn{}).(AddrPortReaderWriter)
+	require.False(t, supportsAddrPort, "discardPacketConn must be a standard-only PacketConn")
+
 	agent, err := NewAgent(&AgentConfig{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -715,8 +802,35 @@ func TestConnWriteDoesNotAllocateAbovePacketConn(t *testing.T) {
 	require.Positive(t, conn.BytesSent())
 }
 
-func BenchmarkConnWriteRead(b *testing.B) {
-	ca, cb := pipe(b, nil)
+// TestCustomTCPMuxAddrPortCapability verifies that TCP candidates use
+// netip.AddrPort methods exposed by a custom mux.
+func TestCustomTCPMuxAddrPortCapability(t *testing.T) {
+	packetConn := &addrPortCapablePacketConn{}
+	mux := &addrPortTCPMux{conn: packetConn}
+	conn, err := mux.GetConnByUfrag("ufrag", false, net.IPv4(127, 0, 0, 1))
+	require.NoError(t, err)
+
+	addrPortConn, ok := conn.(AddrPortReaderWriter)
+	require.True(t, ok)
+
+	local := &candidateBase{
+		networkType:  NetworkTypeTCP4,
+		conn:         conn,
+		addrPortConn: addrPortConn,
+	}
+
+	remote := &candidateBase{}
+	remote.setResolvedAddr(&net.TCPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5000})
+
+	_, err = local.writeTo([]byte("framed"), remote)
+	require.NoError(t, err)
+	require.True(t, packetConn.writeToAddrPortCalled)
+	require.False(t, packetConn.writeToCalled)
+}
+
+func BenchmarkUDPConnWriteRead(b *testing.B) {
+	ca, cb := pipe(b, &AgentConfig{NetworkTypes: []NetworkType{NetworkTypeUDP4}})
+	defer closePipe(b, ca, cb)
 
 	// Note: this loop needs to keep the writes and reads synchronous to keep
 	// the allocation benchmark deterministic. Otherwise, if reads fall behind

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -41,10 +41,10 @@ type UDPMuxDefault struct {
 	connsIPv4, connsIPv6 map[string]*udpMuxedConn
 
 	addressMapMu sync.RWMutex
-	addressMap   map[ipPort]*udpMuxedConn
+	addressMap   map[netip.AddrPort]*udpMuxedConn
 
-	// Buffer pool to recycle buffers for net.UDPAddr encodes/decodes
-	pool *sync.Pool
+	// Pool of buffers used to queue packets for muxed connections.
+	bufferPool *sync.Pool
 
 	mu sync.Mutex
 
@@ -102,14 +102,14 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 	params.UDPConnString = params.UDPConn.LocalAddr().String()
 
 	mux := &UDPMuxDefault{
-		addressMap: map[ipPort]*udpMuxedConn{},
+		addressMap: map[netip.AddrPort]*udpMuxedConn{},
 		params:     params,
 		connsIPv4:  make(map[string]*udpMuxedConn),
 		connsIPv6:  make(map[string]*udpMuxedConn),
 		closedChan: make(chan struct{}, 1),
-		pool: &sync.Pool{
+		bufferPool: &sync.Pool{
 			New: func() any {
-				// Big enough buffer to fit both packet and address
+				// Big enough buffer to fit a maximum-size packet.
 				return newBufferHolder(receiveMTU)
 			},
 		},
@@ -438,7 +438,7 @@ func (m *UDPMuxDefault) clearWriteAbortState() {
 	}
 }
 
-func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr ipPort) {
+func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr netip.AddrPort) {
 	if m.IsClosed() {
 		return
 	}
@@ -452,19 +452,44 @@ func (m *UDPMuxDefault) registerConnForAddress(conn *udpMuxedConn, addr ipPort) 
 	}
 	m.addressMap[addr] = conn
 
-	m.params.Logger.Debugf("Registered %s for %s", addr.addr.String(), conn.params.Key)
+	m.params.Logger.Debugf("Registered %s for %s", addr.Addr().String(), conn.params.Key)
 }
 
 func (m *UDPMuxDefault) createMuxedConn(key string) *udpMuxedConn {
 	c := newUDPMuxedConn(&udpMuxedConnParams{
-		Mux:       m,
-		Key:       key,
-		AddrPool:  m.pool,
-		LocalAddr: m.LocalAddr(),
-		Logger:    m.params.Logger,
+		Mux:        m,
+		Key:        key,
+		BufferPool: m.bufferPool,
+		LocalAddr:  m.LocalAddr(),
+		Logger:     m.params.Logger,
 	})
 
 	return c
+}
+
+// readFromUDPConn reads a packet from the underlying connection, returning
+// the source as both netip.AddrPort and *net.UDPAddr so that a later write
+// can use the same address without allocating.
+func (m *UDPMuxDefault) readFromUDPConn(
+	buf []byte,
+) (n int, addrPort netip.AddrPort, udpAddr *net.UDPAddr, err error) {
+	var addr net.Addr
+	n, addr, err = m.params.UDPConn.ReadFrom(buf)
+	if err != nil {
+		return 0, netip.AddrPort{}, nil, err
+	}
+
+	var ok bool
+	udpAddr, ok = addr.(*net.UDPAddr)
+	if !ok {
+		return 0, netip.AddrPort{}, nil, errFailedToCastUDPAddr
+	}
+	addrPort = udpAddr.AddrPort()
+	if !addrPort.IsValid() {
+		return 0, netip.AddrPort{}, nil, errInvalidAddress
+	}
+
+	return
 }
 
 func (m *UDPMuxDefault) connWorker() { //nolint:cyclop
@@ -476,35 +501,29 @@ func (m *UDPMuxDefault) connWorker() { //nolint:cyclop
 
 	buf := make([]byte, receiveMTU)
 	for {
-		n, addr, err := m.params.UDPConn.ReadFrom(buf)
+		n, srcAddrPort, srcUDPAddr, err := m.readFromUDPConn(buf)
 		if m.IsClosed() {
 			return
 		} else if err != nil {
-			if os.IsTimeout(err) {
+			switch {
+			case os.IsTimeout(err):
 				continue
-			} else if !errors.Is(err, io.EOF) {
+			case errors.Is(err, errFailedToCastUDPAddr):
+				logger.Errorf("Underlying PacketConn did not return a UDPAddr")
+			case errors.Is(err, errInvalidAddress):
+				logger.Errorf("Underlying PacketConn returned an invalid UDP address")
+			case !errors.Is(err, io.EOF):
 				logger.Errorf("Failed to read UDP packet: %v", err)
 			}
 
 			return
 		}
 
-		netUDPAddr, ok := addr.(*net.UDPAddr)
-		if !ok {
-			logger.Errorf("Underlying PacketConn did not return a UDPAddr")
-
-			return
-		}
-		udpAddr, err := newIPPort(netUDPAddr.IP, netUDPAddr.Zone, uint16(netUDPAddr.Port)) //nolint:gosec
-		if err != nil {
-			logger.Errorf("Failed to create a new IP/Port host pair")
-
-			return
-		}
+		srcAddr := canonicalAddrPort(srcAddrPort)
 
 		// If we have already seen this address dispatch to the appropriate destination
 		m.addressMapMu.Lock()
-		destinationConn := m.addressMap[udpAddr]
+		destinationConn := m.addressMap[srcAddr]
 		m.addressMapMu.Unlock()
 
 		// If we haven't seen this address before but is a STUN packet lookup by ufrag
@@ -514,20 +533,20 @@ func (m *UDPMuxDefault) connWorker() { //nolint:cyclop
 			}
 
 			if err = msg.Decode(); err != nil {
-				m.params.Logger.Warnf("Failed to handle decode ICE from %s: %v", addr.String(), err)
+				m.params.Logger.Warnf("Failed to handle decode ICE from %s: %v", srcAddrPort, err)
 
 				continue
 			}
 
 			attr, stunAttrErr := msg.Get(stun.AttrUsername)
 			if stunAttrErr != nil {
-				m.params.Logger.Warnf("No Username attribute in STUN message from %s", addr.String())
+				m.params.Logger.Warnf("No Username attribute in STUN message from %s", srcAddrPort)
 
 				continue
 			}
 
 			ufrag := strings.Split(string(attr), ":")[0]
-			isIPv6 := netUDPAddr.IP.To4() == nil
+			isIPv6 := srcAddr.Addr().Is6()
 
 			m.mu.Lock()
 			destinationConn, _ = m.getConn(ufrag, isIPv6)
@@ -535,12 +554,12 @@ func (m *UDPMuxDefault) connWorker() { //nolint:cyclop
 		}
 
 		if destinationConn == nil {
-			m.params.Logger.Tracef("Dropping packet from %s, addr: %s", udpAddr.addr, addr)
+			m.params.Logger.Tracef("Dropping packet from %s", srcAddrPort)
 
 			continue
 		}
 
-		if err = destinationConn.writePacket(buf[:n], netUDPAddr); err != nil {
+		if err = destinationConn.writePacket(buf[:n], srcAddrPort, srcUDPAddr); err != nil {
 			m.params.Logger.Errorf("Failed to write packet: %v", err)
 		}
 	}
@@ -557,9 +576,10 @@ func (m *UDPMuxDefault) getConn(ufrag string, isIPv6 bool) (val *udpMuxedConn, o
 }
 
 type bufferHolder struct {
-	next *bufferHolder
-	buf  []byte
-	addr *net.UDPAddr
+	next           *bufferHolder
+	buf            []byte
+	sourceAddrPort netip.AddrPort
+	sourceAddr     *net.UDPAddr
 }
 
 func newBufferHolder(size int) *bufferHolder {
@@ -570,25 +590,6 @@ func newBufferHolder(size int) *bufferHolder {
 
 func (b *bufferHolder) reset() {
 	b.next = nil
-	b.addr = nil
-}
-
-type ipPort struct {
-	addr netip.Addr
-	port uint16
-}
-
-// newIPPort create a custom type of address based on netip.Addr and
-// port. The underlying ip address passed is converted to IPv6 format
-// to simplify ip address handling.
-func newIPPort(ip net.IP, zone string, port uint16) (ipPort, error) {
-	n, ok := netip.AddrFromSlice(ip.To16())
-	if !ok {
-		return ipPort{}, errInvalidIPAddress
-	}
-
-	return ipPort{
-		addr: n.WithZone(zone),
-		port: port,
-	}, nil
+	b.sourceAddrPort = netip.AddrPort{}
+	b.sourceAddr = nil
 }

--- a/udp_mux.go
+++ b/udp_mux.go
@@ -46,6 +46,10 @@ type UDPMuxDefault struct {
 	// Pool of buffers used to queue packets for muxed connections.
 	bufferPool *sync.Pool
 
+	// addrPortConn is non-nil when params.UDPConn supports allocation-free
+	// netip.AddrPort reads and writes.
+	addrPortConn AddrPortReaderWriter
+
 	mu sync.Mutex
 
 	// whether the UDP connection listens on an unspecified address
@@ -67,7 +71,10 @@ const (
 
 // UDPMuxParams are parameters for UDPMux.
 type UDPMuxParams struct {
-	Logger        logging.LeveledLogger
+	Logger logging.LeveledLogger
+	// UDPConn may implement AddrPortReaderWriter to opt in to
+	// allocation-free address handling. *net.UDPConn will be
+	// automatically adapted to implement AddrPortReaderWriter.
 	UDPConn       net.PacketConn
 	UDPConnString string
 
@@ -115,6 +122,7 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 		},
 		isUnspecified: isUnspecified,
 	}
+	mux.addrPortConn = asAddrPortReaderWriter(params.UDPConn)
 	go mux.connWorker()
 
 	return mux
@@ -203,6 +211,12 @@ func (m *UDPMuxDefault) GetConn(ufrag string, addr net.Addr) (net.PacketConn, er
 		}
 	}
 
+	// Preserve netip.AddrPort I/O only when the underlying connection supports
+	// both methods.
+	if m.addrPortConn != nil {
+		return newSharedAddrPortConn(muxedConn, &muxedConn.refs), nil
+	}
+
 	return newSharedPacketConn(muxedConn, &muxedConn.refs), nil
 }
 
@@ -275,6 +289,31 @@ func (m *UDPMuxDefault) Close() error {
 
 func (m *UDPMuxDefault) writeTo(buf []byte, rAddr net.Addr) (n int, err error) {
 	return m.writeToContext(context.Background(), buf, rAddr)
+}
+
+// writeToUDPAddrPort writes without converting rAddr to net.Addr when
+// supported by the underlying connection. Callers should only invoke
+// this method when the underlying connection supports netip.AddrPort
+// reads and writes, otherwise an extra allocation occurs in the writeTo
+// fallback.
+func (m *UDPMuxDefault) writeToUDPAddrPort(buf []byte, rAddr netip.AddrPort) (n int, err error) {
+	if m.addrPortConn == nil {
+		// GetConn does not expose netip.AddrPort writes in this case.
+		// This fallback only exists for defensive purposes and is not
+		// expected to be called, so the extra allocation here is not
+		// expected to occur.
+		return m.writeTo(buf, net.UDPAddrFromAddrPort(rAddr))
+	}
+
+	if err = m.startWriteContext(context.Background()); err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		err = m.finishWrite(err)
+	}()
+
+	return m.addrPortConn.WriteToAddrPort(buf, rAddr)
 }
 
 func (m *UDPMuxDefault) writeToContext(ctx context.Context, buf []byte, rAddr net.Addr) (n int, err error) {
@@ -467,25 +506,30 @@ func (m *UDPMuxDefault) createMuxedConn(key string) *udpMuxedConn {
 	return c
 }
 
-// readFromUDPConn reads a packet from the underlying connection, returning
-// the source as both netip.AddrPort and *net.UDPAddr so that a later write
-// can use the same address without allocating.
+// readFromUDPConn tries reading with ReadFromAddrPort if available
+// and falls back to ReadFrom otherwise. addrPort is always returned
+// from both paths, but udpAddr is only returned in the fallback path
+// so that a later write can use the same address without allocating.
 func (m *UDPMuxDefault) readFromUDPConn(
 	buf []byte,
 ) (n int, addrPort netip.AddrPort, udpAddr *net.UDPAddr, err error) {
-	var addr net.Addr
-	n, addr, err = m.params.UDPConn.ReadFrom(buf)
-	if err != nil {
-		return 0, netip.AddrPort{}, nil, err
-	}
+	if m.addrPortConn != nil {
+		n, addrPort, err = m.addrPortConn.ReadFromAddrPort(buf)
+	} else {
+		var addr net.Addr
+		n, addr, err = m.params.UDPConn.ReadFrom(buf)
+		if err != nil {
+			return 0, netip.AddrPort{}, nil, err
+		}
 
-	var ok bool
-	udpAddr, ok = addr.(*net.UDPAddr)
-	if !ok {
-		return 0, netip.AddrPort{}, nil, errFailedToCastUDPAddr
+		var ok bool
+		udpAddr, ok = addr.(*net.UDPAddr)
+		if !ok {
+			return 0, netip.AddrPort{}, nil, errFailedToCastUDPAddr
+		}
+		addrPort = udpAddr.AddrPort()
 	}
-	addrPort = udpAddr.AddrPort()
-	if !addrPort.IsValid() {
+	if err == nil && !addrPort.IsValid() {
 		return 0, netip.AddrPort{}, nil, errInvalidAddress
 	}
 

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -298,8 +300,8 @@ func secondTestMuxedConn(t *testing.T, capBytes int) *udpMuxedConn {
 		},
 	}
 	params := &udpMuxedConnParams{
-		AddrPool:  pool,
-		LocalAddr: &net.UDPAddr{IP: net.IPv4zero, Port: 0},
+		BufferPool: pool,
+		LocalAddr:  &net.UDPAddr{IP: net.IPv4zero, Port: 0},
 	}
 
 	return newUDPMuxedConn(params)
@@ -308,9 +310,10 @@ func secondTestMuxedConn(t *testing.T, capBytes int) *udpMuxedConn {
 func TestUDPMuxedConn_ReadFrom(t *testing.T) {
 	conn := secondTestMuxedConn(t, 1500)
 	remote := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5678}
+	remoteAddrPort := remote.AddrPort()
 	payload := []byte("this is a payload of length 29!")
 
-	require.NoError(t, conn.writePacket(payload, remote))
+	require.NoError(t, conn.writePacket(payload, remoteAddrPort, remote))
 
 	// read with too small of a buffer -> expect io.ErrShortBuffer, n=0, rAddr=nil
 	small := make([]byte, 8)
@@ -320,7 +323,7 @@ func TestUDPMuxedConn_ReadFrom(t *testing.T) {
 	require.Nil(t, raddr)
 
 	// try again with sufficient buffer
-	require.NoError(t, conn.writePacket(payload, remote))
+	require.NoError(t, conn.writePacket(payload, remoteAddrPort, remote))
 	dst := make([]byte, len(payload))
 	n, raddr, err = conn.ReadFrom(dst)
 	require.NoError(t, err)
@@ -329,7 +332,7 @@ func TestUDPMuxedConn_ReadFrom(t *testing.T) {
 
 	// rAddr should be what was set on the packet.
 	require.NotNil(t, raddr)
-	require.Equal(t, remote.String(), raddr.String())
+	require.Same(t, remote, raddr)
 }
 
 func TestUDPMuxedConn_ReadFrom_EOFAfterClose(t *testing.T) {
@@ -373,7 +376,7 @@ func TestUDPMuxedConn_TwoReadersWokenByTwoWrites(t *testing.T) {
 	defer test.TimeOut(time.Second * 10).Stop()
 
 	conn := secondTestMuxedConn(t, 1500)
-	remote := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5678}
+	remote := netip.AddrPortFrom(netip.AddrFrom4([4]byte{1, 2, 3, 4}), 5678)
 
 	type readResult struct {
 		data []byte
@@ -394,7 +397,7 @@ func TestUDPMuxedConn_TwoReadersWokenByTwoWrites(t *testing.T) {
 	}, 2*time.Second, time.Millisecond, "both readers must block on the empty queue")
 
 	// First write wakes exactly one reader, which drains the single packet.
-	require.NoError(t, conn.writePacket([]byte("p1"), remote))
+	require.NoError(t, conn.writePacket([]byte("p1"), remote, nil))
 	first := <-results
 	require.NoError(t, first.err)
 	require.Equal(t, []byte("p1"), first.data)
@@ -405,7 +408,7 @@ func TestUDPMuxedConn_TwoReadersWokenByTwoWrites(t *testing.T) {
 	}, 2*time.Second, time.Millisecond, "the second reader must still be parked")
 
 	// Second write wakes the remaining reader.
-	require.NoError(t, conn.writePacket([]byte("p2"), remote))
+	require.NoError(t, conn.writePacket([]byte("p2"), remote, nil))
 	second := <-results
 	require.NoError(t, second.err)
 	require.Equal(t, []byte("p2"), second.data)
@@ -438,8 +441,8 @@ func TestUDPMuxedConn_WriteTo_BadAddrType(t *testing.T) {
 	require.ErrorIs(t, err, errFailedToCastUDPAddr)
 }
 
-// uses invalid IP length so newIPPort returns error.
-func TestUDPMuxedConn_WriteTo_newIPPortError(t *testing.T) {
+// uses invalid IP length so address validation returns an error.
+func TestUDPMuxedConn_WriteTo_InvalidIP(t *testing.T) {
 	conn := secondTestMuxedConn(t, 64)
 
 	invalidIP := net.IP{1} // len=1 -> invalid
@@ -480,11 +483,8 @@ func TestUDPMuxedConn_SetDeadlines(t *testing.T) {
 func TestUDPMuxedConn_removeAddress(t *testing.T) {
 	conn := secondTestMuxedConn(t, 64)
 
-	mk := func(ip string, port uint16) ipPort {
-		p, err := newIPPort(net.ParseIP(ip), "", port)
-		require.NoError(t, err)
-
-		return p
+	mk := func(ip string, port uint16) netip.AddrPort {
+		return canonicalAddrPort(netip.AddrPortFrom(netip.MustParseAddr(ip), port))
 	}
 
 	a1 := mk("1.1.1.1", 1000)
@@ -494,26 +494,26 @@ func TestUDPMuxedConn_removeAddress(t *testing.T) {
 
 	t.Run("remove-existing-middle", func(t *testing.T) {
 		// true for a1/a3, false for a2
-		conn.addresses = []ipPort{a1, a2, a3}
+		conn.addresses = []netip.AddrPort{a1, a2, a3}
 		conn.removeAddress(a2)
 		got := conn.getAddresses()
-		require.Equal(t, []ipPort{a1, a3}, got)
+		require.Equal(t, []netip.AddrPort{a1, a3}, got)
 	})
 
 	t.Run("remove-non-existing", func(t *testing.T) {
 		// only true (no matches)
-		conn.addresses = []ipPort{a1, a3}
+		conn.addresses = []netip.AddrPort{a1, a3}
 		conn.removeAddress(a4)
 		got := conn.getAddresses()
-		require.Equal(t, []ipPort{a1, a3}, got)
+		require.Equal(t, []netip.AddrPort{a1, a3}, got)
 	})
 
 	t.Run("remove-duplicates-all", func(t *testing.T) {
 		// all occurrences are removed (false twice)
-		conn.addresses = []ipPort{a1, a1, a2}
+		conn.addresses = []netip.AddrPort{a1, a1, a2}
 		conn.removeAddress(a1)
 		got := conn.getAddresses()
-		require.Equal(t, []ipPort{a2}, got)
+		require.Equal(t, []netip.AddrPort{a2}, got)
 	})
 
 	t.Run("remove-from-empty", func(t *testing.T) {
@@ -527,9 +527,9 @@ func TestUDPMuxedConn_removeAddress(t *testing.T) {
 
 func TestUDPMuxedConn_writePacket_ShortBuffer(t *testing.T) {
 	conn := secondTestMuxedConn(t, 8) // pool buf cap=8
-	addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 9999}
+	addr := netip.AddrPortFrom(netip.AddrFrom4([4]byte{1, 2, 3, 4}), 9999)
 
-	err := conn.writePacket(make([]byte, 16), addr) // len=16 > cap=8
+	err := conn.writePacket(make([]byte, 16), addr, nil) // len=16 > cap=8
 	require.ErrorIs(t, err, io.ErrShortBuffer)
 
 	require.Nil(t, conn.bufHead)
@@ -538,14 +538,14 @@ func TestUDPMuxedConn_writePacket_ShortBuffer(t *testing.T) {
 
 func TestUDPMuxedConn_writePacket_ClosedState(t *testing.T) {
 	conn := secondTestMuxedConn(t, 64)
-	addr := &net.UDPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 1234}
+	addr := netip.AddrPortFrom(netip.AddrFrom4([4]byte{5, 6, 7, 8}), 1234)
 
 	// closed state before write
 	conn.mu.Lock()
 	conn.closed = true
 	conn.mu.Unlock()
 
-	err := conn.writePacket([]byte{1, 2, 3}, addr) // fits in cap
+	err := conn.writePacket([]byte{1, 2, 3}, addr, nil) // fits in cap
 	require.ErrorIs(t, err, io.ErrClosedPipe)
 
 	// queue unchanged
@@ -555,7 +555,7 @@ func TestUDPMuxedConn_writePacket_ClosedState(t *testing.T) {
 
 func TestUDPMuxedConn_writePacket_NotifyDefaultBranch(t *testing.T) {
 	conn := secondTestMuxedConn(t, 64)
-	addr := &net.UDPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 4242}
+	addr := netip.AddrPortFrom(netip.AddrFrom4([4]byte{9, 9, 9, 9}), 4242)
 
 	// fill notify channel so send would block
 	conn.notify <- struct{}{}
@@ -564,7 +564,7 @@ func TestUDPMuxedConn_writePacket_NotifyDefaultBranch(t *testing.T) {
 	conn.readWaiting.Store(1)
 
 	// write should take default branch
-	err := conn.writePacket([]byte("hello"), addr)
+	err := conn.writePacket([]byte("hello"), addr, nil)
 	require.NoError(t, err)
 
 	// packet enqueued
@@ -631,8 +631,7 @@ func TestUDPMuxDefault_registerConnForAddress_ClosedMuxEarlyReturn(t *testing.T)
 	_ = udp.Close()
 
 	conn := secondTestMuxedConn(t, 64)
-	addr, err := newIPPort(net.ParseIP("1.2.3.4"), "", 9999)
-	require.NoError(t, err)
+	addr := canonicalAddrPort(netip.AddrPortFrom(netip.MustParseAddr("1.2.3.4"), 9999))
 
 	before := len(udpMux.addressMap)
 	udpMux.registerConnForAddress(conn, addr)
@@ -654,11 +653,10 @@ func TestUDPMuxDefault_registerConnForAddress_ReplacesExisting(t *testing.T) {
 		_ = udp.Close()
 	}()
 
-	ipAddr, err := newIPPort(net.ParseIP("5.6.7.8"), "", 12345)
-	require.NoError(t, err)
+	ipAddr := canonicalAddrPort(netip.AddrPortFrom(netip.MustParseAddr("5.6.7.8"), 12345))
 
 	existing := secondTestMuxedConn(t, 64)
-	existing.addresses = []ipPort{ipAddr}
+	existing.addresses = []netip.AddrPort{ipAddr}
 	udpMux.addressMapMu.Lock()
 	udpMux.addressMap[ipAddr] = existing
 	udpMux.addressMapMu.Unlock()
@@ -857,10 +855,12 @@ type scriptedUDPPC struct {
 		addr net.Addr
 		err  error
 	}
-	i int
+	i         int
+	readCount atomic.Int32
 }
 
 func (s *scriptedUDPPC) ReadFrom(p []byte) (int, net.Addr, error) {
+	s.readCount.Add(1)
 	if s.i >= len(s.seq) {
 		return 0, s.local, errIoEOF
 	}
@@ -915,7 +915,7 @@ func TestUDPMux_connWorker_ReadError_Timeout(t *testing.T) {
 	_ = mux.Close()
 }
 
-func TestUDPMux_connWorker_NewIPPortError(t *testing.T) {
+func TestUDPMux_connWorker_InvalidSrcIP(t *testing.T) {
 	defer test.CheckRoutines(t)()
 
 	badIP := net.IP{1}
@@ -927,12 +927,15 @@ func TestUDPMux_connWorker_NewIPPortError(t *testing.T) {
 			addr net.Addr
 			err  error
 		}{
-			{data: []byte{1}, addr: remote, err: nil}, // triggers newIPPort error
+			{data: []byte{1}, addr: remote, err: nil},
 		},
 	}
 	mux := NewUDPMuxDefault(UDPMuxParams{UDPConn: pc})
 	require.NotNil(t, mux)
-	_ = mux.Close()
+	defer func() { _ = mux.Close() }()
+
+	require.Eventually(t, mux.IsClosed, time.Second, time.Millisecond)
+	require.Equal(t, int32(1), pc.readCount.Load(), "invalid source must stop the worker")
 }
 
 func TestUDPMux_connWorker_STUNDecodeError(t *testing.T) {
@@ -1005,7 +1008,7 @@ func TestUDPMux_connWorker_WritePacketError(t *testing.T) {
 	}()
 
 	// shrink pool to force io.ErrShortBuffer in writePacket
-	mux.pool = &sync.Pool{New: func() any { return newBufferHolder(8) }}
+	mux.bufferPool = &sync.Pool{New: func() any { return newBufferHolder(8) }}
 
 	// make connWorker route to new conn.
 	c, err := mux.GetConn("ufragX", mux.LocalAddr())
@@ -1014,10 +1017,7 @@ func TestUDPMux_connWorker_WritePacketError(t *testing.T) {
 		_ = c.Close()
 	}()
 
-	// remote port is controlled. we use 5555 here to skip int overflow check as we would
-	// otherwise have to cast remote.Port (int) to uint16.
-	ipport, err := newIPPort(remote.IP, remote.Zone, 5555)
-	require.NoError(t, err)
+	ipport := canonicalAddrPort(remote.AddrPort())
 
 	cInner, ok := c.(*sharedPacketConn)
 	require.True(t, ok, "expected *sharedPacketConn from UDPMuxDefault.GetConn")

--- a/udp_mux_test.go
+++ b/udp_mux_test.go
@@ -1045,9 +1045,9 @@ func TestUDPMux_GetConn_SharedRefcount(t *testing.T) {
 	connB, err := mux.GetConn("shared-ufrag", addr)
 	require.NoError(t, err)
 
-	wrapperA, ok := connA.(*sharedPacketConn)
-	require.True(t, ok, "GetConn must return *sharedPacketConn")
-	wrapperB, ok := connB.(*sharedPacketConn)
+	wrapperA, ok := connA.(*sharedAddrPortConn)
+	require.True(t, ok, "GetConn must return *sharedAddrPortConn")
+	wrapperB, ok := connB.(*sharedAddrPortConn)
 	require.True(t, ok)
 	require.NotSame(t, wrapperA, wrapperB, "each call must produce its own wrapper")
 	require.Same(t, wrapperA.underlying, wrapperB.underlying,
@@ -1068,6 +1068,105 @@ func TestUDPMux_GetConn_SharedRefcount(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "underlying must close when the last wrapper is released")
 	}
+}
+
+// TestUDPMux_AddrPortReadWrite exercises the netip.AddrPort read/write path
+// through the mux: writes register the remote address and reads report the
+// packet source without materializing a net.Addr.
+func TestUDPMux_AddrPortReadWrite(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(10 * time.Second).Stop()
+
+	udpConn, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+
+	mux := NewUDPMuxDefault(UDPMuxParams{UDPConn: udpConn})
+	defer func() {
+		_ = mux.Close()
+		_ = udpConn.Close()
+	}()
+
+	pc, err := mux.GetConn("ufrag-addrport", mux.LocalAddr())
+	require.NoError(t, err)
+	defer func() { _ = pc.Close() }()
+
+	conn, ok := pc.(*sharedAddrPortConn)
+	require.True(t, ok, "GetConn must expose AddrPort writes when the socket supports them")
+
+	remote, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer func() { _ = remote.Close() }()
+
+	remoteAddr, ok := remote.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	// The remote deliberately uses ordinary UDP methods; only the mux side is
+	// exercising the netip.AddrPort variants. Writing also registers the remote
+	// address so subsequent non-STUN packets from it route back to this conn.
+	payload := []byte("addrport payload")
+	n, err := conn.WriteToAddrPort(payload, remoteAddr.AddrPort())
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+
+	buf := make([]byte, receiveMTU)
+	n, _, err = remote.ReadFromUDP(buf)
+	require.NoError(t, err)
+	require.Equal(t, payload, buf[:n])
+
+	muxAddr, ok := mux.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	reply := []byte("addrport reply")
+	_, err = remote.WriteToUDP(reply, muxAddr)
+	require.NoError(t, err)
+
+	// The registration above lets the mux route the reply to this logical conn.
+	n, src, err := conn.ReadFromAddrPort(buf)
+	require.NoError(t, err)
+	require.Equal(t, reply, buf[:n])
+	require.Equal(t, remoteAddr.AddrPort(), src)
+}
+
+// TestUDPMuxGetConnAddrPortCapability verifies that the mux only exposes
+// netip.AddrPort I/O when the underlying connection supports both methods.
+func TestUDPMuxGetConnAddrPortCapability(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	t.Run("standard-only conn", func(t *testing.T) {
+		udpConn, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		require.NoError(t, err)
+		pc := &embeddingUDPConnWrapper{UDPConn: udpConn}
+		mux := NewUDPMuxDefault(UDPMuxParams{UDPConn: pc})
+		defer func() { _ = mux.Close() }()
+
+		conn, err := mux.GetConn("ufrag", mux.LocalAddr())
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		_, isAddrPortWrapper := conn.(*sharedAddrPortConn)
+		require.False(t, isAddrPortWrapper, "standard-only conn must not get the AddrPort wrapper")
+		_, supportsAddrPort := conn.(AddrPortReaderWriter)
+		require.False(t, supportsAddrPort, "standard-only conn must not advertise AddrPort I/O")
+	})
+
+	t.Run("UDPConn supports AddrPort I/O", func(t *testing.T) {
+		udpConn, err := net.ListenUDP(udp4, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		require.NoError(t, err)
+		mux := NewUDPMuxDefault(UDPMuxParams{UDPConn: udpConn})
+		defer func() {
+			_ = mux.Close()
+			_ = udpConn.Close()
+		}()
+
+		conn, err := mux.GetConn("ufrag", mux.LocalAddr())
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		_, isAddrPortWrapper := conn.(*sharedAddrPortConn)
+		require.True(t, isAddrPortWrapper, "AddrPort-capable socket must get the specialized wrapper")
+		_, supportsAddrPort := conn.(AddrPortReaderWriter)
+		require.True(t, supportsAddrPort, "wrapper must advertise AddrPort I/O")
+	})
 }
 
 type mutableNet struct {

--- a/udp_mux_universal.go
+++ b/udp_mux_universal.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/pion/logging"
@@ -33,7 +34,7 @@ type UniversalUDPMuxDefault struct {
 	// Since we have a shared socket, for srflx candidates it makes sense
 	// to have a shared mapped address across all the agents
 	// stun.XORMappedAddress indexed by the STUN server addr
-	xorMappedMap map[string]*xorMapped
+	xorMappedMap map[netip.AddrPort]*xorMapped
 }
 
 // UniversalUDPMuxParams are parameters for UniversalUDPMux server reflexive.
@@ -55,7 +56,7 @@ func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDef
 
 	mux := &UniversalUDPMuxDefault{
 		params:       params,
-		xorMappedMap: make(map[string]*xorMapped),
+		xorMappedMap: make(map[netip.AddrPort]*xorMapped),
 	}
 
 	// Wrap UDP connection, process server reflexive messages
@@ -99,45 +100,48 @@ func (m *UniversalUDPMuxDefault) GetConnForURL(ufrag string, url string, addr ne
 
 // ReadFrom is called by UDPMux connWorker and handles packets coming from the STUN server discovering a mapped address.
 // It passes processed packets further to the UDPMux (maybe this is not really necessary).
-func (c *udpConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	n, addr, err = c.PacketConn.ReadFrom(p)
+func (c *udpConn) ReadFrom(buf []byte) (n int, addr net.Addr, err error) {
+	n, addr, err = c.PacketConn.ReadFrom(buf)
 	if err != nil {
 		return n, addr, err
 	}
 
-	if stun.IsMessage(p[:n]) { //nolint:nestif
-		msg := &stun.Message{
-			Raw: append([]byte{}, p[:n]...),
-		}
-
-		if err = msg.Decode(); err != nil {
-			c.logger.Warnf("Failed to handle decode ICE from %s: %v", addr.String(), err)
-
+	if stun.IsMessage(buf[:n]) {
+		addrPort := netAddrToAddrPort(addr)
+		if !addrPort.IsValid() {
+			// Let UDPMuxDefault report the unexpected source address type.
 			return n, addr, nil
 		}
 
-		udpAddr, ok := addr.(*net.UDPAddr)
-		if !ok {
-			// Message about this err will be logged in the UDPMux
-			return n, addr, err
-		}
-
-		if c.mux.isXORMappedResponse(msg, udpAddr.String()) {
-			err = c.mux.handleXORMappedResponse(udpAddr, msg)
-			if err != nil {
-				c.logger.Debugf("%w: %v", errGetXorMappedAddrResponse, err)
-				err = nil
-			}
-
-			return n, addr, err
-		}
+		c.handleSTUNMessage(buf[:n], addrPort)
 	}
 
-	return n, addr, err
+	return n, addr, nil
+}
+
+// handleSTUNMessage intercepts XOR-mapped-address responses coming from known
+// STUN servers before the packet is passed on to the UDPMux connWorker.
+func (c *udpConn) handleSTUNMessage(buf []byte, stunAddr netip.AddrPort) {
+	stunAddr = canonicalAddrPort(stunAddr)
+	msg := &stun.Message{
+		Raw: append([]byte{}, buf...),
+	}
+
+	if err := msg.Decode(); err != nil {
+		c.logger.Warnf("Failed to handle decode ICE from %s: %v", stunAddr, err)
+
+		return
+	}
+
+	if c.mux.isXORMappedResponse(msg, stunAddr) {
+		if err := c.mux.handleXORMappedResponse(stunAddr, msg); err != nil {
+			c.logger.Debugf("%w: %v", errGetXorMappedAddrResponse, err)
+		}
+	}
 }
 
 // isXORMappedResponse indicates whether the message is a XORMappedAddress and is coming from the known STUN server.
-func (m *UniversalUDPMuxDefault) isXORMappedResponse(msg *stun.Message, stunAddr string) bool {
+func (m *UniversalUDPMuxDefault) isXORMappedResponse(msg *stun.Message, stunAddr netip.AddrPort) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Check first if it is a STUN server address,
@@ -150,11 +154,11 @@ func (m *UniversalUDPMuxDefault) isXORMappedResponse(msg *stun.Message, stunAddr
 
 // handleXORMappedResponse parses response from the STUN server, extracts XORMappedAddress attribute.
 // and set the mapped address for the server.
-func (m *UniversalUDPMuxDefault) handleXORMappedResponse(stunAddr *net.UDPAddr, msg *stun.Message) error {
+func (m *UniversalUDPMuxDefault) handleXORMappedResponse(stunAddr netip.AddrPort, msg *stun.Message) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	mappedAddr, ok := m.xorMappedMap[stunAddr.String()]
+	mappedAddr, ok := m.xorMappedMap[stunAddr]
 	if !ok {
 		return errNoXorAddrMapping
 	}
@@ -164,7 +168,6 @@ func (m *UniversalUDPMuxDefault) handleXORMappedResponse(stunAddr *net.UDPAddr, 
 		return err
 	}
 
-	m.xorMappedMap[stunAddr.String()] = mappedAddr
 	mappedAddr.SetAddr(&addr)
 
 	return nil
@@ -186,13 +189,19 @@ func (m *UniversalUDPMuxDefault) GetXORMappedAddrContext(
 	serverAddr net.Addr,
 	deadline time.Duration,
 ) (*stun.XORMappedAddress, error) {
-	if mappedAddr, ok := m.cachedXORMappedAddr(serverAddr); ok {
+	serverAddrPort := netAddrToAddrPort(serverAddr)
+	if !serverAddrPort.IsValid() {
+		return nil, errInvalidAddress
+	}
+	serverAddrPort = canonicalAddrPort(serverAddrPort)
+
+	if mappedAddr, ok := m.cachedXORMappedAddr(serverAddrPort); ok {
 		return mappedAddr, nil
 	}
 
 	// Otherwise, make a STUN request to discover the address
 	// or wait for already sent request to complete
-	waitAddrReceived, err := m.writeSTUN(ctx, serverAddr)
+	waitAddrReceived, err := m.writeSTUN(ctx, serverAddr, serverAddrPort)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -209,7 +218,7 @@ func (m *UniversalUDPMuxDefault) GetXORMappedAddrContext(
 	case <-waitAddrReceived:
 		// When channel closed, addr was obtained
 		m.mu.Lock()
-		mappedAddr, ok := m.xorMappedMap[serverAddr.String()]
+		mappedAddr, ok := m.xorMappedMap[serverAddrPort]
 		if !ok || mappedAddr.addr == nil {
 			m.mu.Unlock()
 
@@ -226,11 +235,11 @@ func (m *UniversalUDPMuxDefault) GetXORMappedAddrContext(
 	}
 }
 
-func (m *UniversalUDPMuxDefault) cachedXORMappedAddr(serverAddr net.Addr) (*stun.XORMappedAddress, bool) {
+func (m *UniversalUDPMuxDefault) cachedXORMappedAddr(serverAddr netip.AddrPort) (*stun.XORMappedAddress, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	mappedAddr, ok := m.xorMappedMap[serverAddr.String()]
+	mappedAddr, ok := m.xorMappedMap[serverAddr]
 	// If we already have a mapping for this STUN server (address already received)
 	// and if it is not too old we return it without making a new request to STUN server
 	if !ok {
@@ -238,7 +247,7 @@ func (m *UniversalUDPMuxDefault) cachedXORMappedAddr(serverAddr net.Addr) (*stun
 	}
 	if mappedAddr.expired() {
 		mappedAddr.closeWaiters()
-		delete(m.xorMappedMap, serverAddr.String())
+		delete(m.xorMappedMap, serverAddr)
 
 		return nil, false
 	}
@@ -253,18 +262,22 @@ func (m *UniversalUDPMuxDefault) cachedXORMappedAddr(serverAddr net.Addr) (*stun
 //
 // The returned channel is closed when the STUN response has been received.
 // Method is safe for concurrent use.
-func (m *UniversalUDPMuxDefault) writeSTUN(ctx context.Context, serverAddr net.Addr) (chan struct{}, error) {
+func (m *UniversalUDPMuxDefault) writeSTUN(
+	ctx context.Context,
+	serverAddr net.Addr,
+	serverAddrPort netip.AddrPort,
+) (chan struct{}, error) {
 	m.mu.Lock()
 
 	// If record present in the map, we already sent a STUN request,
 	// just wait when waitAddrReceived will be closed
-	addrMap, ok := m.xorMappedMap[serverAddr.String()]
+	addrMap, ok := m.xorMappedMap[serverAddrPort]
 	if !ok {
 		addrMap = &xorMapped{
 			expiresAt:        time.Now().Add(m.params.XORMappedAddrCacheTTL),
 			waitAddrReceived: make(chan struct{}),
 		}
-		m.xorMappedMap[serverAddr.String()] = addrMap
+		m.xorMappedMap[serverAddrPort] = addrMap
 	}
 	waitAddrReceived := addrMap.waitAddrReceived
 	m.mu.Unlock()

--- a/udp_mux_universal.go
+++ b/udp_mux_universal.go
@@ -39,7 +39,10 @@ type UniversalUDPMuxDefault struct {
 
 // UniversalUDPMuxParams are parameters for UniversalUDPMux server reflexive.
 type UniversalUDPMuxParams struct {
-	Logger                logging.LeveledLogger
+	Logger logging.LeveledLogger
+	// UDPConn may implement AddrPortReaderWriter to opt in to allocation-free
+	// address handling. *net.UDPConn will automatically be adapted to
+	// implement AddrPortReaderWriter.
 	UDPConn               net.PacketConn
 	XORMappedAddrCacheTTL time.Duration
 	Net                   transport.Net
@@ -61,11 +64,19 @@ func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDef
 
 	// Wrap UDP connection, process server reflexive messages
 	// before they are passed to the UDPMux connection handler (connWorker)
-	mux.params.UDPConn = &udpConn{
+	baseConn := &udpConn{
 		PacketConn: params.UDPConn,
 		mux:        mux,
 		logger:     params.Logger,
 	}
+	var wrappedConn net.PacketConn = baseConn
+	if addrPortConn := asAddrPortReaderWriter(params.UDPConn); addrPortConn != nil {
+		wrappedConn = &udpAddrPortConn{
+			udpConn:      baseConn,
+			addrPortConn: addrPortConn,
+		}
+	}
+	mux.params.UDPConn = wrappedConn
 
 	// Embed UDPMux
 	udpMuxParams := UDPMuxParams{
@@ -117,6 +128,29 @@ func (c *udpConn) ReadFrom(buf []byte) (n int, addr net.Addr, err error) {
 	}
 
 	return n, addr, nil
+}
+
+// udpAddrPortConn preserves netip.AddrPort I/O while udpConn intercepts STUN packets.
+type udpAddrPortConn struct {
+	*udpConn
+	addrPortConn AddrPortReaderWriter
+}
+
+func (c *udpAddrPortConn) ReadFromAddrPort(buf []byte) (n int, addrPort netip.AddrPort, err error) {
+	n, addrPort, err = c.addrPortConn.ReadFromAddrPort(buf)
+	if err != nil {
+		return n, addrPort, err
+	}
+
+	if stun.IsMessage(buf[:n]) {
+		c.handleSTUNMessage(buf[:n], addrPort)
+	}
+
+	return n, addrPort, nil
+}
+
+func (c *udpAddrPortConn) WriteToAddrPort(buf []byte, addr netip.AddrPort) (int, error) {
+	return c.addrPortConn.WriteToAddrPort(buf, addr)
 }
 
 // handleSTUNMessage intercepts XOR-mapped-address responses coming from known

--- a/udp_mux_universal_test.go
+++ b/udp_mux_universal_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -61,6 +62,9 @@ func testMuxSrflxConnection(t *testing.T, udpMux *UniversalUDPMuxDefault, ufrag 
 	defer func() {
 		_ = remoteConn.Close()
 	}()
+	remoteAddr, ok := remoteConn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	remoteAddrPort := canonicalAddrPort(remoteAddr.AddrPort())
 
 	// Use small value for TTL to check expiration of the address
 	udpMux.params.XORMappedAddrCacheTTL = time.Millisecond * 20
@@ -71,7 +75,7 @@ func testMuxSrflxConnection(t *testing.T, udpMux *UniversalUDPMuxDefault, ufrag 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		address, e := udpMux.GetXORMappedAddr(remoteConn.LocalAddr(), time.Second)
+		address, e := udpMux.GetXORMappedAddr(remoteAddr, time.Second)
 		require.NoError(t, e)
 		require.NotNil(t, address)
 		require.True(t, address.IP.Equal(testXORIP))
@@ -83,7 +87,7 @@ func testMuxSrflxConnection(t *testing.T, udpMux *UniversalUDPMuxDefault, ufrag 
 
 	// Check that mapped address filled correctly after sent STUN
 	udpMux.mu.Lock()
-	mappedAddr, ok := udpMux.xorMappedMap[remoteConn.LocalAddr().String()]
+	mappedAddr, ok := udpMux.xorMappedMap[remoteAddrPort]
 	require.True(t, ok)
 	require.NotNil(t, mappedAddr)
 	require.True(t, mappedAddr.pending())
@@ -271,6 +275,9 @@ func Test_udpConn_ReadFrom_XOR(t *testing.T) {
 	client, err := net.DialUDP("udp4", nil, srvAddr)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
+	clientAddr, ok := client.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	clientAddrPort := canonicalAddrPort(clientAddr.AddrPort())
 
 	// success response + short XORMappedAddress value will make GetFrom() fail.
 	msg := stun.New()
@@ -280,8 +287,8 @@ func Test_udpConn_ReadFrom_XOR(t *testing.T) {
 
 	mux := &UniversalUDPMuxDefault{
 		UDPMuxDefault: &UDPMuxDefault{},
-		xorMappedMap: map[string]*xorMapped{
-			client.LocalAddr().String(): {
+		xorMappedMap: map[netip.AddrPort]*xorMapped{
+			clientAddrPort: {
 				waitAddrReceived: make(chan struct{}),
 				expiresAt:        time.Now().Add(time.Minute),
 			},
@@ -323,14 +330,41 @@ func Test_udpConn_ReadFrom_NonSTUN(t *testing.T) {
 func TestUniversalUDPMux_handleXORMappedResponse_NoMapping(t *testing.T) {
 	mux := &UniversalUDPMuxDefault{
 		UDPMuxDefault: &UDPMuxDefault{},
-		xorMappedMap:  make(map[string]*xorMapped),
+		xorMappedMap:  make(map[netip.AddrPort]*xorMapped),
 	}
 
 	stunSrv := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 3478}
 	msg := stun.New()
 
-	err := mux.handleXORMappedResponse(stunSrv, msg)
+	err := mux.handleXORMappedResponse(canonicalAddrPort(stunSrv.AddrPort()), msg)
 	require.ErrorIs(t, err, errNoXorAddrMapping)
+}
+
+type wrappedUDPAddr struct {
+	*net.UDPAddr
+}
+
+func TestUniversalUDPMux_GetXORMappedAddr_CustomAddrCacheKey(t *testing.T) {
+	serverAddr := &wrappedUDPAddr{
+		UDPAddr: &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 3478},
+	}
+	serverAddrPort := canonicalAddrPort(serverAddr.UDPAddr.AddrPort())
+	waitAddrReceived := make(chan struct{})
+	mappedAddr := &stun.XORMappedAddress{IP: net.IPv4(203, 0, 113, 1), Port: 5000}
+	mux := &UniversalUDPMuxDefault{
+		UDPMuxDefault: &UDPMuxDefault{},
+		xorMappedMap: map[netip.AddrPort]*xorMapped{
+			serverAddrPort: {
+				addr:             mappedAddr,
+				waitAddrReceived: waitAddrReceived,
+				expiresAt:        time.Now().Add(time.Minute),
+			},
+		},
+	}
+
+	got, err := mux.GetXORMappedAddr(serverAddr, time.Second)
+	require.NoError(t, err)
+	require.Same(t, mappedAddr, got)
 }
 
 func newFakePC(t *testing.T) (*fakenet.PacketConn, net.Conn, net.Conn) {
@@ -344,6 +378,7 @@ func newFakePC(t *testing.T) (*fakenet.PacketConn, net.Conn, net.Conn) {
 
 func TestUniversalUDPMux_GetXORMappedAddr_Pending_WriteError(t *testing.T) {
 	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	serverAddrPort := canonicalAddrPort(serverAddr.AddrPort())
 
 	pc, c1, c2 := newFakePC(t)
 	_ = c2.Close() // other end unused
@@ -354,8 +389,8 @@ func TestUniversalUDPMux_GetXORMappedAddr_Pending_WriteError(t *testing.T) {
 		params: UniversalUDPMuxParams{
 			UDPConn: pc, // writeSTUN will call WriteTo on this fakenet PacketConn
 		},
-		xorMappedMap: map[string]*xorMapped{
-			serverAddr.String(): {
+		xorMappedMap: map[netip.AddrPort]*xorMapped{
+			serverAddrPort: {
 				waitAddrReceived: make(chan struct{}),
 				expiresAt:        time.Now().Add(time.Minute),
 			},
@@ -369,6 +404,7 @@ func TestUniversalUDPMux_GetXORMappedAddr_Pending_WriteError(t *testing.T) {
 
 func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_NoAddr(t *testing.T) {
 	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	serverAddrPort := canonicalAddrPort(serverAddr.AddrPort())
 
 	pc, c1, c2 := newFakePC(t)
 	drainDone := make(chan struct{})
@@ -390,8 +426,8 @@ func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_NoAddr(t *testing.T) {
 		params: UniversalUDPMuxParams{
 			UDPConn: pc,
 		},
-		xorMappedMap: map[string]*xorMapped{
-			serverAddr.String(): {
+		xorMappedMap: map[netip.AddrPort]*xorMapped{
+			serverAddrPort: {
 				addr:             nil,
 				waitAddrReceived: waitCh,
 				expiresAt:        time.Now().Add(time.Minute),
@@ -406,6 +442,7 @@ func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_NoAddr(t *testing.T) {
 
 func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_DeletedMapping(t *testing.T) {
 	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	serverAddrPort := canonicalAddrPort(serverAddr.AddrPort())
 	waitCh := make(chan struct{})
 
 	var mux *UniversalUDPMuxDefault
@@ -413,9 +450,9 @@ func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_DeletedMapping(t *testing.T
 		local: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1},
 		onWrite: func() {
 			mux.mu.Lock()
-			mappedAddr := mux.xorMappedMap[serverAddr.String()]
+			mappedAddr := mux.xorMappedMap[serverAddrPort]
 			mappedAddr.closeWaiters()
-			delete(mux.xorMappedMap, serverAddr.String())
+			delete(mux.xorMappedMap, serverAddrPort)
 			mux.mu.Unlock()
 		},
 	}
@@ -424,8 +461,8 @@ func TestUniversalUDPMux_GetXORMappedAddr_WaitClosed_DeletedMapping(t *testing.T
 		params: UniversalUDPMuxParams{
 			UDPConn: pc,
 		},
-		xorMappedMap: map[string]*xorMapped{
-			serverAddr.String(): {
+		xorMappedMap: map[netip.AddrPort]*xorMapped{
+			serverAddrPort: {
 				waitAddrReceived: waitCh,
 				expiresAt:        time.Now().Add(time.Minute),
 			},

--- a/udp_mux_universal_test.go
+++ b/udp_mux_universal_test.go
@@ -167,12 +167,11 @@ func TestUniversalUDPMux_GetConnForURL_UniquePerURL(t *testing.T) {
 		_ = pc2.Close()
 	}()
 
-	// GetConnForURL now hands out *sharedPacketConn wrappers around the
-	// per-(ufrag,url) underlying *udpMuxedConn; unwrap to compare identity.
-	w1, ok := pc1.(*sharedPacketConn)
-	require.True(t, ok, "pc1 is not *sharedPacketConn")
-	w2, ok := pc2.(*sharedPacketConn)
-	require.True(t, ok, "pc2 is not *sharedPacketConn")
+	// Unwrap the per-(ufrag,url) connections to compare identity.
+	w1, ok := pc1.(*sharedAddrPortConn)
+	require.True(t, ok, "pc1 is not *sharedAddrPortConn")
+	w2, ok := pc2.(*sharedAddrPortConn)
+	require.True(t, ok, "pc2 is not *sharedAddrPortConn")
 	c1, ok := w1.underlying.(*udpMuxedConn)
 	require.True(t, ok, "pc1 underlying is not *udpMuxedConn")
 	c2, ok := w2.underlying.(*udpMuxedConn)
@@ -185,8 +184,8 @@ func TestUniversalUDPMux_GetConnForURL_UniquePerURL(t *testing.T) {
 		_ = pc1b.Close()
 	}()
 
-	w1b, ok := pc1b.(*sharedPacketConn)
-	require.True(t, ok, "pc1b is not *sharedPacketConn")
+	w1b, ok := pc1b.(*sharedAddrPortConn)
+	require.True(t, ok, "pc1b is not *sharedAddrPortConn")
 	c1b, ok := w1b.underlying.(*udpMuxedConn)
 	require.True(t, ok, "pc1b underlying is not *udpMuxedConn")
 

--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/netip"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -16,18 +17,18 @@ import (
 )
 
 type udpMuxedConnParams struct {
-	Mux       *UDPMuxDefault
-	AddrPool  *sync.Pool
-	Key       string
-	LocalAddr net.Addr
-	Logger    logging.LeveledLogger
+	Mux        *UDPMuxDefault
+	BufferPool *sync.Pool
+	Key        string
+	LocalAddr  net.Addr
+	Logger     logging.LeveledLogger
 }
 
 // udpMuxedConn represents a logical packet conn for a single remote as identified by ufrag.
 type udpMuxedConn struct {
 	params *udpMuxedConnParams
 	// Remote addresses that we have sent to on this conn
-	addresses []ipPort
+	addresses []netip.AddrPort
 
 	// FIFO queue holding incoming packets
 	bufHead, bufTail *bufferHolder
@@ -54,7 +55,24 @@ func (c *udpMuxedConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return c.readFromContext(context.Background(), b)
 }
 
-func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (n int, rAddr net.Addr, err error) {
+func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (int, net.Addr, error) {
+	n, addrPort, udpAddr, err := c.readPacket(ctx, b)
+	if udpAddr != nil {
+		return n, udpAddr, err
+	}
+
+	var rAddr net.Addr
+	if addrPort.IsValid() {
+		rAddr = net.UDPAddrFromAddrPort(addrPort)
+	}
+
+	return n, rAddr, err
+}
+
+func (c *udpMuxedConn) readPacket(
+	ctx context.Context,
+	b []byte,
+) (n int, addrPort netip.AddrPort, udpAddr *net.UDPAddr, err error) {
 	for {
 		c.mu.Lock()
 		if c.bufTail != nil {
@@ -70,19 +88,20 @@ func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (n int, rA
 				err = io.ErrShortBuffer
 			} else {
 				n = copy(b, pkt.buf)
-				rAddr = pkt.addr
+				addrPort = pkt.sourceAddrPort
+				udpAddr = pkt.sourceAddr
 			}
 
 			pkt.reset()
-			c.params.AddrPool.Put(pkt)
+			c.params.BufferPool.Put(pkt)
 
-			return n, rAddr, err
+			return n, addrPort, udpAddr, err
 		}
 
 		if c.closed {
 			c.mu.Unlock()
 
-			return 0, nil, io.EOF
+			return 0, netip.AddrPort{}, nil, io.EOF
 		}
 
 		c.readWaiting.Add(1)
@@ -100,7 +119,7 @@ func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (n int, rA
 		c.readWaiting.Add(-1)
 
 		if err != nil {
-			return 0, nil, err
+			return 0, netip.AddrPort{}, nil, err
 		}
 	}
 }
@@ -115,19 +134,24 @@ func (c *udpMuxedConn) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 		return 0, errFailedToCastUDPAddr
 	}
 
-	port := netUDPAddr.Port
-	if port < 0 || port > 0xFFFF {
+	if netUDPAddr.Port < 0 || netUDPAddr.Port > 0xFFFF {
 		return 0, ErrPort
 	}
-	ipAndPort, err := newIPPort(netUDPAddr.IP, netUDPAddr.Zone, uint16(port))
-	if err != nil {
-		return 0, err
+	addrPort := netUDPAddr.AddrPort()
+	if !addrPort.IsValid() {
+		return 0, errInvalidIPAddress
 	}
-	if !c.containsAddress(ipAndPort) {
-		c.addAddress(ipAndPort)
-	}
+	c.registerAddress(canonicalAddrPort(addrPort))
 
 	return c.params.Mux.writeTo(buf, rAddr)
+}
+
+// registerAddress registers addr with the mux the first time this conn
+// writes to it.
+func (c *udpMuxedConn) registerAddress(addr netip.AddrPort) {
+	if !c.containsAddress(addr) {
+		c.addAddress(addr)
+	}
 }
 
 func (c *udpMuxedConn) LocalAddr() net.Addr {
@@ -162,7 +186,7 @@ func (c *udpMuxedConn) Close() error {
 			next := pkt.next
 
 			pkt.reset()
-			c.params.AddrPool.Put(pkt)
+			c.params.BufferPool.Put(pkt)
 
 			pkt = next
 		}
@@ -183,16 +207,16 @@ func (c *udpMuxedConn) isClosed() bool {
 	return c.closed
 }
 
-func (c *udpMuxedConn) getAddresses() []ipPort {
+func (c *udpMuxedConn) getAddresses() []netip.AddrPort {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	addresses := make([]ipPort, len(c.addresses))
+	addresses := make([]netip.AddrPort, len(c.addresses))
 	copy(addresses, c.addresses)
 
 	return addresses
 }
 
-func (c *udpMuxedConn) addAddress(addr ipPort) {
+func (c *udpMuxedConn) addAddress(addr netip.AddrPort) {
 	c.mu.Lock()
 	c.addresses = append(c.addresses, addr)
 	c.mu.Unlock()
@@ -201,11 +225,11 @@ func (c *udpMuxedConn) addAddress(addr ipPort) {
 	c.params.Mux.registerConnForAddress(c, addr)
 }
 
-func (c *udpMuxedConn) removeAddress(addr ipPort) {
+func (c *udpMuxedConn) removeAddress(addr netip.AddrPort) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	newAddresses := make([]ipPort, 0, len(c.addresses))
+	newAddresses := make([]netip.AddrPort, 0, len(c.addresses))
 	for _, a := range c.addresses {
 		if a != addr {
 			newAddresses = append(newAddresses, a)
@@ -215,30 +239,35 @@ func (c *udpMuxedConn) removeAddress(addr ipPort) {
 	c.addresses = newAddresses
 }
 
-func (c *udpMuxedConn) containsAddress(addr ipPort) bool {
+func (c *udpMuxedConn) containsAddress(addr netip.AddrPort) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	return slices.Contains(c.addresses, addr)
 }
 
-func (c *udpMuxedConn) writePacket(data []byte, addr *net.UDPAddr) error {
-	pkt := c.params.AddrPool.Get().(*bufferHolder) //nolint:forcetypeassert
+func (c *udpMuxedConn) writePacket(
+	data []byte,
+	sourceAddrPort netip.AddrPort,
+	sourceAddr *net.UDPAddr,
+) error {
+	pkt := c.params.BufferPool.Get().(*bufferHolder) //nolint:forcetypeassert
 	if cap(pkt.buf) < len(data) {
-		c.params.AddrPool.Put(pkt)
+		c.params.BufferPool.Put(pkt)
 
 		return io.ErrShortBuffer
 	}
 
 	pkt.buf = append(pkt.buf[:0], data...)
-	pkt.addr = addr
+	pkt.sourceAddrPort = sourceAddrPort
+	pkt.sourceAddr = sourceAddr
 
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
 
 		pkt.reset()
-		c.params.AddrPool.Put(pkt)
+		c.params.BufferPool.Put(pkt)
 
 		return io.ErrClosedPipe
 	}

--- a/udp_muxed_conn.go
+++ b/udp_muxed_conn.go
@@ -55,6 +55,10 @@ func (c *udpMuxedConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return c.readFromContext(context.Background(), b)
 }
 
+func (c *udpMuxedConn) ReadFromAddrPort(b []byte) (int, netip.AddrPort, error) {
+	return c.readFromAddrPortContext(context.Background(), b)
+}
+
 func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (int, net.Addr, error) {
 	n, addrPort, udpAddr, err := c.readPacket(ctx, b)
 	if udpAddr != nil {
@@ -67,6 +71,12 @@ func (c *udpMuxedConn) readFromContext(ctx context.Context, b []byte) (int, net.
 	}
 
 	return n, rAddr, err
+}
+
+func (c *udpMuxedConn) readFromAddrPortContext(ctx context.Context, b []byte) (int, netip.AddrPort, error) {
+	n, addrPort, _, err := c.readPacket(ctx, b)
+
+	return n, addrPort, err
 }
 
 func (c *udpMuxedConn) readPacket(
@@ -144,6 +154,18 @@ func (c *udpMuxedConn) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 	c.registerAddress(canonicalAddrPort(addrPort))
 
 	return c.params.Mux.writeTo(buf, rAddr)
+}
+
+func (c *udpMuxedConn) WriteToAddrPort(buf []byte, rAddr netip.AddrPort) (n int, err error) {
+	if c.isClosed() {
+		return 0, io.ErrClosedPipe
+	}
+	if !rAddr.IsValid() {
+		return 0, errInvalidIPAddress
+	}
+	c.registerAddress(canonicalAddrPort(rAddr))
+
+	return c.params.Mux.writeToUDPAddrPort(buf, rAddr)
 }
 
 // registerAddress registers addr with the mux the first time this conn


### PR DESCRIPTION
The normal methods to read and write from `net.PacketConn` return and accept a `net.Addr`, respectively. As an interface, this requires at least one allocation for each read. On the write path, this package already makes an effort to cache the addresses returned from reads to reuse, meaning the current usage of `WriteTo()` does not always allocate. The benchmark added in #941 shows 2 allocs/op on a read/write round trip. Profiling indicates both allocations are on the read path, with one allocation for the `*net.UDPAddr` struct and a second allocation for the backing IPv4 byte slice.

In Go 1.18 a pair of methods were added to `*net.UDPConn` to perform allocation-free reads and writes by using the `netip.AddrPort` struct instead of an interface: `ReadFromUDPAddrPort` and `WriteToUDPAddrPort`.

This change reduces the read/write roundtrip to 0 allocs/op for UDP connections (at least when using the built in UDP mux and a connection that supports allocation-free read/writes). A test is added to pin the allocations to zero.

Other than the two aforementioned allocations for every read, there were additional allocations related to `net.Addr` performed for periodic STUN binding requests (which in many cases happen every several seconds for an established connection). These allocations are reduced a fair amount but not entirely to zero.

This change refactors the internals of the agent to use `netip.AddrPort` instead of `net.Addr` where possible. A new exported interface, `AddrPortReaderWriter`, is added that lets users of the library opt into allocation-free read/writes by implementing the interface for `PacketConn`s. The interface is automatically implemented for `*net.UDPConn` with an internal adapter. Custom packet connections that don't implement the new interface fall back to the prior behavior.

A few implementation notes:
 - I rejected looking for `ReadFromUDPAddrPort` and `WriteToUDPAddrPort` directly with an unexported interface, because this could be a back-compat breakage for [users who wrapped a UDP connection](https://github.com/netbirdio/netbird/blob/51f17bf9197d1abcc88218bc052614a6e98f18d5/client/net/listener_listen.go#L58-L70) and only overrode `ReadFrom` and `WriteTo`.
 - The fallback behavior requires us to keep parallel versions of the old `net.Addr` and new `netip.AddrPort` on candidates so that we can reuse the `net.Addr` in write calls to avoid adding an allocation.
 - The NAT response symmetry check now looks at network type explicitly since `netip.AddrPort` doesn't carry a network type, but I believe this is behavior-preserving and matches the spec.
 - Similarly, peer reflexive candidates now determine network type from the local candidate, which I also believe to be behavior-preserving.
 - The UDPMux connection maps previously normalized to always preserve zone and map ipv4 to ipv4-in-6. They now use a standard/centralized function to canonicalize, which preserves zone only for ipv6 link-local and unmaps ipv4-in-6 to ipv4. For all practical purposes this should be the same behavior, as kernels usually strip zone from non-link local ipv6 addresses returned in a read call.

There are two known behavior changes:

The first is that previously mDNS candidates would fail to be matched and thus fall back to peer reflexive. This is because matching compared the candidate's SDP address string (Candidate.Address()), which for an mDNS candidate remains the unresolved somehostname.local name, against the stringified source IP of inbound traffic, so a resolved mDNS candidate could never match and traffic fell back to peer reflexive. This change incidentally changed the matching code to compare canonical IP/port to canonical IP/port, and the code will have already set the IP/port for mDNS candidates by the time it tries to match to a remote candidate. This change seems more in line with RFC 8445 (section [7.3.1.3](https://datatracker.ietf.org/doc/html/rfc8445#section-7.3.1.3) in particular, with the definition of transport address in [section 4](https://datatracker.ietf.org/doc/html/rfc8445#section-4) being "address and port") so I kept the change and added a test.

The second is that consumers who call `GetXORMappedAddr()` or `GetXORMappedAddrContext()` directly on `UniversalUDPMuxDefault` with a custom `net.Addr` whose string representation isn't "ip:port" will now immediately get an error returned rather than the previous behavior of sending the request and getting a timeout error. Based on scanning open source projects that depend on pion/ice, I don't think this will come up in actual usage.