### PR TITLE
Range check candidate component-id and priority

### DIFF
--- a/candidate_base.go
+++ b/candidate_base.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"net"
 	"net/netip"
 	"strconv"
@@ -840,7 +841,7 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 	}
 
 	// component-id ( 1*5DIGIT )
-	component, pos, err := readCandidateDigitToken(raw, pos, 5)
+	component, pos, err := readCandidateComponent(raw, pos)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v in %s", errParseComponent, err, raw) //nolint:errorlint // we wrap the error
 	}
@@ -857,7 +858,7 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 	}
 
 	// priority ( 1*10DIGIT ) SP
-	priority, pos, err := readCandidateDigitToken(raw, pos, 10)
+	priority, pos, err := readCandidatePriority(raw, pos)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v in %s", errParsePriority, err, raw) //nolint:errorlint // we wrap the error
 	}
@@ -927,8 +928,8 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 			protocol,
 			address,
 			port,
-			uint16(component), //nolint:gosec // G115 no overflow we read 5 digits
-			uint32(priority),  //nolint:gosec // G115 no overflow we read 5 digits
+			component,
+			priority,
 			foundation,
 			tcpType,
 			false,
@@ -946,8 +947,8 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 			protocol,
 			address,
 			port,
-			uint16(component), //nolint:gosec // G115 no overflow we read 5 digits
-			uint32(priority),  //nolint:gosec // G115 no overflow we read 5 digits
+			component,
+			priority,
 			foundation,
 			raddr,
 			rport,
@@ -965,8 +966,8 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 			protocol,
 			address,
 			port,
-			uint16(component), //nolint:gosec // G115 no overflow we read 5 digits
-			uint32(priority),  //nolint:gosec // G115 no overflow we read 5 digits
+			component,
+			priority,
 			foundation,
 			raddr,
 			rport,
@@ -984,8 +985,8 @@ func UnmarshalCandidate(raw string) (Candidate, error) { //nolint:cyclop
 			protocol,
 			address,
 			port,
-			uint16(component), //nolint:gosec // G115 no overflow we read 5 digits
-			uint32(priority),  //nolint:gosec // G115 no overflow we read 5 digits
+			component,
+			priority,
 			foundation,
 			raddr,
 			rport,
@@ -1043,8 +1044,10 @@ func readCandidateStringToken(raw string, start int) (string, int) {
 
 // Read a digit token from the raw string
 // stop reading when a space is encountered or the end of the string.
-func readCandidateDigitToken(raw string, start, limit int) (int, int, error) {
-	var val int
+// The value accumulates in a uint64 so a 10 digit token cannot overflow on
+// 32 bit platforms; callers range check the returned value.
+func readCandidateDigitToken(raw string, start, limit int) (uint64, int, error) {
+	var val uint64
 	for i, char := range raw[start:] {
 		if char == 0x20 { // SP
 			return val, start + i + 1, nil
@@ -1059,7 +1062,7 @@ func readCandidateDigitToken(raw string, start, limit int) (int, int, error) {
 			return 0, 0, fmt.Errorf("invalid digit token: %c", char) //nolint: err113 // handled by caller
 		}
 
-		val = val*10 + int(char-'0')
+		val = val*10 + uint64(char-'0')
 	}
 
 	return val, len(raw), nil
@@ -1076,7 +1079,37 @@ func readCandidatePort(raw string, start int) (int, int, error) {
 		return 0, 0, fmt.Errorf("invalid RFC 4566 port %d", port) //nolint: err113 // handled by caller
 	}
 
-	return port, pos, nil
+	return int(port), pos, nil
+}
+
+// readCandidateComponent reads a RFC 8445 component-id ( 1*5DIGIT ).
+func readCandidateComponent(raw string, start int) (uint16, int, error) {
+	component, pos, err := readCandidateDigitToken(raw, start, 5)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if component > math.MaxUint16 {
+		//nolint: err113 // handled by caller
+		return 0, 0, fmt.Errorf("invalid RFC 8445 component-id %d", component)
+	}
+
+	return uint16(component), pos, nil
+}
+
+// readCandidatePriority reads a RFC 8445 priority ( 1*10DIGIT ).
+func readCandidatePriority(raw string, start int) (uint32, int, error) {
+	priority, pos, err := readCandidateDigitToken(raw, start, 10)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if priority > math.MaxUint32 {
+		//nolint: err113 // handled by caller
+		return 0, 0, fmt.Errorf("invalid RFC 8445 priority %d", priority)
+	}
+
+	return uint32(priority), pos, nil
 }
 
 // Read a byte-string token from the raw string

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -541,11 +541,15 @@ func TestCandidateMarshal(t *testing.T) {
 		{nil, "3$3 1 udp 500 " + localhostIPStr + " 80 typ host", true},
 		// invalid component; longer than 5 digits
 		{nil, "4207374051 123456 udp 500 " + localhostIPStr + " 0 typ host", true},
+		// invalid component; does not fit in a uint16
+		{nil, "4207374051 65536 udp 500 " + localhostIPStr + " 80 typ host", true},
 		// invalid priority; longer than 10 digits
-		{nil, "4207374051 99999 udp 12345678910 " + localhostIPStr + " 99999 typ host", true},
+		{nil, "4207374051 1 udp 12345678910 " + localhostIPStr + " 99999 typ host", true},
+		// invalid priority; does not fit in a uint32
+		{nil, "4207374051 1 udp 4294967296 " + localhostIPStr + " 80 typ host", true},
 		// invalid port;
-		{nil, "4207374051 99999 udp 500 " + localhostIPStr + " 65536 typ host", true},
-		{nil, "4207374051 99999 udp 500 " + localhostIPStr + " 999999 typ host", true},
+		{nil, "4207374051 1 udp 500 " + localhostIPStr + " 65536 typ host", true},
+		{nil, "4207374051 1 udp 500 " + localhostIPStr + " 999999 typ host", true},
 		{nil, "848194626 1 udp 16777215 50.0.0.1 5000 typ relay raddr 192.168.0.1 rport 999999", true},
 
 		// bad byte-string in extension value
@@ -564,12 +568,12 @@ func TestCandidateMarshal(t *testing.T) {
 		{nil, "848194626 1 udp 16777215 50.0.0.1 5000 typ relay raddr 192.168.0.1 rport", true},
 		{nil, "848194626 1 udp 16777215 50.0.0.1 5000 typ relay raddr 192.168.0.1", true},
 		{nil, "848194626 1 udp 16777215 50.0.0.1 5000 typ relay raddr", true},
-		{nil, "4207374051 99999 udp 500 " + localhostIPStr + " 80 typ", true},
-		{nil, "4207374051 99999 udp 500 " + localhostIPStr + " 80", true},
-		{nil, "4207374051 99999 udp 500 " + localhostIPStr, true},
-		{nil, "4207374051 99999 udp 500 ", true},
-		{nil, "4207374051 99999 udp", true},
-		{nil, "4207374051 99999", true},
+		{nil, "4207374051 1 udp 500 " + localhostIPStr + " 80 typ", true},
+		{nil, "4207374051 1 udp 500 " + localhostIPStr + " 80", true},
+		{nil, "4207374051 1 udp 500 " + localhostIPStr, true},
+		{nil, "4207374051 1 udp 500 ", true},
+		{nil, "4207374051 1 udp", true},
+		{nil, "4207374051 1", true},
 		{nil, "4207374051", true},
 	} {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
@@ -595,6 +599,32 @@ func TestCandidateMarshal(t *testing.T) {
 			} else {
 				require.Equal(t, test.marshaled, actualCandidate.Marshal())
 			}
+		})
+	}
+}
+
+func TestUnmarshalCandidateNumericBounds(t *testing.T) {
+	// The 1*5DIGIT and 1*10DIGIT length limits still admit values that do not
+	// fit in the uint16 and uint32 the Candidate API exposes.
+	for _, test := range []struct {
+		raw      string
+		expected bool
+	}{
+		{"4207374051 65535 udp 500 " + localhostIPStr + " 80 typ host", false},
+		{"4207374051 65536 udp 500 " + localhostIPStr + " 80 typ host", true},
+		{"4207374051 1 udp 4294967295 " + localhostIPStr + " 80 typ host", false},
+		{"4207374051 1 udp 4294967296 " + localhostIPStr + " 80 typ host", true},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			candidate, err := UnmarshalCandidate(test.raw)
+			if test.expected {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.raw, candidate.Marshal())
 		})
 	}
 }


