### PR TITLE
Fix UniversalUDPMux initialization race

### DIFF
--- a/udp_mux.go
+++ b/udp_mux.go
@@ -90,6 +90,13 @@ type UDPMuxParams struct {
 
 // NewUDPMuxDefault creates an implementation of UDPMux.
 func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
+	mux := newUDPMuxDefault(params)
+	go mux.connWorker()
+
+	return mux
+}
+
+func newUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 	if params.Logger == nil {
 		params.Logger = logging.NewDefaultLoggerFactory().NewLogger("ice")
 	}
@@ -127,7 +134,6 @@ func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 		isUnspecified: isUnspecified,
 	}
 	mux.addrPortConn = asAddrPortReaderWriter(params.UDPConn)
-	go mux.connWorker()
 
 	return mux
 }

--- a/udp_mux_universal.go
+++ b/udp_mux_universal.go
@@ -89,7 +89,8 @@ func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDef
 		UDPConn: mux.params.UDPConn,
 		Net:     mux.params.Net,
 	}
-	mux.UDPMuxDefault = NewUDPMuxDefault(udpMuxParams)
+	mux.UDPMuxDefault = newUDPMuxDefault(udpMuxParams)
+	go mux.connWorker()
 
 	return mux
 }

--- a/udp_mux_universal_test.go
+++ b/udp_mux_universal_test.go
@@ -20,6 +20,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUniversalUDPMux_QueuedSTUNDuringInitialization(t *testing.T) {
+	for _, useAddrPort := range []bool{false, true} {
+		conn := &queuedSTUNPacketConn{
+			packet:  stun.MustBuild(stun.BindingRequest, stun.TransactionID).Raw,
+			drained: make(chan struct{}),
+		}
+		var packetConn net.PacketConn = conn
+		if useAddrPort {
+			packetConn = &queuedSTUNAddrPortConn{conn}
+		}
+		mux := NewUniversalUDPMuxDefault(UniversalUDPMuxParams{UDPConn: packetConn})
+		<-conn.drained
+		require.NoError(t, mux.Close())
+	}
+}
+
+type queuedSTUNPacketConn struct {
+	fakenet.MockPacketConn
+	packet  []byte
+	drained chan struct{}
+}
+
+func (c *queuedSTUNPacketConn) ReadFrom(buf []byte) (int, net.Addr, error) {
+	if c.packet == nil {
+		close(c.drained)
+
+		return 0, nil, net.ErrClosed
+	}
+	n := copy(buf, c.packet)
+	c.packet = nil
+
+	return n, c.LocalAddr(), nil
+}
+
+func (*queuedSTUNPacketConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}
+}
+
+type queuedSTUNAddrPortConn struct{ *queuedSTUNPacketConn }
+
+func (c *queuedSTUNAddrPortConn) ReadFromAddrPort(buf []byte) (int, netip.AddrPort, error) {
+	n, _, err := c.ReadFrom(buf)
+
+	return n, netip.MustParseAddrPort("127.0.0.1:12345"), err
+}
+
+func (*queuedSTUNAddrPortConn) WriteToAddrPort(buf []byte, _ netip.AddrPort) (int, error) {
+	return len(buf), nil
+}
+
 func TestUniversalUDPMux(t *testing.T) {
 	conn, err := net.ListenUDP(udp, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
 	require.NoError(t, err)


### PR DESCRIPTION
STUN packets arriving before or during UniversalUDPMux creation can be processed before initialization finishes, causing a data race or a possible nil-pointer panic.

This change initializes the embedded UDP mux before starting the reader. Regression tests cover both ReadFrom and ReadFromAddrPort.

Validation:
- Both tests reproduce the race before the fix.
- Both pass 100 runs with the race detector after the fix.
- The full Go test suite passes with the race detector enabled.