### PR TITLE
Fix URL update race during candidate gathering

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -3821,6 +3821,71 @@ func TestAgentUpdateOptions(t *testing.T) {
 	})
 }
 
+func TestAgentUpdateOptionsConcurrentWithGathering(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	firstURLs := []*stun.URI{{Scheme: stun.SchemeTypeSTUN, Host: "127.0.0.1", Port: 9, Proto: stun.ProtoTypeUDP}}
+	secondURLs := []*stun.URI{{Scheme: stun.SchemeTypeSTUN, Host: "127.0.0.1", Port: 10, Proto: stun.ProtoTypeUDP}}
+	agent, err := NewAgentWithOptions(
+		WithUrls(firstURLs),
+		WithCandidateTypes([]CandidateType{CandidateTypeServerReflexive}),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+	)
+	require.NoError(t, err)
+	require.NoError(t, agent.OnCandidate(func(Candidate) {}))
+
+	updatesDone := make(chan error, 1)
+	go func() {
+		for index := range 256 {
+			urls := firstURLs
+			if index%2 == 0 {
+				urls = secondURLs
+			}
+			if updateErr := agent.UpdateOptions(WithUrls(urls)); updateErr != nil {
+				updatesDone <- updateErr
+
+				return
+			}
+		}
+		updatesDone <- nil
+	}()
+	for range 256 {
+		require.NoError(t, agent.Restart("", ""))
+		require.NoError(t, agent.GatherCandidates())
+	}
+	require.NoError(t, <-updatesDone)
+	require.NoError(t, agent.Close())
+}
+
+func TestAgentSnapshotURLs(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	firstURLs := []*stun.URI{{Scheme: stun.SchemeTypeSTUN, Host: "127.0.0.1", Port: 9, Proto: stun.ProtoTypeUDP}}
+	secondURLs := []*stun.URI{{Scheme: stun.SchemeTypeSTUN, Host: "127.0.0.1", Port: 10, Proto: stun.ProtoTypeUDP}}
+	agent, err := NewAgentWithOptions(
+		WithUrls(firstURLs),
+		WithMulticastDNSMode(MulticastDNSModeDisabled),
+	)
+	require.NoError(t, err)
+
+	urls, err := agent.snapshotURLs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, firstURLs, urls)
+	urls[0] = secondURLs[0]
+	urls, err = agent.snapshotURLs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, firstURLs, urls)
+
+	require.NoError(t, agent.UpdateOptions(WithUrls(secondURLs)))
+	urls, err = agent.snapshotURLs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, secondURLs, urls)
+
+	require.NoError(t, agent.Close())
+	_, err = agent.snapshotURLs(context.Background())
+	require.Error(t, err)
+}
+
 func TestRemoteDialIPForLocalInterface(t *testing.T) {
 	t.Run("adds local zone for zone-less link-local IPv6", func(t *testing.T) {
 		remote := netip.MustParseAddr("fe80::1234")

--- a/gather.go
+++ b/gather.go
@@ -132,8 +132,9 @@ func (a *Agent) GatherCandidates() error {
 		a.gatherCandidateCancel = cancel
 		done := make(chan struct{})
 		a.gatherCandidateDone = done
+		urls := append([]*stun.URI(nil), a.urls...)
 
-		go a.gatherCandidates(ctx, done)
+		go a.gatherCandidates(ctx, done, urls)
 	}); runErr != nil {
 		return runErr
 	}
@@ -141,7 +142,7 @@ func (a *Agent) GatherCandidates() error {
 	return gatherErr
 }
 
-func (a *Agent) gatherCandidates(ctx context.Context, done chan struct{}) { //nolint:cyclop
+func (a *Agent) gatherCandidates(ctx context.Context, done chan struct{}, urls []*stun.URI) { //nolint:cyclop
 	defer close(done)
 	applied, err := a.setGatheringState(ctx, GatheringStateGathering)
 	if err != nil {
@@ -154,7 +155,7 @@ func (a *Agent) gatherCandidates(ctx context.Context, done chan struct{}) { //no
 		return
 	}
 
-	a.gatherCandidatesInternal(ctx)
+	a.gatherCandidatesInternal(ctx, urls)
 
 	switch a.continualGatheringPolicy {
 	case GatherOnce:
@@ -263,7 +264,7 @@ func (a *Agent) applyHostRewriteForUDPMux(candidateIPs []net.IP, udpAddr *net.UD
 }
 
 // gatherCandidatesInternal performs the actual candidate gathering for all configured types.
-func (a *Agent) gatherCandidatesInternal(ctx context.Context) {
+func (a *Agent) gatherCandidatesInternal(ctx context.Context, urls []*stun.URI) {
 	var wg sync.WaitGroup
 	for _, t := range a.candidateTypes {
 		switch t {
@@ -274,11 +275,11 @@ func (a *Agent) gatherCandidatesInternal(ctx context.Context) {
 				wg.Done()
 			}()
 		case CandidateTypeServerReflexive:
-			a.gatherServerReflexiveCandidates(ctx, &wg)
+			a.gatherServerReflexiveCandidates(ctx, &wg, urls)
 		case CandidateTypeRelay:
 			wg.Add(1)
 			go func() {
-				a.gatherCandidatesRelay(ctx, a.urls)
+				a.gatherCandidatesRelay(ctx, urls)
 				wg.Done()
 			}()
 		case CandidateTypePeerReflexive, CandidateTypeUnspecified:
@@ -289,15 +290,15 @@ func (a *Agent) gatherCandidatesInternal(ctx context.Context) {
 	wg.Wait()
 }
 
-func (a *Agent) gatherServerReflexiveCandidates(ctx context.Context, wg *sync.WaitGroup) {
+func (a *Agent) gatherServerReflexiveCandidates(ctx context.Context, wg *sync.WaitGroup, urls []*stun.URI) {
 	replaceSrflx := a.addressRewriteMapper != nil && a.addressRewriteMapper.shouldReplace(CandidateTypeServerReflexive)
 	if !replaceSrflx {
 		wg.Add(1)
 		go func() {
 			if a.udpMuxSrflx != nil {
-				a.gatherCandidatesSrflxUDPMux(ctx, a.urls, a.networkTypes)
+				a.gatherCandidatesSrflxUDPMux(ctx, urls, a.networkTypes)
 			} else {
-				a.gatherCandidatesSrflx(ctx, a.urls, a.networkTypes)
+				a.gatherCandidatesSrflx(ctx, urls, a.networkTypes)
 			}
 			wg.Done()
 		}()
@@ -1418,10 +1419,25 @@ func (a *Agent) startNetworkMonitoring(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if a.detectNetworkChanges() {
-				a.gatherCandidatesInternal(ctx)
+				urls, err := a.snapshotURLs(ctx)
+				if err != nil {
+					return
+				}
+				a.gatherCandidatesInternal(ctx, urls)
 			}
 		}
 	}
+}
+
+func (a *Agent) snapshotURLs(ctx context.Context) ([]*stun.URI, error) {
+	var urls []*stun.URI
+	if err := a.loop.Run(ctx, func(context.Context) {
+		urls = append([]*stun.URI(nil), a.urls...)
+	}); err != nil {
+		return nil, err
+	}
+
+	return urls, nil
 }
 
 // detectNetworkChanges checks if the network interfaces have changed since the last check.


### PR DESCRIPTION
`UpdateOptions` serializes writes to `Agent.urls` through the task loop, but the gathering goroutines read the same slice header outside that loop. Updating ICE server credentials while a gather is in flight therefore races with both server-reflexive and relay gathering.

This change snapshots the URL slice while `GatherCandidates` still owns the task-loop turn and passes that immutable snapshot through the complete gathering generation. Continual gathering obtains a fresh serialized snapshot before each interface-triggered re-gather, so later URL updates still take effect.

The regression test repeatedly overlaps URL updates with gathering. It reliably reports a data race on v4.4.1 under `go test -race` and passes with this change.

Validation:

- `go test -race -run 'TestAgentUpdateOptions(ConcurrentWithGathering)?$' -count=10 .`
- Existing full-suite network tests were also exercised locally; the macOS host's pre-existing UDP mux timeout remains unrelated to these files.
