### PR TITLE
Clone code reason on errors

### DIFF
--- a/internal/stun/stun.go
+++ b/internal/stun/stun.go
@@ -5,6 +5,7 @@
 package stun
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -236,6 +237,7 @@ func (t *XORMappedAddrTransaction) HandleResponse(msg *stun.Message) bool {
 		var code stun.ErrorCodeAttribute
 		err := code.GetFrom(msg)
 		if err == nil {
+			code.Reason = bytes.Clone(code.Reason)
 			err = stun.TurnError{StunMessageType: msg.Type, ErrorCodeAttr: code}
 		}
 		t.complete(nil, err)

--- a/internal/stun/stun_test.go
+++ b/internal/stun/stun_test.go
@@ -4,6 +4,7 @@
 package stun
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"os"
@@ -286,17 +287,21 @@ func TestXORMappedAddrTransactionReportsErrorResponse(t *testing.T) {
 		stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
 	)
 	require.NoError(t, err)
+	raw := bytes.Clone(response.Raw)
+	response = &stun.Message{Raw: raw}
+	require.NoError(t, response.Decode())
 
-	handled := false
+	require.True(t, transaction.HandleResponse(response))
+
+	clear(raw)
+
 	_, err = transaction.Get(context.Background(), time.Second, func(context.Context, []byte) error {
-		handled = transaction.HandleResponse(response)
-
 		return nil
 	})
 	var stunErr stun.TurnError
 	require.ErrorAs(t, err, &stunErr)
 	require.Equal(t, stun.CodeBadRequest, stunErr.ErrorCodeAttr.Code)
-	require.True(t, handled)
+	require.Equal(t, []byte("Bad Request"), stunErr.ErrorCodeAttr.Reason)
 }
 
 func TestXORMappedAddrTransactionPrefersCanceledContextToSendError(t *testing.T) {


### PR DESCRIPTION
#### Description
While I was reviewing all the AI directed & generated patches we merged past two weeks I came across #960 removal of datagram copy, Which is a nice (out of scope) optimization. 
I reviewed all paths and they seem all fine except for the error-code path because it's just a slice off msg.Raw :) https://github.com/pion/stun/blob/32a32c3/errorcode.go#L72 
This doesn't bring the datagram copy back and just copies `Reason`.

###### Surprisingly very remotely related to https://github.com/pion/turn/pull/581