### PR TITLE
Fix racy port allocation in tests

### DIFF
--- a/candidate_relay_test.go
+++ b/candidate_relay_test.go
@@ -7,7 +7,6 @@ package ice
 
 import (
 	"net"
-	"strconv"
 	"testing"
 	"time"
 
@@ -27,9 +26,9 @@ func TestRelayOnlyConnection(t *testing.T) {
 
 	defer test.CheckRoutines(t)()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 	server, err := turn.NewServer(turn.ServerConfig{
 		Realm:       "pion.ly",

--- a/candidate_server_reflexive_test.go
+++ b/candidate_server_reflexive_test.go
@@ -7,7 +7,6 @@ package ice
 
 import (
 	"net"
-	"strconv"
 	"testing"
 	"time"
 
@@ -23,9 +22,9 @@ func TestServerReflexiveOnlyConnection(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	defer test.TimeOut(time.Second * 30).Stop()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp4", "127.0.0.1:"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 	server, err := turn.NewServer(turn.ServerConfig{
 		Realm:       "pion.ly",

--- a/gather_test.go
+++ b/gather_test.go
@@ -353,9 +353,9 @@ func TestSTUNConcurrency(t *testing.T) {
 
 	defer test.TimeOut(time.Second * 30).Stop()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 	server, err := turn.NewServer(turn.ServerConfig{
 		Realm:       "pion.ly",
@@ -516,17 +516,17 @@ func TestTURNConcurrency(t *testing.T) {
 	}
 
 	t.Run("UDP Relay", func(t *testing.T) {
-		serverPort := randomPort(t)
-		serverListener, err := net.ListenPacket("udp", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+		serverListener, err := net.ListenPacket("udp", localhostIPStr+":0") // nolint: noctx
 		require.NoError(t, err)
+		serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 		runTest(stun.ProtoTypeUDP, stun.SchemeTypeTURN, serverListener, nil, serverPort)
 	})
 
 	t.Run("TCP Relay", func(t *testing.T) {
-		serverPort := randomPort(t)
-		serverListener, err := net.Listen("tcp", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+		serverListener, err := net.Listen("tcp", localhostIPStr+":0") // nolint: noctx
 		require.NoError(t, err)
+		serverPort := portFromAddr(t, serverListener.Addr())
 
 		runTest(stun.ProtoTypeTCP, stun.SchemeTypeTURN, nil, serverListener, serverPort)
 	})
@@ -535,11 +535,11 @@ func TestTURNConcurrency(t *testing.T) {
 		certificate, genErr := selfsign.GenerateSelfSigned()
 		require.NoError(t, genErr)
 
-		serverPort := randomPort(t)
-		serverListener, err := tls.Listen("tcp", localhostIPStr+":"+strconv.Itoa(serverPort), &tls.Config{ //nolint:gosec
+		serverListener, err := tls.Listen("tcp", localhostIPStr+":0", &tls.Config{ //nolint:gosec
 			Certificates: []tls.Certificate{certificate},
 		})
 		require.NoError(t, err)
+		serverPort := portFromAddr(t, serverListener.Addr())
 
 		runTest(stun.ProtoTypeTCP, stun.SchemeTypeTURNS, nil, serverListener, serverPort)
 	})
@@ -548,13 +548,13 @@ func TestTURNConcurrency(t *testing.T) {
 		certificate, genErr := selfsign.GenerateSelfSigned()
 		require.NoError(t, genErr)
 
-		serverPort := randomPort(t)
 		serverListener, err := dtls.ListenWithOptions(
 			"udp",
-			&net.UDPAddr{IP: net.ParseIP(localhostIPStr), Port: serverPort},
+			&net.UDPAddr{IP: net.ParseIP(localhostIPStr), Port: 0},
 			dtls.WithCertificates(certificate),
 		)
 		require.NoError(t, err)
+		serverPort := portFromAddr(t, serverListener.Addr())
 
 		runTest(stun.ProtoTypeUDP, stun.SchemeTypeTURNS, nil, serverListener, serverPort)
 	})
@@ -566,9 +566,9 @@ func TestSTUNTURNConcurrency(t *testing.T) {
 
 	defer test.TimeOut(time.Second * 8).Stop()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 	server, err := turn.NewServer(turn.ServerConfig{
 		Realm:       "pion.ly",
@@ -639,9 +639,9 @@ func TestTURNSrflx(t *testing.T) {
 
 	defer test.TimeOut(time.Second * 30).Stop()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 
 	server, err := turn.NewServer(turn.ServerConfig{
 		Realm:       "pion.ly",
@@ -714,7 +714,7 @@ func TestGatherCandidatesRelayProducesRelay(t *testing.T) {
 		require.NoError(t, server.Close())
 	}()
 
-	serverPort := listener.LocalAddr().(*net.UDPAddr).Port //nolint:forcetypeassert
+	serverPort := portFromAddr(t, listener.LocalAddr())
 	turnURL := &stun.URI{
 		Scheme:   stun.SchemeTypeTURN,
 		Host:     "127.0.0.1",
@@ -2152,14 +2152,13 @@ func TestMultiUDPMuxUsage(t *testing.T) {
 	var expectedPorts []int
 	var udpMuxInstances []UDPMux
 	for i := range 3 {
-		port := randomPort(t)
-		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: port})
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 0})
 		require.NoError(t, err)
 		defer func() {
 			_ = conn.Close()
 		}()
 
-		expectedPorts = append(expectedPorts, port)
+		expectedPorts = append(expectedPorts, portFromAddr(t, conn.LocalAddr()))
 		muxDefault := NewUDPMuxDefault(UDPMuxParams{UDPConn: conn})
 		udpMuxInstances = append(udpMuxInstances, muxDefault)
 		idx := i
@@ -3247,17 +3246,16 @@ func TestMultiTCPMuxUsage(t *testing.T) {
 	var expectedPorts []int
 	var tcpMuxInstances []TCPMux
 	for range 3 {
-		port := randomPort(t)
 		listener, err := net.ListenTCP("tcp", &net.TCPAddr{
 			IP:   net.IP{127, 0, 0, 1},
-			Port: port,
+			Port: 0,
 		})
 		require.NoError(t, err)
 		defer func() {
 			_ = listener.Close()
 		}()
 
-		expectedPorts = append(expectedPorts, port)
+		expectedPorts = append(expectedPorts, portFromAddr(t, listener.Addr()))
 		tcpMux := NewTCPMuxDefault(TCPMuxParams{
 			Listener:       listener,
 			ReadBufferSize: 8,
@@ -3978,7 +3976,7 @@ func TestUniversalUDPMuxUsage(t *testing.T) {
 
 	defer test.TimeOut(time.Second * 30).Stop()
 
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: randomPort(t)})
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 0})
 	require.NoError(t, err)
 	defer func() {
 		_ = conn.Close()

--- a/transport_filtering_matrix_test.go
+++ b/transport_filtering_matrix_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -507,9 +506,9 @@ func TestTransportFilteringRelayMatrix(t *testing.T) { // nolint:cyclop
 func TestTransportFilteringSrflxMatrix(t *testing.T) {
 	defer test.CheckRoutines(t)()
 
-	serverPort := randomPort(t)
-	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":"+strconv.Itoa(serverPort)) // nolint: noctx
+	serverListener, err := net.ListenPacket("udp4", localhostIPStr+":0") // nolint: noctx
 	require.NoError(t, err)
+	serverPort := portFromAddr(t, serverListener.LocalAddr())
 	defer func() {
 		_ = serverListener.Close()
 	}()

--- a/transport_test.go
+++ b/transport_test.go
@@ -351,17 +351,14 @@ func onConnected() (func(ConnectionState), chan struct{}) {
 	}, done
 }
 
-func randomPort(tb testing.TB) int {
+// portFromAddr returns the port of a bound socket address, so tests can bind
+// to port 0 and read the assigned port back instead of guessing a free one.
+func portFromAddr(tb testing.TB, addr net.Addr) int {
 	tb.Helper()
-	conn, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
-	if err != nil {
-		tb.Fatalf("failed to pickPort: %v", err)
-	}
-	defer func() {
-		_ = conn.Close()
-	}()
-	switch addr := conn.LocalAddr().(type) {
+	switch addr := addr.(type) {
 	case *net.UDPAddr:
+		return addr.Port
+	case *net.TCPAddr:
 		return addr.Port
 	default:
 		tb.Fatalf("unknown addr type %T", addr)


### PR DESCRIPTION
`randomPort` picked a free port by binding a UDP socket to :0, closing it, and letting the test bind that port again later, sometimes over TCP. The port can be taken by another process in between. On Windows it can also land in a TCP excluded port range, where the bind is denied with `An attempt was made to access a socket in a way forbidden by its access permissions`, the recurring `test-windows` failure ([30253981058](https://github.com/pion/ice/actions/runs/30253981058/job/89938195996), [29532177809](https://github.com/pion/ice/actions/runs/29532177809)).

Tests now bind :0 directly and read the assigned port back (new `portFromAddr` helper). Every `randomPort` call site is converted and `randomPort` is removed. Test files only, no library change.

The previously flaky tests (`TestMultiTCPMuxUsage`, `TestTURNConcurrency`, `TestMultiUDPMuxUsage`) pass `go test -race -count=30` on a local Windows machine, and all CI test lanes pass on a fork dry run of this branch.
