### PR TITLE
Finish lite-lite candidate selection

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -111,10 +111,11 @@ type Agent struct {
 	localPwd        string
 	localCandidates map[NetworkType][]Candidate
 
-	remoteUfrag      string
-	remotePwd        string
-	remoteLite       bool
-	remoteCandidates map[NetworkType][]Candidate
+	remoteUfrag               string
+	remotePwd                 string
+	remoteLite                bool
+	remoteCandidates          map[NetworkType][]Candidate
+	remoteCandidateGeneration uint64
 
 	checklist  []*CandidatePair
 	nextPairID uint64
@@ -997,21 +998,8 @@ func (a *Agent) AddRemoteCandidate(cand Candidate) error {
 	}
 
 	// If we have a mDNS Candidate lets fully resolve it before adding it locally
-	if cand.Type() == CandidateTypeHost && strings.HasSuffix(cand.Address(), ".local") {
-		if a.mDNSMode == MulticastDNSModeDisabled {
-			a.log.Warnf("Remote mDNS candidate added, but mDNS is disabled: (%s)", cand.Address())
-
-			return nil
-		}
-
-		hostCandidate, ok := cand.(*CandidateHost)
-		if !ok {
-			return ErrAddressParseFailed
-		}
-
-		go a.resolveAndAddMulticastCandidate(hostCandidate)
-
-		return nil
+	if isMulticastDNSCandidate(cand) {
+		return a.addRemoteMulticastCandidate(cand)
 	}
 
 	go func() {
@@ -1020,15 +1008,40 @@ func (a *Agent) AddRemoteCandidate(cand Candidate) error {
 			a.addRemoteCandidate(cand)
 		}); err != nil {
 			a.log.Warnf("Failed to add remote candidate %s: %v", cand.Address(), err)
-
-			return
 		}
 	}()
 
 	return nil
 }
 