### PR DESCRIPTION
`UnmarshalCandidate` rejects a port over 65535, but a component-id over 65535
and a priority over 2^32-1 are truncated instead of rejected. Both of these
parse with `err == nil` on current main:

```
4207374051 99999 udp 500 127.0.0.1 80 typ host
  -> Component() == 34463
  -> Marshal()   == "4207374051 34463 udp 500 127.0.0.1 80 typ host"

4207374051 1 udp 5000000000 127.0.0.1 80 typ host
  -> Priority() == 705032704
  -> Marshal()  == "4207374051 1 udp 705032704 127.0.0.1 80 typ host"
```

So the caller ends up holding a candidate with a number the remote peer never
sent. That matters because this is the function pion/webrtc runs over every
`a=candidate:` line of a remote SDP (`sdp.go:958`), and a truncated priority
then feeds candidate-pair ordering.

`readCandidatePort` already range checks its value (`candidate_base.go:1069`).
Component-id and priority go through the same `readCandidateDigitToken`, which
only limits the digit *count* - 5 digits still admits 99999 and 10 digits still
admits 9999999999, and neither fits the `uint16`/`uint32` that `Component()`
and `Priority()` return (`candidate.go:37`, `candidate.go:50`).

So I added `readCandidateComponent` and `readCandidatePriority` next to
`readCandidatePort` and range check there, returning the existing
`errParseComponent` / `errParsePriority`. `readCandidateDigitToken` now
accumulates into a `uint64` so a 10-digit priority cannot overflow before the
check runs on the i386 job.

That also drops the four `//nolint:gosec // G115 no overflow we read 5 digits`
comments. The conversions they covered are gone, and the claim was not correct
anyway - it also says "5 digits" on the 10-digit priority field.

I bounded on uint16/uint32 rather than RFC 8445 5.1.2's tighter priority range
of 1..2^31-1, so this only rejects values the API cannot represent at all and
doesn't start refusing candidates that implementations actually send today.

One bit of test churn worth flagging: several existing invalid-input rows in
`TestCandidateMarshal` use `99999` as filler in the component slot. After this
change those rows would be rejected on the component rather than on the thing
they are there to test, so I changed the filler to `1`.

Checks I ran locally: `golangci-lint run ./...` at v2.10.1 (the version
`lint.yaml` pins) reports 0 issues, `gofmt`/`go vet ./...`/`GOARCH=386 go vet
./...` are clean, and the new tests fail on main and pass with the fix. I could
not get the full `./...` suite to finish on my machine - `TestMultiUDPMux`
hits the `test.TimeOut` watchdog at `udp_mux_multi_test.go:73` - but it aborts
at the identical test and line on an unmodified checkout too, so it is a local
networking limitation rather than something this change causes. The rest of the
package (the tests that don't need that networking setup) is green before and
after, as are `internal/stun` and `internal/taskloop`.

Disclosure: I used AI assistance while working on this. I ran every check quoted
above myself, and I'll handle review discussion personally.
