### PR TITLE
Honor disabled timeouts during checks

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -703,7 +703,7 @@ func (a *Agent) connectivityChecks() { //nolint:cyclop
 				}
 
 				// The initial checking deadline has elapsed, so set the connection to Failed.
-				if time.Since(checkingDuration) > checkingTimeout {
+				if checkingTimeout != 0 && time.Since(checkingDuration) > checkingTimeout {
 					a.updateConnectionState(ConnectionStateFailed)
 
 					return
@@ -759,6 +759,11 @@ func (a *Agent) connectivityChecks() { //nolint:cyclop
 }
 
 func (a *Agent) initialCheckingTimeout() time.Duration {
+	// A zero value disables transitions to failed.
+	if a.failedTimeout == 0 {
+		return 0
+	}
+
 	disconnectedTimeout := a.disconnectedTimeout
 	if a.lite && !a.disconnectedTimeoutExplicit {
 		disconnectedTimeout = defaultDisconnectedTimeout

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -299,6 +299,24 @@ func TestICELiteDisconnectedTimeoutDefault(t *testing.T) {
 			expectedCheckingTimeout: defaultFailedTimeout,
 		},
 		{
+			name: "zero failed timeout disables initial checking timeout",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithFailedTimeout(0),
+			},
+			expectedDisconnectedTimeout: defaultDisconnectedTimeout,
+			expectedCheckingTimeout:     0,
+		},
+		{
+			name: "zero disconnected and failed timeouts disable initial checking timeout",
+			options: []AgentOption{
+				WithCandidateTypes([]CandidateType{CandidateTypeHost}),
+				WithDisconnectedTimeout(0),
+				WithFailedTimeout(0),
+			},
+			expectedCheckingTimeout: 0,
+		},
+		{
 			name: "final full mode keeps full default",
 			options: []AgentOption{
 				WithCandidateTypes([]CandidateType{CandidateTypeHost}),


### PR DESCRIPTION
#### Description
While I was debugging the timeouts issue with Firefox, I tried to set the timeouts to 0, but it caused the connection to fail immediately during checks, even tho we respect 0 timeouts for active connections:
https://github.com/pion/ice/blob/main/agent.go#L930-L933
https://github.com/pion/ice/blob/main/agent.go#L944-L945

It doesn't work because we didn't honor them during checks, other than testing this is useful for applications that want to control connections life them-self.