-func (a *Agent) resolveAndAddMulticastCandidate(cand *CandidateHost) {
+func isMulticastDNSCandidate(cand Candidate) bool {
+	return cand.Type() == CandidateTypeHost && strings.HasSuffix(cand.Address(), ".local")
+}
+
+func (a *Agent) addRemoteMulticastCandidate(cand Candidate) error {
+	if a.mDNSMode == MulticastDNSModeDisabled {
+		a.log.Warnf("Remote mDNS candidate added, but mDNS is disabled: (%s)", cand.Address())
+
+		return nil
+	}
+
+	hostCandidate, ok := cand.(*CandidateHost)
+	if !ok {
+		return ErrAddressParseFailed
+	}
+
+	var generation uint64
+	if err := a.loop.Run(a.loop, func(_ context.Context) {
+		generation = a.remoteCandidateGeneration
+	}); err != nil {
+		return err
+	}
+	go a.resolveAndAddMulticastCandidate(hostCandidate, generation)
+
+	return nil
+}
+
+func (a *Agent) resolveAndAddMulticastCandidate(cand *CandidateHost, generation uint64) {
 	if a.mDNSConn == nil {
 		return
 	}
@@ -1050,6 +1063,10 @@ func (a *Agent) resolveAndAddMulticastCandidate(cand *CandidateHost) {
 	}
 
 	if err = a.loop.Run(a.loop, func(_ context.Context) {
+		if generation != a.remoteCandidateGeneration {
+			return
+		}
+
 		// nolint: contextcheck
 		a.addRemoteCandidate(cand)
 	}); err != nil {
@@ -1126,6 +1143,7 @@ func (a *Agent) addRemotePassiveTCPCandidate(remoteCandidate Candidate) {
 		}
 
 		localCandidate.start(a, conn, a.startedCh)
+		a.setUniqueLiteCandidatePriority(localCandidate)
 		a.localCandidates[localCandidate.NetworkType()] = append(
 			a.localCandidates[localCandidate.NetworkType()],
 			localCandidate,
@@ -1331,6 +1349,33 @@ func (a *Agent) addRemoteCandidate(cand Candidate) bool { //nolint:cyclop
 	return true
 }
 
+// setUniqueLiteCandidatePriority gives each local ICE-lite candidate a unique
+// priority.
+// https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2
+func (a *Agent) setUniqueLiteCandidatePriority(cand Candidate) {
+	if !a.lite {
+		return
+	}
+
+	used := make(map[uint32]struct{})
+	for _, candidates := range a.localCandidates {
+		for _, candidate := range candidates {
+			used[candidate.Priority()] = struct{}{}
+		}
+	}
+
+	priority := cand.Priority()
+	for {
+		if _, ok := used[priority]; !ok {
+			cand.setPriority(priority)
+
+			return
+		}
+
+		priority -= 1 << 8
+	}
+}
+
 func (a *Agent) shouldAcceptRemoteCandidate(cand Candidate) bool {
 	if a.remoteIPFilter == nil {
 		return true
@@ -1375,6 +1420,7 @@ func (a *Agent) addCandidate(ctx context.Context, cand Candidate, candidateConn 
 
 		a.setCandidateExtensions(cand)
 		cand.start(a, candidateConn, a.startedCh)
+		a.setUniqueLiteCandidatePriority(cand)
 
 		set = append(set, cand)
 		a.localCandidates[cand.NetworkType()] = set
@@ -1584,6 +1630,16 @@ func (a *Agent) findRemoteCandidate(networkType NetworkType, addr netip.AddrPort
 	for _, c := range set {
 		if addrPortEqual(c.addrPort(), addr) {
 			return c
+		}
+	}
+
+	return nil
+}
+
+func (a *Agent) findRemoteCandidateByIP(networkType NetworkType, addr netip.Addr) Candidate {
+	for _, candidate := range a.remoteCandidates[networkType] {
+		if candidate.addrPort().Addr() == addr {
+			return candidate
 		}
 	}
 
@@ -1861,6 +1917,12 @@ func (a *Agent) validateNonSTUNTraffic(local Candidate, remote netip.AddrPort) (
 	var remoteCandidate Candidate
 	if err := a.loop.Run(local.context(), func(context.Context) {
 		remoteCandidate = a.findRemoteCandidate(local.NetworkType(), remote)
+		if remoteCandidate == nil && a.lite && a.remoteLite {
+			// with no connectivity checks, a multi-candidate ICE-lite peer cannot
+			// discover that the the other peer emitted a packet from another
+			// advertised interface and source port
+			remoteCandidate = a.findRemoteCandidateByIP(local.NetworkType(), remote.Addr())
+		}
 		if remoteCandidate != nil {
 			remoteCandidate.seen(false)
 		}
@@ -1980,7 +2042,6 @@ func (a *Agent) Restart(ufrag, pwd string) error { //nolint:cyclop
 		return err
 	}
 
-	var err error
 	if runErr := a.loop.Run(a.loop, func(_ context.Context) {
 		// Cancel unconditionally: a gather goroutine that has started but not yet
 		// marked Gathering would otherwise outlive the restart and later
@@ -1993,6 +2054,7 @@ func (a *Agent) Restart(ufrag, pwd string) error { //nolint:cyclop
 		a.localPwd = pwd
 		a.remoteUfrag = ""
 		a.remotePwd = ""
+		a.remoteCandidateGeneration++
 		a.gatheringState = GatheringStateNew
 		a.checklist = make([]*CandidatePair, 0)
 		a.pairsByID = make(map[uint64]*CandidatePair)
@@ -2010,7 +2072,7 @@ func (a *Agent) Restart(ufrag, pwd string) error { //nolint:cyclop
 		return runErr
 	}
 
-	return err
+	return nil
 }
 
 // setGatheringState applies newState and reports whether it was applied. A write

--- a/agent_test.go
+++ b/agent_test.go
@@ -2816,6 +2816,39 @@ func TestGetLocalCandidates(t *testing.T) {
 	require.ElementsMatch(t, expectedCandidates, actualCandidates)
 }
 
+func TestLiteLocalCandidatePrioritiesAreUnique(t *testing.T) {
+	agent := &Agent{
+		lite:            true,
+		localCandidates: make(map[NetworkType][]Candidate),
+	}
+
+	var previousPriority uint32
+	for i := range 3 {
+		candidate, err := NewCandidateHost(&CandidateHostConfig{
+			Network:   "udp",
+			Address:   "192.0.2." + strconv.Itoa(i+1),
+			Port:      10000 + i,
+			Component: ComponentRTP,
+		})
+		require.NoError(t, err)
+
+		agent.setUniqueLiteCandidatePriority(candidate)
+		agent.localCandidates[candidate.NetworkType()] = append(
+			agent.localCandidates[candidate.NetworkType()],
+			candidate,
+		)
+
+		if i == 0 {
+			previousPriority = candidate.Priority()
+
+			continue
+		}
+
+		require.Equal(t, previousPriority-(1<<8), candidate.Priority())
+		previousPriority = candidate.Priority()
+	}
+}
+
 func TestCloseInConnectionStateCallback(t *testing.T) {
 	defer test.CheckRoutines(t)()
 

--- a/candidate.go
+++ b/candidate.go
@@ -98,6 +98,7 @@ type Candidate interface {
 	seen(outbound bool)
 	start(a *Agent, conn net.PacketConn, initializedCh <-chan struct{})
 	writeTo(raw []byte, dst Candidate) (int, error)
+	setPriority(uint32)
 
 	replaceRemoteCandidateCacheValues(oldRemote, newRemote Candidate)
 }

--- a/candidate_base.go
+++ b/candidate_base.go
@@ -355,7 +355,7 @@ func (c *candidateBase) handleInboundPacket(buf []byte, srcAddr netip.AddrPort) 
 	if !c.validateSTUNTrafficCache(srcAddr) {
 		remoteCandidate, valid := agent.validateNonSTUNTraffic(c, srcAddr) //nolint:contextcheck
 		if !valid {
-			agent.log.Warnf("Discarded message from %s, not a valid remote candidate", c.addr())
+			agent.log.Warnf("Discarded message from %s, not a valid remote candidate", srcAddr)
 
 			return
 		}
@@ -513,6 +513,10 @@ func (c *candidateBase) Priority() uint32 {
 	return (1<<24)*uint32(c.TypePreference()) +
 		(1<<8)*uint32(c.LocalPreference()) +
 		(1<<0)*uint32(256-c.Component())
+}
+
+func (c *candidateBase) setPriority(priority uint32) {
+	c.priorityOverride = priority
 }
 
 // transportAddressEqual checks if the transport address (IP, Port, NetworkType, TCPType) is equal to another

--- a/selection.go
+++ b/selection.go
@@ -523,16 +523,27 @@ type liteSelector struct {
 }
 
 func (s *liteSelector) ContactCandidates() {
-	if s.agent.validateSelectedPair() || !s.agent.remoteLite {
+	if !s.agent.remoteLite {
+		s.agent.validateSelectedPair()
+
 		return
+	}
+	selectedPair := s.agent.getSelectedPair()
+	if selectedPair != nil {
+		s.agent.validateSelectedPair()
+		selectedPair = s.agent.getSelectedPair()
 	}
 
 	pair := s.agent.getBestAvailableCandidatePair()
-	if pair == nil {
+	if pair == nil || selectedPair == pair {
 		return
 	}
 
 	pair.state = CandidatePairStateSucceeded
+	// lite candidates pair becomes valid without a connectivity check. so we need to
+	// start its liveness window now so a later candidate update does not immediately
+	// fail a pair whose LastReceived timestamp is still zero.
+	pair.Remote.seen(false)
 	s.agent.setSelectedPair(pair)
 }
 

--- a/selection_test.go
+++ b/selection_test.go
@@ -1685,14 +1685,30 @@ func TestLiteControllingSelectorContactCandidates(t *testing.T) {
 	selector.ContactCandidates()
 	require.Nil(t, agent.getSelectedPair())
 
-	pair := agent.addPair(newPingNoIOCand(), newPingNoIOCand())
+	local := newPingNoIOCand()
+	local.priorityOverride = 100
+	remote := newPingNoIOCand()
+	remote.priorityOverride = 100
+	pair := agent.addPair(local, remote)
 	selector.ContactCandidates()
 	require.Equal(t, pair, agent.getSelectedPair())
 	require.Equal(t, CandidatePairStateSucceeded, pair.state)
+	require.False(t, pair.Remote.LastReceived().IsZero())
 	require.Zero(t, pair.RequestsSent())
 
+	lowerPriorityLocal := newPingNoIOCand()
+	lowerPriorityLocal.priorityOverride = 50
+	lowerPriorityPair := agent.addPair(lowerPriorityLocal, remote)
 	selector.ContactCandidates()
 	require.Equal(t, pair, agent.getSelectedPair())
+	require.Equal(t, CandidatePairStateWaiting, lowerPriorityPair.state)
+
+	higherPriorityLocal := newPingNoIOCand()
+	higherPriorityLocal.priorityOverride = 200
+	higherPriorityPair := agent.addPair(higherPriorityLocal, remote)
+	selector.ContactCandidates()
+	require.Equal(t, higherPriorityPair, agent.getSelectedPair())
+	require.Equal(t, CandidatePairStateSucceeded, higherPriorityPair.state)
 }
 
 // TestLiteControlledSelector_NoPingCandidate verifies that a lite controlled


### PR DESCRIPTION
#### Description
While testing pion/ice@main against WebRTC, I noticed that TestPeerConnection_IceLite was failing. Pion supports ICE-lite to ICE-lite connections in both the controlling and controlled roles, but it did not correctly handle pair selection with multiple candidates #959 and #961
ICE-lite agents do not send connectivity checks, so the previously selected pair could remain selected even when a better candidate pair became available later. ICE-lite behavior is defined across several sections of [RFC 8445](https://www.rfc-editor.org/rfc/rfc8445.html), particularly [Section 6.2](https://www.rfc-editor.org/rfc/rfc8445.html#section-6.2). Candidate priority uniqueness is required by [Section 5.1.2](https://www.rfc-editor.org/rfc/rfc8445.html#section-5.1.2).
This change assigns unique priorities to locally gathered ICE-lite candidates and re-evaluates the standard ICE pair-priority ordering as candidates arrive. Both peers can select the same best pair and switch when a higher-priority pair becomes available, without sending connectivity checks.

Tldr: this fixes a race where both agents select different candidates because of the lack of connectivity checks.