### PR TITLE
Support ICE-lite controlling agents

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -1380,11 +1380,12 @@ func TestConnectivityLite(t *testing.T) {
 		Proto:  stun.ProtoTypeUDP,
 	}
 
-	natType := &vnet.NATType{
+	fullAgentNATType := &vnet.NATType{
 		MappingBehavior:   vnet.EndpointIndependent,
 		FilteringBehavior: vnet.EndpointIndependent,
 	}
-	vent, err := buildVNet(natType, natType)
+	liteAgentNATType := &vnet.NATType{Mode: vnet.NATModeNAT1To1}
+	vent, err := buildVNet(fullAgentNATType, liteAgentNATType)
 	require.NoError(t, err, "should succeed")
 	defer vent.close()
 
@@ -1412,6 +1413,7 @@ func TestConnectivityLite(t *testing.T) {
 		NetworkTypes:     supportedNetworkTypes(),
 		MulticastDNSMode: MulticastDNSModeDisabled,
 		Net:              vent.net1,
+		NAT1To1IPs:       []string{vnetGlobalIPB},
 	}
 
 	bAgent, err := NewAgent(cfg1)
@@ -1421,7 +1423,7 @@ func TestConnectivityLite(t *testing.T) {
 	}()
 	require.NoError(t, bAgent.OnConnectionStateChange(bNotifier))
 
-	connectWithVNet(t, aAgent, bAgent)
+	connectWithVNet(t, bAgent, aAgent)
 
 	// Ensure pair selected
 	// Note: this assumes ConnectionStateConnected is thrown after selecting the final pair

--- a/selection.go
+++ b/selection.go
@@ -525,32 +525,38 @@ func (s *liteSelector) Start() {
 	s.pairCandidateSelector.Start()
 }
 
-// A lite selector should not contact candidates.
 func (s *liteSelector) ContactCandidates() {
-	if _, ok := s.pairCandidateSelector.(*controllingSelector); ok {
-		//nolint:godox
-		// https://github.com/pion/ice/issues/96
-		// TODO: implement lite controlling agent. For now falling back to full agent.
-		// This only happens if both peers are lite. See RFC 8445 S6.1.1 and S6.2
-		s.pairCandidateSelector.ContactCandidates()
-	} else if v, ok := s.pairCandidateSelector.(*controlledSelector); ok {
-		v.agent.validateSelectedPair()
+	if controlled, ok := s.pairCandidateSelector.(*controlledSelector); ok {
+		if !controlled.agent.validateSelectedPair() {
+			if pair := controlled.agent.getBestAvailableCandidatePair(); pair != nil {
+				pair.state = CandidatePairStateSucceeded
+			}
+		}
+
+		return
 	}
+
+	controlling, ok := s.pairCandidateSelector.(*controllingSelector)
+	if !ok || controlling.agent.getSelectedPair() != nil {
+		if ok {
+			controlling.agent.validateSelectedPair()
+		}
+
+		return
+	}
+
+	pair := controlling.agent.getBestAvailableCandidatePair()
+	if pair == nil {
+		return
+	}
+
+	pair.state = CandidatePairStateSucceeded
+	controlling.agent.setSelectedPair(pair)
 }
 
-func (s *liteSelector) PingCandidate(local, remote Candidate) {
-	if _, ok := s.pairCandidateSelector.(*controllingSelector); ok {
-		s.pairCandidateSelector.PingCandidate(local, remote)
-	}
-}
+func (s *liteSelector) PingCandidate(_, _ Candidate) {}
 
-func (s *liteSelector) HandleSuccessResponse(
-	m *stun.Message, local, remote Candidate, remoteAddr netip.AddrPort,
-) {
-	if _, ok := s.pairCandidateSelector.(*controllingSelector); ok {
-		s.pairCandidateSelector.HandleSuccessResponse(m, local, remote, remoteAddr)
-	}
-}
+func (s *liteSelector) HandleSuccessResponse(*stun.Message, Candidate, Candidate, netip.AddrPort) {}
 
 func (s *liteSelector) HandleBindingRequest(message *stun.Message, local, remote Candidate) {
 	s.pairCandidateSelector.HandleBindingRequest(message, local, remote)

--- a/selection_test.go
+++ b/selection_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4/test"
+	"github.com/pion/transport/v4/vnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1669,6 +1670,30 @@ func TestControllingSideRenomination(t *testing.T) {
 // Lite mode tests
 // ---------------------------------------------------------------------------
 
+func TestLiteControllingSelectorContactCandidates(t *testing.T) {
+	agent := bareAgentForPing()
+	agent.log = logging.NewDefaultLoggerFactory().NewLogger("test")
+	agent.lite = true
+	agent.isControlling.Store(true)
+	agent.onConnected = make(chan struct{})
+	agent.setSelector()
+
+	selector, ok := agent.getSelector().(*liteSelector)
+	require.True(t, ok)
+
+	selector.ContactCandidates()
+	require.Nil(t, agent.getSelectedPair())
+
+	pair := agent.addPair(newPingNoIOCand(), newPingNoIOCand())
+	selector.ContactCandidates()
+	require.Equal(t, pair, agent.getSelectedPair())
+	require.Equal(t, CandidatePairStateSucceeded, pair.state)
+	require.Zero(t, pair.RequestsSent())
+
+	selector.ContactCandidates()
+	require.Equal(t, pair, agent.getSelectedPair())
+}
+
 // TestLiteControlledSelector_NoPingCandidate verifies that a lite controlled
 // agent NEVER sends triggered connectivity checks (PingCandidate), regardless
 // of the pair state. Per RFC 8445 §7, a lite implementation only acts as a
@@ -1976,4 +2001,79 @@ func TestLiteMode_FullToLite_Integration(t *testing.T) {
 	require.True(t, sendUntilDone(t, liteConn, fullConn, 120))
 
 	closePipe(t, liteConn, fullConn)
+}
+
+func TestLiteMode_LiteControlling_Integration(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(30 * time.Second).Stop()
+
+	virtualNet, err := buildVNet(
+		&vnet.NATType{Mode: vnet.NATModeNAT1To1},
+		&vnet.NATType{Mode: vnet.NATModeNAT1To1},
+	)
+	require.NoError(t, err)
+	defer virtualNet.close()
+
+	newLiteAgent := func(network *vnet.Net, externalIP string) *Agent {
+		agent, newAgentErr := NewAgent(&AgentConfig{
+			Lite:             true,
+			CandidateTypes:   []CandidateType{CandidateTypeHost},
+			NetworkTypes:     []NetworkType{NetworkTypeUDP4},
+			MulticastDNSMode: MulticastDNSModeDisabled,
+			Net:              network,
+			NAT1To1IPs:       []string{externalIP},
+		})
+		require.NoError(t, newAgentErr)
+
+		return agent
+	}
+
+	controlledAgent := newLiteAgent(virtualNet.net0, vnetGlobalIPA)
+	defer func() { require.NoError(t, controlledAgent.Close()) }()
+	controllingAgent := newLiteAgent(virtualNet.net1, vnetGlobalIPB)
+	defer func() { require.NoError(t, controllingAgent.Close()) }()
+	gatherAndExchangeCandidates(t, controlledAgent, controllingAgent)
+
+	controlledUfrag, controlledPwd, err := controlledAgent.GetLocalUserCredentials()
+	require.NoError(t, err)
+	controllingUfrag, controllingPwd, err := controllingAgent.GetLocalUserCredentials()
+	require.NoError(t, err)
+
+	controlledConn, err := controlledAgent.StartAccept(controllingUfrag, controllingPwd)
+	require.NoError(t, err)
+	controllingConn, err := controllingAgent.StartDial(controlledUfrag, controlledPwd)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, controllingAgent.AwaitConnect(ctx))
+	require.Equal(t, Controlling, controllingAgent.role())
+	require.Equal(t, Controlled, controlledAgent.role())
+
+	for _, agent := range []*Agent{controlledAgent, controllingAgent} {
+		for _, stats := range agent.GetCandidatePairsStats() {
+			require.Zero(t, stats.RequestsSent)
+			require.Zero(t, stats.RequestsReceived)
+		}
+	}
+
+	request := []byte("lite controlling to lite controlled")
+	_, err = controllingConn.Write(request)
+	require.NoError(t, err)
+	require.NoError(t, controlledConn.SetReadDeadline(time.Now().Add(time.Second)))
+	buf := make([]byte, len(request))
+	n, err := controlledConn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, request, buf[:n])
+
+	controlledPairs := controlledConn.GetCandidatePairsInfo()
+	require.NotEmpty(t, controlledPairs)
+	response := []byte("lite controlled to lite controlling")
+	_, err = controlledConn.WriteToPair(controlledPairs[0].ID, response)
+	require.NoError(t, err)
+	require.NoError(t, controllingConn.SetReadDeadline(time.Now().Add(time.Second)))
+	buf = make([]byte, len(response))
+	n, err = controllingConn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, response, buf[:n])
 }


### PR DESCRIPTION
ICE-lite agents usually run controlled because a full peer always takes
the controlling role. When both peers are lite, signaling assigns the
controlling role to the initiating agent.

The controlling fallback entered full-agent checklist processing and
originated a connectivity check, even though ICE-lite agents never send
checks.

Select the highest-priority available pair locally when the lite agent
is controlling. Mark exchanged pairs usable on the controlled side so
application traffic can flow while signaling communicates selection.
Keep ping and success-response handling inactive for both lite roles.

Add selector coverage and a lite-to-lite integration test that verify
state transitions, role assignment, pair selection, bidirectional
traffic, and zero connectivity checks.

Fixes #96.
