### PR TITLE
Fixed WithLoggerFactory agent option

### DIFF
--- a/agent_options.go
+++ b/agent_options.go
@@ -1020,6 +1020,8 @@ func WithLoggerFactory(loggerFactory logging.LoggerFactory) AgentOption {
 			return ErrAgentOptionNotUpdatable
 		}
 
+		// Logger factory will be passed down to objects created by the agent
+		a.loggerFactory = loggerFactory
 		a.log = loggerFactory.NewLogger("ice")
 
 		return nil

--- a/agent_options_test.go
+++ b/agent_options_test.go
@@ -802,6 +802,7 @@ func TestWithLoggerFactory(t *testing.T) {
 		assert.NoError(t, err)
 		defer agent.Close() //nolint:errcheck
 
+		assert.Equal(t, loggerFactory, agent.loggerFactory)
 		assert.NotNil(t, agent.log)
 	})
 


### PR DESCRIPTION
ICE Agent passes LoggerFactory to created objects. Now it passes nil, so created objects use default LoggerFactory instead of user-supplied one.
