### PR TITLE
Increase timeouts for lite agents

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -91,9 +91,10 @@ type Agent struct {
 
 	candidateTypes []CandidateType
 
-	// How long connectivity checks can fail before the ICE Agent
-	// goes to disconnected
-	disconnectedTimeout time.Duration
+	// How long the selected pair can receive no traffic before the ICE Agent
+	// goes to disconnected.
+	disconnectedTimeout         time.Duration
+	disconnectedTimeoutExplicit bool
 
 	// How long connectivity checks can fail before the ICE Agent
 	// goes to failed
@@ -474,6 +475,8 @@ func newAgentWithConfig(agent *Agent, opts ...AgentOption) (*Agent, error) {
 		}
 	}
 
+	agent.applyICELiteDisconnectedTimeoutDefault()
+
 	agent.connectionStateNotifier = &handlerNotifier{
 		connectionStateFunc: agent.onConnectionStateChange,
 		done:                make(chan struct{}),
@@ -581,6 +584,12 @@ func newAgentWithConfig(agent *Agent, opts ...AgentOption) (*Agent, error) {
 	return agent, nil
 }
 
+func (a *Agent) applyICELiteDisconnectedTimeoutDefault() {
+	if a.lite && !a.disconnectedTimeoutExplicit {
+		a.disconnectedTimeout = defaultLiteDisconnectedTimeout
+	}
+}
+
 func mDNSLocalAddressFromTCPMux(tcpMux TCPMux, networkTypes []NetworkType) net.IP {
 	if tcpMux == nil || !allNetworkTypesTCP(networkTypes) {
 		return nil
@@ -674,6 +683,7 @@ func (a *Agent) startConnectivityChecks(isControlling bool, remoteUfrag, remoteP
 func (a *Agent) connectivityChecks() { //nolint:cyclop
 	lastConnectionState := ConnectionState(0)
 	checkingDuration := time.Time{}
+	checkingTimeout := a.initialCheckingTimeout()
 
 	contact := func() {
 		if err := a.loop.Run(a.loop, func(_ context.Context) {
@@ -692,8 +702,8 @@ func (a *Agent) connectivityChecks() { //nolint:cyclop
 					checkingDuration = time.Now()
 				}
 
-				// We have been in checking longer then Disconnect+Failed timeout, set the connection to Failed
-				if time.Since(checkingDuration) > a.disconnectedTimeout+a.failedTimeout {
+				// The initial checking deadline has elapsed, so set the connection to Failed.
+				if time.Since(checkingDuration) > checkingTimeout {
 					a.updateConnectionState(ConnectionStateFailed)
 
 					return
@@ -746,6 +756,15 @@ func (a *Agent) connectivityChecks() { //nolint:cyclop
 			return
 		}
 	}
+}
+
+func (a *Agent) initialCheckingTimeout() time.Duration {
+	disconnectedTimeout := a.disconnectedTimeout
+	if a.lite && !a.disconnectedTimeoutExplicit {
+		disconnectedTimeout = defaultDisconnectedTimeout
+	}
+
+	return disconnectedTimeout + a.failedTimeout
 }
 
 func (a *Agent) updateConnectionState(newState ConnectionState) {

--- a/agent_config.go
+++ b/agent_config.go
@@ -23,6 +23,10 @@ const (
 	// defaultDisconnectedTimeout is the default time till an Agent transitions disconnected.
 	defaultDisconnectedTimeout = 5 * time.Second
 
+	// defaultLiteDisconnectedTimeout uses the RFC 7675 consent-expiry period as a
+	// conservative receive-idle window for lite Agents.
+	defaultLiteDisconnectedTimeout = 10 * time.Second
+
 	// defaultFailedTimeout is the default time till an Agent transitions to failed after disconnected.
 	defaultFailedTimeout = 25 * time.Second
 
@@ -94,7 +98,10 @@ type AgentConfig struct {
 	// MulticastDNSHostName controls the hostname for this agent. If none is specified a random one will be generated
 	MulticastDNSHostName string
 
-	// DisconnectedTimeout defaults to 5 seconds when this property is nil.
+	// DisconnectedTimeout controls how long a selected pair may receive no traffic
+	// before the Agent transitions to disconnected. It defaults to 10 seconds for
+	// lite Agents and 5 seconds for full Agents when this property is nil. The
+	// longer lite default does not extend the default initial checking deadline.
 	// If the duration is 0, the ICE Agent will never go to disconnected
 	DisconnectedTimeout *time.Duration
 
@@ -295,6 +302,7 @@ func (config *AgentConfig) initWithDefaults(agent *Agent) { //nolint:cyclop
 	} else {
 		agent.disconnectedTimeout = *config.DisconnectedTimeout
 	}
+	agent.disconnectedTimeoutExplicit = config.DisconnectedTimeout != nil
 
 	if config.FailedTimeout == nil {
 		agent.failedTimeout = defaultFailedTimeout

--- a/agent_options.go
+++ b/agent_options.go
@@ -386,6 +386,7 @@ func WithDisconnectedTimeout(timeout time.Duration) AgentOption {
 		}
 
 		a.disconnectedTimeout = timeout
+		a.disconnectedTimeoutExplicit = true
 
 		return nil
 	}

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -170,6 +170,163 @@ func TestWithTimeoutOptions(t *testing.T) {
 	assert.Equal(t, 150*time.Millisecond, agent.checkInterval)
 }
 
+func TestICELiteDisconnectedTimeoutDefault(t *testing.T) {
+	explicitDisconnectedTimeout := 10 * time.Second
+	explicitFailedTimeout := 10 * time.Second
+
+	createFromConfig := func(t *testing.T, config *AgentConfig) *Agent {
+		t.Helper()
+		agent, err := NewAgent(config)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, agent.Close()) })
+
+		return agent
+	}
+
+	createFromOptions := func(t *testing.T, options ...AgentOption) *Agent {
+		t.Helper()
+		agent, err := NewAgentWithOptions(options...)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, agent.Close()) })
+
+		return agent
+	}
+
+	tests := []struct {
+		name                        string
+		config                      *AgentConfig
+		options                     []AgentOption
+		expectedDisconnectedTimeout time.Duration
+		expectedFailedTimeout       time.Duration
+		expectedCheckingTimeout     time.Duration
+	}{
+		{
+			name:                        "full config keeps full default",
+			config:                      &AgentConfig{},
+			expectedDisconnectedTimeout: defaultDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "lite config uses lite default",
+			config: &AgentConfig{
+				Lite:           true,
+				CandidateTypes: []CandidateType{CandidateTypeHost},
+			},
+			expectedDisconnectedTimeout: defaultLiteDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "lite config preserves explicit timeout",
+			config: &AgentConfig{
+				Lite:                true,
+				CandidateTypes:      []CandidateType{CandidateTypeHost},
+				DisconnectedTimeout: &explicitDisconnectedTimeout,
+			},
+			expectedDisconnectedTimeout: explicitDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     explicitDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name:                        "full options keep full default",
+			expectedDisconnectedTimeout: defaultDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "lite options use lite default",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+			},
+			expectedDisconnectedTimeout: defaultLiteDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "explicit lite default value uses explicit checking deadline",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+				WithDisconnectedTimeout(defaultLiteDisconnectedTimeout),
+			},
+			expectedDisconnectedTimeout: defaultLiteDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultLiteDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "lite default combines with explicit failed timeout during checking",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+				WithFailedTimeout(explicitFailedTimeout),
+			},
+			expectedDisconnectedTimeout: defaultLiteDisconnectedTimeout,
+			expectedFailedTimeout:       explicitFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + explicitFailedTimeout,
+		},
+		{
+			name: "explicit option before lite is preserved",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithDisconnectedTimeout(explicitDisconnectedTimeout),
+				WithICELite(true),
+			},
+			expectedDisconnectedTimeout: explicitDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     explicitDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "explicit option after lite is preserved",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+				WithDisconnectedTimeout(explicitDisconnectedTimeout),
+			},
+			expectedDisconnectedTimeout: explicitDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     explicitDisconnectedTimeout + defaultFailedTimeout,
+		},
+		{
+			name: "explicit zero is preserved",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+				WithDisconnectedTimeout(0),
+			},
+			expectedFailedTimeout:   defaultFailedTimeout,
+			expectedCheckingTimeout: defaultFailedTimeout,
+		},
+		{
+			name: "final full mode keeps full default",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithICELite(true),
+				WithICELite(false),
+			},
+			expectedDisconnectedTimeout: defaultDisconnectedTimeout,
+			expectedFailedTimeout:       defaultFailedTimeout,
+			expectedCheckingTimeout:     defaultDisconnectedTimeout + defaultFailedTimeout,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			var agent *Agent
+			if testCase.config == nil {
+				agent = createFromOptions(t, testCase.options...)
+			} else {
+				agent = createFromConfig(t, testCase.config)
+			}
+			assert.Equal(t, testCase.expectedDisconnectedTimeout, agent.disconnectedTimeout)
+			assert.Equal(t, testCase.expectedCheckingTimeout, agent.initialCheckingTimeout())
+			assert.Equal(t, testCase.expectedFailedTimeout, agent.failedTimeout)
+			assert.Equal(t, defaultKeepaliveInterval, agent.keepaliveInterval)
+		})
+	}
+}
+
 func TestWithAcceptanceWaitOptions(t *testing.T) {
 	agent, err := NewAgentWithOptions(
 		WithHostAcceptanceMinWait(1*time.Second),


### PR DESCRIPTION
#### Description
The current 5 second disconnect timeout is not safe for ICE Lite. RFC 7675 recommends sending connectivity checks every 4-6 seconds (which Firefox uses). Pion can consistently mark otherwise healthy ICE Lite connections as disconnected when there is no active traffic (e.g idle data channel connections with no media tracks).

This changes the disconnected timeout to 10s for ICE-lite, the other change is that we change the failed timeout to roughly 35s this fixes a rare issue we observed at my work and I was able to reproduce it manually where a throttled Firefox in the background can push the connectivity interval up to 20-30s which cases pion to mark the connection as failed. (I think it's related to how Firefox schedule timers).