### PR TITLE
Require 4/22 ice-chars for local ICE credentials

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1942,11 +1942,8 @@ func (a *Agent) Restart(ufrag, pwd string) error { //nolint:cyclop
 		}
 	}
 
-	if len([]rune(ufrag))*8 < 24 {
-		return ErrLocalUfragInsufficientBits
-	}
-	if len([]rune(pwd))*8 < 128 {
-		return ErrLocalPwdInsufficientBits
+	if err := validateLocalCredentials(ufrag, pwd); err != nil {
+		return err
 	}
 
 	var err error

--- a/agent_options.go
+++ b/agent_options.go
@@ -562,11 +562,8 @@ func WithLocalCredentials(ufrag, pwd string) AgentOption {
 			return ErrAgentOptionNotUpdatable
 		}
 
-		if ufrag != "" && len([]rune(ufrag))*8 < 24 {
-			return ErrLocalUfragInsufficientBits
-		}
-		if pwd != "" && len([]rune(pwd))*8 < 128 {
-			return ErrLocalPwdInsufficientBits
+		if err := validateLocalCredentials(ufrag, pwd); err != nil {
+			return err
 		}
 
 		a.localUfrag = ufrag

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -248,7 +248,7 @@ func TestWithMulticastDNSOptions(t *testing.T) {
 }
 
 func TestWithLocalCredentials(t *testing.T) {
-	password := strings.Repeat("p", 16)
+	password := strings.Repeat("p", minLenPwd)
 
 	agent, err := NewAgentWithOptions(WithLocalCredentials("abcd", password))
 	require.NoError(t, err)
@@ -263,6 +263,57 @@ func TestWithLocalCredentials(t *testing.T) {
 	shortPassword := strings.Repeat("p", 10)
 	_, err = NewAgentWithOptions(WithLocalCredentials("abcd", shortPassword))
 	assert.ErrorIs(t, err, ErrLocalPwdInsufficientBits)
+}
+
+func TestLocalCredentialsLength(t *testing.T) {
+	ufrag, shortUfrag := strings.Repeat("u", minLenUFrag), strings.Repeat("u", minLenUFrag-1)
+	pwd, shortPwd := strings.Repeat("p", minLenPwd), strings.Repeat("p", minLenPwd-1)
+
+	tests := []struct {
+		name       string
+		ufrag, pwd string
+		expected   error
+	}{
+		{"ufrag too short", shortUfrag, pwd, ErrLocalUfragInsufficientBits},
+		{"ufrag at minimum", ufrag, pwd, nil},
+		{"pwd too short", ufrag, shortPwd, ErrLocalPwdInsufficientBits},
+		{"pwd at minimum", ufrag, pwd, nil},
+		{"stateless token", strings.Repeat("u", 24), strings.Repeat("p", 32), nil},
+		{"both empty", "", "", nil},
+	}
+
+	for _, test := range tests {
+		t.Run("WithLocalCredentials/"+test.name, func(t *testing.T) {
+			agent, err := NewAgentWithOptions(WithLocalCredentials(test.ufrag, test.pwd))
+			if test.expected != nil {
+				assert.ErrorIs(t, err, test.expected)
+
+				return
+			}
+			require.NoError(t, err)
+			defer agent.Close() //nolint:errcheck
+
+			assert.GreaterOrEqual(t, len([]rune(agent.localUfrag)), minLenUFrag)
+			assert.GreaterOrEqual(t, len([]rune(agent.localPwd)), minLenPwd)
+		})
+
+		t.Run("Restart/"+test.name, func(t *testing.T) {
+			agent, err := NewAgentWithOptions()
+			require.NoError(t, err)
+			defer agent.Close() //nolint:errcheck
+
+			err = agent.Restart(test.ufrag, test.pwd)
+			if test.expected != nil {
+				assert.ErrorIs(t, err, test.expected)
+
+				return
+			}
+			require.NoError(t, err)
+
+			assert.GreaterOrEqual(t, len([]rune(agent.localUfrag)), minLenUFrag)
+			assert.GreaterOrEqual(t, len([]rune(agent.localPwd)), minLenPwd)
+		})
+	}
 }
 
 func TestWithMuxOptions(t *testing.T) {

--- a/agent_test.go
+++ b/agent_test.go
@@ -2354,8 +2354,8 @@ func TestAgentCredentials(t *testing.T) {
 	defer func() {
 		require.NoError(t, agent.Close())
 	}()
-	require.GreaterOrEqual(t, len([]rune(agent.localUfrag))*8, 24)
-	require.GreaterOrEqual(t, len([]rune(agent.localPwd))*8, 128)
+	require.GreaterOrEqual(t, len([]rune(agent.localUfrag)), minLenUFrag)
+	require.GreaterOrEqual(t, len([]rune(agent.localPwd)), minLenPwd)
 
 	// Should honor RFC standards
 	// Local values MUST be unguessable, with at least 128 bits of

--- a/errors.go
+++ b/errors.go
@@ -29,12 +29,16 @@ var (
 	ErrPort = errors.New("invalid port")
 
 	// ErrLocalUfragInsufficientBits indicates local username fragment insufficient bits are provided.
-	// Have to be at least 24 bits long.
-	ErrLocalUfragInsufficientBits = errors.New("local username fragment is less than 24 bits long")
+	// Have to be at least 4 ice-chars, carrying the 24 bits of randomness RFC 8445 §5.3 requires.
+	ErrLocalUfragInsufficientBits = errors.New(
+		"local username fragment must be at least 4 ice-chars for 24 bits of randomness",
+	)
 
 	// ErrLocalPwdInsufficientBits indicates local password insufficient bits are provided.
-	// Have to be at least 128 bits long.
-	ErrLocalPwdInsufficientBits = errors.New("local password is less than 128 bits long")
+	// Have to be at least 22 ice-chars, carrying the 128 bits of randomness RFC 8445 §5.3 requires.
+	ErrLocalPwdInsufficientBits = errors.New(
+		"local password must be at least 22 ice-chars for 128 bits of randomness",
+	)
 
 	// ErrProtoType indicates an unsupported transport type was provided.
 	ErrProtoType = errors.New("invalid transport protocol type")

--- a/rand.go
+++ b/rand.go
@@ -12,7 +12,25 @@ const (
 
 	lenUFrag = 16
 	lenPwd   = 32
+
+	// https://tools.ietf.org/html/rfc5245#section-15.4 (now RFC 8839 section 5.4):
+	// ufrag = 4*256ice-char, password = 22*256ice-char.
+	minLenUFrag = 4
+	minLenPwd   = 22
 )
+
+// validateLocalCredentials checks caller-supplied ICE credentials.
+// Empty values mean "generate one" to both call sites.
+func validateLocalCredentials(ufrag, pwd string) error {
+	if ufrag != "" && len([]rune(ufrag)) < minLenUFrag {
+		return ErrLocalUfragInsufficientBits
+	}
+	if pwd != "" && len([]rune(pwd)) < minLenPwd {
+		return ErrLocalPwdInsufficientBits
+	}
+
+	return nil
+}
 
 // Seeding random generator each time limits number of generated sequence to 31-bits,
 // and causes collision on low time accuracy environments.


### PR DESCRIPTION
An ice-char carries 6 bits, not 8, so the RFC 8445 randomness
minimums are exactly the RFC 8839 grammar minimums of 4 and 22
characters. The old *8 check accepted a 16-char password carrying
~96 bits against a 128-bit requirement, and values too short to
be legal in SDP.

RFC 5245 description is still the best:
 https://datatracker.ietf.org/doc/html/rfc5245#section-15.4